### PR TITLE
chore: Add permissions to CI and deploy workflows

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -32,7 +32,13 @@
       "Bash(gh label list:*)",
       "mcp__context7__resolve-library-id",
       "mcp__context7__get-library-docs",
-      "WebFetch(domain:www.npmjs.com)"
+      "WebFetch(domain:www.npmjs.com)",
+      "Bash(npx tsc:*)",
+      "mcp__playwright__browser_navigate",
+      "mcp__playwright__browser_take_screenshot",
+      "mcp__playwright__browser_close",
+      "Bash(cat:*)",
+      "Bash(find:*)"
     ],
     "deny": [],
     "ask": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   backend:
     name: Backend CI
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     services:
       postgres:
@@ -77,6 +79,8 @@ jobs:
   frontend:
     name: Frontend CI
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,6 +12,8 @@ jobs:
   deploy:
     name: Deploy to Azure VM
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     # Uncomment when ready to deploy (Phase 12)
     # environment:
     #   name: production


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add `permissions.contents: read` to backend and frontend CI jobs and the deploy job in GitHub workflows