### PR TITLE
Feature/phase 7 notification preferences

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -549,8 +549,19 @@ Once this plan is committed, Phase 1 implementation will begin with:
   - Type-safe with mypy --strict compliance
   - Linting compliant (minor exception string warnings accepted)
 
+- [x] Phase 7: Notification Preferences (Completed: November 2025)
+  - Full CRUD API for notification preferences (GET, POST, PATCH, DELETE)
+  - Service layer with comprehensive validation (contact ownership, verification, duplicates, limits)
+  - Configurable preference limit per route (MAX_NOTIFICATION_PREFERENCES_PER_ROUTE = 5)
+  - Duplicate prevention (same route + contact + method)
+  - Method-target type validation (email method requires email target, SMS requires phone)
+  - Pydantic model validators for request validation
+  - Relationship updates: Route ↔ NotificationPreference (cascade delete)
+  - 38 comprehensive tests covering all CRUD operations and edge cases
+  - Coverage: API 100%, Service 96.79%, Overall 96.76% (exceeds 95% target)
+  - Type-safe (mypy --strict) and linting compliant (ruff)
+
 ### Upcoming Phases
-- [ ] Phase 7: Notification Preferences
 - [ ] Phase 8: Alert Processing Worker
 - [ ] Phase 9: Admin Dashboard Backend
 - [ ] Phase 10: Frontend Development

--- a/backend/app/api/notification_preferences.py
+++ b/backend/app/api/notification_preferences.py
@@ -1,0 +1,201 @@
+"""Notification preferences API endpoints."""
+
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, status
+from pydantic import BaseModel, ConfigDict, model_validator
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import get_current_user
+from app.core.database import get_db
+from app.models.notification import NotificationMethod, NotificationPreference
+from app.models.user import User
+from app.services.notification_preference_service import NotificationPreferenceService
+
+router = APIRouter(tags=["notification-preferences"])
+
+
+# ==================== Pydantic Schemas ====================
+
+
+class CreateNotificationPreferenceRequest(BaseModel):
+    """Request to create a new notification preference."""
+
+    method: NotificationMethod
+    target_email_id: UUID | None = None
+    target_phone_id: UUID | None = None
+
+    @model_validator(mode="after")
+    def validate_exactly_one_target(self) -> "CreateNotificationPreferenceRequest":
+        """Validate that exactly one target is provided."""
+        email_id = self.target_email_id
+        phone_id = self.target_phone_id
+
+        if (email_id is None and phone_id is None) or (email_id is not None and phone_id is not None):
+            msg = "Exactly one of target_email_id or target_phone_id must be provided."
+            raise ValueError(msg)
+
+        return self
+
+
+class UpdateNotificationPreferenceRequest(BaseModel):
+    """Request to update a notification preference."""
+
+    method: NotificationMethod | None = None
+    target_email_id: UUID | None = None
+    target_phone_id: UUID | None = None
+
+    @model_validator(mode="after")
+    def validate_not_both_targets(self) -> "UpdateNotificationPreferenceRequest":
+        """Validate that both targets are not provided simultaneously."""
+        if self.target_email_id is not None and self.target_phone_id is not None:
+            msg = "Cannot specify both target_email_id and target_phone_id."
+            raise ValueError(msg)
+
+        return self
+
+
+class NotificationPreferenceResponse(BaseModel):
+    """Notification preference response."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    route_id: UUID
+    method: NotificationMethod
+    target_email_id: UUID | None
+    target_phone_id: UUID | None
+    created_at: datetime
+    updated_at: datetime
+
+
+# ==================== API Endpoints ====================
+
+
+@router.get(
+    "/routes/{route_id}/notifications",
+    response_model=list[NotificationPreferenceResponse],
+)
+async def list_notification_preferences(
+    route_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[NotificationPreference]:
+    """
+    List all notification preferences for a route.
+
+    Args:
+        route_id: Route UUID
+        current_user: Authenticated user
+        db: Database session
+
+    Returns:
+        List of notification preferences
+
+    Raises:
+        HTTPException: 404 if route not found or doesn't belong to user
+    """
+    service = NotificationPreferenceService(db)
+    return await service.list_preferences(route_id, current_user.id)
+
+
+@router.post(
+    "/routes/{route_id}/notifications",
+    response_model=NotificationPreferenceResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_notification_preference(
+    route_id: UUID,
+    request: CreateNotificationPreferenceRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> NotificationPreference:
+    """
+    Create a new notification preference for a route.
+
+    Args:
+        route_id: Route UUID
+        request: Notification preference creation request
+        current_user: Authenticated user
+        db: Database session
+
+    Returns:
+        Created notification preference
+
+    Raises:
+        HTTPException: 400 (validation errors), 404 (route/contact not found),
+                      409 (duplicate), 429 (rate limit)
+    """
+    service = NotificationPreferenceService(db)
+    return await service.create_preference(
+        route_id=route_id,
+        user_id=current_user.id,
+        method=request.method,
+        target_email_id=request.target_email_id,
+        target_phone_id=request.target_phone_id,
+    )
+
+
+@router.patch(
+    "/routes/{route_id}/notifications/{preference_id}",
+    response_model=NotificationPreferenceResponse,
+)
+async def update_notification_preference(
+    route_id: UUID,
+    preference_id: UUID,
+    request: UpdateNotificationPreferenceRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> NotificationPreference:
+    """
+    Update a notification preference.
+
+    Args:
+        route_id: Route UUID (for URL consistency, not used in validation)
+        preference_id: Preference UUID
+        request: Update request
+        current_user: Authenticated user
+        db: Database session
+
+    Returns:
+        Updated notification preference
+
+    Raises:
+        HTTPException: 400 (validation errors), 404 (preference/contact not found),
+                      409 (duplicate)
+    """
+    service = NotificationPreferenceService(db)
+    return await service.update_preference(
+        preference_id=preference_id,
+        user_id=current_user.id,
+        method=request.method,
+        target_email_id=request.target_email_id,
+        target_phone_id=request.target_phone_id,
+    )
+
+
+@router.delete(
+    "/routes/{route_id}/notifications/{preference_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+)
+async def delete_notification_preference(
+    route_id: UUID,
+    preference_id: UUID,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """
+    Delete a notification preference.
+
+    Args:
+        route_id: Route UUID (for URL consistency, not used in validation)
+        preference_id: Preference UUID
+        current_user: Authenticated user
+        db: Database session
+
+    Raises:
+        HTTPException: 404 if preference not found or doesn't belong to user
+    """
+    service = NotificationPreferenceService(db)
+    await service.delete_preference(preference_id, current_user.id)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -69,6 +69,9 @@ class Settings(BaseSettings):
     CELERY_BROKER_URL: str
     CELERY_RESULT_BACKEND: str
 
+    # Notification Settings (for Phase 7)
+    MAX_NOTIFICATION_PREFERENCES_PER_ROUTE: int = 5
+
     # Alembic Settings
     ALEMBIC_INI_PATH: str = "alembic.ini"
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -14,7 +14,7 @@ from sqlalchemy import text
 from sqlalchemy.engine import Connection
 
 from app import __version__
-from app.api import admin, auth, contacts, routes, tfl
+from app.api import admin, auth, contacts, notification_preferences, routes, tfl
 from app.core.config import settings
 from app.core.database import engine
 
@@ -128,6 +128,7 @@ app.add_middleware(
 app.include_router(auth.router, prefix=settings.API_V1_PREFIX)
 app.include_router(contacts.router, prefix=settings.API_V1_PREFIX)
 app.include_router(routes.router, prefix=settings.API_V1_PREFIX)
+app.include_router(notification_preferences.router, prefix=settings.API_V1_PREFIX)
 app.include_router(tfl.router, prefix=settings.API_V1_PREFIX)
 app.include_router(admin.router, prefix=settings.API_V1_PREFIX)
 

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -71,7 +71,7 @@ class NotificationPreference(BaseModel):
     )
 
     # Relationships
-    route: Mapped["Route"] = relationship()
+    route: Mapped["Route"] = relationship(back_populates="notification_preferences")
 
     # Ensure one and only one target is set
     __table_args__ = (

--- a/backend/app/models/route.py
+++ b/backend/app/models/route.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.models.base import BaseModel
 
 if TYPE_CHECKING:
+    from app.models.notification import NotificationPreference
     from app.models.user import User
 
 
@@ -57,6 +58,10 @@ class Route(BaseModel):
         order_by="RouteSegment.sequence",
     )
     schedules: Mapped[list["RouteSchedule"]] = relationship(
+        back_populates="route",
+        cascade="all, delete-orphan",
+    )
+    notification_preferences: Mapped[list["NotificationPreference"]] = relationship(
         back_populates="route",
         cascade="all, delete-orphan",
     )

--- a/backend/app/services/notification_preference_service.py
+++ b/backend/app/services/notification_preference_service.py
@@ -1,0 +1,425 @@
+"""Notification preference management service."""
+
+import uuid
+
+from fastapi import HTTPException, status
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.notification import NotificationMethod, NotificationPreference
+from app.models.route import Route
+from app.models.user import EmailAddress, PhoneNumber
+
+
+class NotificationPreferenceService:
+    """Service for managing notification preferences."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        """
+        Initialize the notification preference service.
+
+        Args:
+            db: Database session
+        """
+        self.db = db
+
+    async def get_preference_by_id(
+        self,
+        preference_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> NotificationPreference:
+        """
+        Get a notification preference by ID with ownership validation.
+
+        Args:
+            preference_id: Preference UUID
+            user_id: User UUID (for ownership check via route)
+
+        Returns:
+            NotificationPreference object
+
+        Raises:
+            HTTPException: 404 if preference not found or user doesn't own the route
+        """
+        # Join with route to validate ownership
+        query = (
+            select(NotificationPreference)
+            .join(Route, NotificationPreference.route_id == Route.id)
+            .where(
+                NotificationPreference.id == preference_id,
+                Route.user_id == user_id,
+            )
+        )
+
+        result = await self.db.execute(query)
+
+        if not (preference := result.scalar_one_or_none()):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Notification preference not found.",
+            )
+
+        return preference
+
+    async def list_preferences(
+        self,
+        route_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> list[NotificationPreference]:
+        """
+        List all notification preferences for a route.
+
+        Args:
+            route_id: Route UUID
+            user_id: User UUID (for ownership check)
+
+        Returns:
+            List of notification preferences
+
+        Raises:
+            HTTPException: 404 if route not found or doesn't belong to user
+        """
+        # First validate route ownership
+        route_result = await self.db.execute(
+            select(Route).where(
+                Route.id == route_id,
+                Route.user_id == user_id,
+            )
+        )
+
+        if not route_result.scalar_one_or_none():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Route not found.",
+            )
+
+        # Get preferences
+        result = await self.db.execute(
+            select(NotificationPreference)
+            .where(NotificationPreference.route_id == route_id)
+            .order_by(NotificationPreference.created_at.desc())
+        )
+
+        return list(result.scalars().all())
+
+    async def create_preference(  # noqa: PLR0912
+        self,
+        route_id: uuid.UUID,
+        user_id: uuid.UUID,
+        method: NotificationMethod,
+        target_email_id: uuid.UUID | None,
+        target_phone_id: uuid.UUID | None,
+    ) -> NotificationPreference:
+        """
+        Create a new notification preference.
+
+        Args:
+            route_id: Route UUID
+            user_id: User UUID (for ownership validation)
+            method: Notification method (email or sms)
+            target_email_id: Email address ID (required if method is email)
+            target_phone_id: Phone number ID (required if method is sms)
+
+        Returns:
+            Created notification preference
+
+        Raises:
+            HTTPException: Various validation errors (400, 404, 409)
+        """
+        # Validate route ownership
+        route_result = await self.db.execute(
+            select(Route).where(
+                Route.id == route_id,
+                Route.user_id == user_id,
+            )
+        )
+
+        if not route_result.scalar_one_or_none():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Route not found.",
+            )
+
+        # Validate exactly one target is provided
+        if (target_email_id is None and target_phone_id is None) or (
+            target_email_id is not None and target_phone_id is not None
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Exactly one of target_email_id or target_phone_id must be provided.",
+            )
+
+        # Validate method matches target type
+        if method == NotificationMethod.EMAIL and target_email_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Email method requires target_email_id.",
+            )
+
+        if method == NotificationMethod.SMS and target_phone_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="SMS method requires target_phone_id.",
+            )
+
+        # Validate contact ownership and verification
+        if target_email_id is not None:
+            email_result = await self.db.execute(
+                select(EmailAddress).where(
+                    EmailAddress.id == target_email_id,
+                    EmailAddress.user_id == user_id,
+                )
+            )
+
+            if not (email := email_result.scalar_one_or_none()):
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Email address not found.",
+                )
+
+            if not email.verified:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Email address must be verified.",
+                )
+
+        if target_phone_id is not None:
+            phone_result = await self.db.execute(
+                select(PhoneNumber).where(
+                    PhoneNumber.id == target_phone_id,
+                    PhoneNumber.user_id == user_id,
+                )
+            )
+
+            if not (phone := phone_result.scalar_one_or_none()):
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Phone number not found.",
+                )
+
+            if not phone.verified:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Phone number must be verified.",
+                )
+
+        # Check for duplicates (same route + contact + method)
+        duplicate_query = select(NotificationPreference).where(
+            NotificationPreference.route_id == route_id,
+            NotificationPreference.method == method,
+        )
+
+        if target_email_id is not None:
+            duplicate_query = duplicate_query.where(NotificationPreference.target_email_id == target_email_id)
+        if target_phone_id is not None:
+            duplicate_query = duplicate_query.where(NotificationPreference.target_phone_id == target_phone_id)
+
+        duplicate_result = await self.db.execute(duplicate_query)
+
+        if duplicate_result.scalar_one_or_none():
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Notification preference already exists for this route and contact.",
+            )
+
+        # Check preference count limit
+        count_result = await self.db.execute(
+            select(func.count()).select_from(NotificationPreference).where(NotificationPreference.route_id == route_id)
+        )
+
+        count = count_result.scalar_one()
+
+        if count >= settings.MAX_NOTIFICATION_PREFERENCES_PER_ROUTE:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Maximum {settings.MAX_NOTIFICATION_PREFERENCES_PER_ROUTE} notification preferences per route.",
+            )
+
+        # Create preference
+        preference = NotificationPreference(
+            route_id=route_id,
+            method=method,
+            target_email_id=target_email_id,
+            target_phone_id=target_phone_id,
+        )
+
+        self.db.add(preference)
+        await self.db.commit()
+        await self.db.refresh(preference)
+
+        return preference
+
+    async def update_preference(  # noqa: PLR0912, PLR0915
+        self,
+        preference_id: uuid.UUID,
+        user_id: uuid.UUID,
+        method: NotificationMethod | None,
+        target_email_id: uuid.UUID | None,
+        target_phone_id: uuid.UUID | None,
+    ) -> NotificationPreference:
+        """
+        Update a notification preference.
+
+        Args:
+            preference_id: Preference UUID
+            user_id: User UUID (for ownership validation)
+            method: New notification method (optional)
+            target_email_id: New email address ID (optional)
+            target_phone_id: New phone number ID (optional)
+
+        Returns:
+            Updated notification preference
+
+        Raises:
+            HTTPException: Various validation errors (400, 404, 409)
+        """
+        # Get existing preference with ownership check
+        preference = await self.get_preference_by_id(preference_id, user_id)
+
+        # Load route for later validation
+        await self.db.refresh(preference, attribute_names=["route"])
+        route_id = preference.route_id
+
+        # If both targets provided in update, reject
+        if target_email_id is not None and target_phone_id is not None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Cannot specify both target_email_id and target_phone_id.",
+            )
+
+        # Determine final values
+        final_method = method if method is not None else preference.method
+
+        # If switching targets, clear the other one
+        if target_email_id is not None:
+            # Explicitly setting email, clear phone
+            final_email_id = target_email_id
+            final_phone_id = None
+        elif target_phone_id is not None:
+            # Explicitly setting phone, clear email
+            final_phone_id = target_phone_id
+            final_email_id = None
+        else:
+            # No target change, keep existing
+            final_email_id = preference.target_email_id
+            final_phone_id = preference.target_phone_id
+
+        # Validate exactly one target is set
+        if (final_email_id is None and final_phone_id is None) or (
+            final_email_id is not None and final_phone_id is not None
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Exactly one of target_email_id or target_phone_id must be set.",
+            )
+
+        # Validate method matches target type
+        if final_method == NotificationMethod.EMAIL and final_email_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Email method requires target_email_id.",
+            )
+
+        if final_method == NotificationMethod.SMS and final_phone_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="SMS method requires target_phone_id.",
+            )
+
+        # Validate new contact ownership and verification (if changed)
+        if target_email_id is not None and target_email_id != preference.target_email_id:
+            email_result = await self.db.execute(
+                select(EmailAddress).where(
+                    EmailAddress.id == target_email_id,
+                    EmailAddress.user_id == user_id,
+                )
+            )
+
+            if not (email := email_result.scalar_one_or_none()):
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Email address not found.",
+                )
+
+            if not email.verified:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Email address must be verified.",
+                )
+
+        if target_phone_id is not None and target_phone_id != preference.target_phone_id:
+            phone_result = await self.db.execute(
+                select(PhoneNumber).where(
+                    PhoneNumber.id == target_phone_id,
+                    PhoneNumber.user_id == user_id,
+                )
+            )
+
+            if not (phone := phone_result.scalar_one_or_none()):
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="Phone number not found.",
+                )
+
+            if not phone.verified:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Phone number must be verified.",
+                )
+
+        # Check for duplicates (excluding current preference)
+        duplicate_query = select(NotificationPreference).where(
+            NotificationPreference.route_id == route_id,
+            NotificationPreference.method == final_method,
+            NotificationPreference.id != preference_id,
+        )
+
+        if final_email_id is not None:
+            duplicate_query = duplicate_query.where(NotificationPreference.target_email_id == final_email_id)
+        if final_phone_id is not None:
+            duplicate_query = duplicate_query.where(NotificationPreference.target_phone_id == final_phone_id)
+
+        duplicate_result = await self.db.execute(duplicate_query)
+
+        if duplicate_result.scalar_one_or_none():
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Notification preference already exists for this route and contact.",
+            )
+
+        # Update fields
+        if method is not None:
+            preference.method = method
+        if target_email_id is not None:
+            preference.target_email_id = target_email_id
+            preference.target_phone_id = None  # Clear the other target
+        if target_phone_id is not None:
+            preference.target_phone_id = target_phone_id
+            preference.target_email_id = None  # Clear the other target
+
+        await self.db.commit()
+        await self.db.refresh(preference)
+
+        return preference
+
+    async def delete_preference(
+        self,
+        preference_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> None:
+        """
+        Delete a notification preference.
+
+        Args:
+            preference_id: Preference UUID
+            user_id: User UUID (for ownership validation)
+
+        Raises:
+            HTTPException: 404 if preference not found
+        """
+        # Validate ownership
+        preference = await self.get_preference_by_id(preference_id, user_id)
+
+        await self.db.delete(preference)
+        await self.db.commit()

--- a/backend/app/services/notification_preference_service.py
+++ b/backend/app/services/notification_preference_service.py
@@ -24,6 +24,130 @@ class NotificationPreferenceService:
         """
         self.db = db
 
+    # ==================== Private Helper Methods ====================
+
+    async def _validate_email_ownership_and_verification(
+        self,
+        email_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> EmailAddress:
+        """
+        Validate email ownership and verification status.
+
+        Args:
+            email_id: Email address ID
+            user_id: User ID for ownership check
+
+        Returns:
+            EmailAddress object
+
+        Raises:
+            HTTPException: 404 if not found, 400 if not verified
+        """
+        result = await self.db.execute(
+            select(EmailAddress).where(
+                EmailAddress.id == email_id,
+                EmailAddress.user_id == user_id,
+            )
+        )
+
+        if not (email := result.scalar_one_or_none()):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Email address not found.",
+            )
+
+        if not email.verified:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Email address must be verified.",
+            )
+
+        return email
+
+    async def _validate_phone_ownership_and_verification(
+        self,
+        phone_id: uuid.UUID,
+        user_id: uuid.UUID,
+    ) -> PhoneNumber:
+        """
+        Validate phone ownership and verification status.
+
+        Args:
+            phone_id: Phone number ID
+            user_id: User ID for ownership check
+
+        Returns:
+            PhoneNumber object
+
+        Raises:
+            HTTPException: 404 if not found, 400 if not verified
+        """
+        result = await self.db.execute(
+            select(PhoneNumber).where(
+                PhoneNumber.id == phone_id,
+                PhoneNumber.user_id == user_id,
+            )
+        )
+
+        if not (phone := result.scalar_one_or_none()):
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Phone number not found.",
+            )
+
+        if not phone.verified:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Phone number must be verified.",
+            )
+
+        return phone
+
+    async def _check_duplicate_preference(
+        self,
+        route_id: uuid.UUID,
+        method: NotificationMethod,
+        email_id: uuid.UUID | None,
+        phone_id: uuid.UUID | None,
+        exclude_preference_id: uuid.UUID | None = None,
+    ) -> None:
+        """
+        Check for duplicate preferences.
+
+        Args:
+            route_id: Route UUID
+            method: Notification method
+            email_id: Email address ID (if email method)
+            phone_id: Phone number ID (if SMS method)
+            exclude_preference_id: Preference ID to exclude from check (for updates)
+
+        Raises:
+            HTTPException: 409 if duplicate exists
+        """
+        query = select(NotificationPreference).where(
+            NotificationPreference.route_id == route_id,
+            NotificationPreference.method == method,
+        )
+
+        if exclude_preference_id is not None:
+            query = query.where(NotificationPreference.id != exclude_preference_id)
+
+        if email_id is not None:
+            query = query.where(NotificationPreference.target_email_id == email_id)
+        if phone_id is not None:
+            query = query.where(NotificationPreference.target_phone_id == phone_id)
+
+        result = await self.db.execute(query)
+
+        if result.scalar_one_or_none():
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Notification preference already exists for this route and contact.",
+            )
+
+    # ==================== Public API Methods ====================
+
     async def get_preference_by_id(
         self,
         preference_id: uuid.UUID,
@@ -103,7 +227,7 @@ class NotificationPreferenceService:
 
         return list(result.scalars().all())
 
-    async def create_preference(  # noqa: PLR0912
+    async def create_preference(
         self,
         route_id: uuid.UUID,
         user_id: uuid.UUID,
@@ -163,65 +287,20 @@ class NotificationPreferenceService:
                 detail="SMS method requires target_phone_id.",
             )
 
-        # Validate contact ownership and verification
+        # Validate contact ownership and verification using helper methods
         if target_email_id is not None:
-            email_result = await self.db.execute(
-                select(EmailAddress).where(
-                    EmailAddress.id == target_email_id,
-                    EmailAddress.user_id == user_id,
-                )
-            )
-
-            if not (email := email_result.scalar_one_or_none()):
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="Email address not found.",
-                )
-
-            if not email.verified:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Email address must be verified.",
-                )
+            await self._validate_email_ownership_and_verification(target_email_id, user_id)
 
         if target_phone_id is not None:
-            phone_result = await self.db.execute(
-                select(PhoneNumber).where(
-                    PhoneNumber.id == target_phone_id,
-                    PhoneNumber.user_id == user_id,
-                )
-            )
+            await self._validate_phone_ownership_and_verification(target_phone_id, user_id)
 
-            if not (phone := phone_result.scalar_one_or_none()):
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="Phone number not found.",
-                )
-
-            if not phone.verified:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Phone number must be verified.",
-                )
-
-        # Check for duplicates (same route + contact + method)
-        duplicate_query = select(NotificationPreference).where(
-            NotificationPreference.route_id == route_id,
-            NotificationPreference.method == method,
+        # Check for duplicates using helper method
+        await self._check_duplicate_preference(
+            route_id=route_id,
+            method=method,
+            email_id=target_email_id,
+            phone_id=target_phone_id,
         )
-
-        if target_email_id is not None:
-            duplicate_query = duplicate_query.where(NotificationPreference.target_email_id == target_email_id)
-        if target_phone_id is not None:
-            duplicate_query = duplicate_query.where(NotificationPreference.target_phone_id == target_phone_id)
-
-        duplicate_result = await self.db.execute(duplicate_query)
-
-        if duplicate_result.scalar_one_or_none():
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="Notification preference already exists for this route and contact.",
-            )
 
         # Check preference count limit
         count_result = await self.db.execute(
@@ -250,7 +329,7 @@ class NotificationPreferenceService:
 
         return preference
 
-    async def update_preference(  # noqa: PLR0912, PLR0915
+    async def update_preference(
         self,
         preference_id: uuid.UUID,
         user_id: uuid.UUID,
@@ -293,24 +372,19 @@ class NotificationPreferenceService:
 
         # If switching targets, clear the other one
         if target_email_id is not None:
-            # Explicitly setting email, clear phone
             final_email_id = target_email_id
             final_phone_id = None
         elif target_phone_id is not None:
-            # Explicitly setting phone, clear email
             final_phone_id = target_phone_id
             final_email_id = None
         else:
-            # No target change, keep existing
             final_email_id = preference.target_email_id
             final_phone_id = preference.target_phone_id
 
-        # Validate exactly one target is set
+        # Validate exactly one target is set (defensive check)
         if (final_email_id is None and final_phone_id is None) or (
             final_email_id is not None and final_phone_id is not None
         ):
-            # This defensive line would only execute if the database constraint was somehow
-            # bypassed, which shouldn't happen...
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Exactly one of target_email_id or target_phone_id must be set.",
@@ -329,66 +403,21 @@ class NotificationPreferenceService:
                 detail="SMS method requires target_phone_id.",
             )
 
-        # Validate new contact ownership and verification (if changed)
+        # Validate new contact ownership and verification (if changed) using helper methods
         if target_email_id is not None and target_email_id != preference.target_email_id:
-            email_result = await self.db.execute(
-                select(EmailAddress).where(
-                    EmailAddress.id == target_email_id,
-                    EmailAddress.user_id == user_id,
-                )
-            )
-
-            if not (email := email_result.scalar_one_or_none()):
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="Email address not found.",
-                )
-
-            if not email.verified:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Email address must be verified.",
-                )
+            await self._validate_email_ownership_and_verification(target_email_id, user_id)
 
         if target_phone_id is not None and target_phone_id != preference.target_phone_id:
-            phone_result = await self.db.execute(
-                select(PhoneNumber).where(
-                    PhoneNumber.id == target_phone_id,
-                    PhoneNumber.user_id == user_id,
-                )
-            )
+            await self._validate_phone_ownership_and_verification(target_phone_id, user_id)
 
-            if not (phone := phone_result.scalar_one_or_none()):
-                raise HTTPException(
-                    status_code=status.HTTP_404_NOT_FOUND,
-                    detail="Phone number not found.",
-                )
-
-            if not phone.verified:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Phone number must be verified.",
-                )
-
-        # Check for duplicates (excluding current preference)
-        duplicate_query = select(NotificationPreference).where(
-            NotificationPreference.route_id == route_id,
-            NotificationPreference.method == final_method,
-            NotificationPreference.id != preference_id,
+        # Check for duplicates using helper method
+        await self._check_duplicate_preference(
+            route_id=route_id,
+            method=final_method,
+            email_id=final_email_id,
+            phone_id=final_phone_id,
+            exclude_preference_id=preference_id,
         )
-
-        if final_email_id is not None:
-            duplicate_query = duplicate_query.where(NotificationPreference.target_email_id == final_email_id)
-        if final_phone_id is not None:
-            duplicate_query = duplicate_query.where(NotificationPreference.target_phone_id == final_phone_id)
-
-        duplicate_result = await self.db.execute(duplicate_query)
-
-        if duplicate_result.scalar_one_or_none():
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="Notification preference already exists for this route and contact.",
-            )
 
         # Update fields
         if method is not None:

--- a/backend/app/services/notification_preference_service.py
+++ b/backend/app/services/notification_preference_service.py
@@ -309,6 +309,8 @@ class NotificationPreferenceService:
         if (final_email_id is None and final_phone_id is None) or (
             final_email_id is not None and final_phone_id is not None
         ):
+            # This defensive line would only execute if the database constraint was somehow
+            # bypassed, which shouldn't happen...
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Exactly one of target_email_id or target_phone_id must be set.",

--- a/backend/tests/test_notification_preference_service.py
+++ b/backend/tests/test_notification_preference_service.py
@@ -1,0 +1,188 @@
+"""Direct service-level tests for notification preference service."""
+
+import pytest
+from app.models.notification import NotificationMethod
+from app.models.route import Route
+from app.models.user import EmailAddress, PhoneNumber, User
+from app.services.notification_preference_service import NotificationPreferenceService
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.helpers.test_data import make_unique_email, make_unique_phone
+
+
+class TestNotificationPreferenceServiceDirect:
+    """Test cases for service-level validation bypassing Pydantic."""
+
+    @pytest.fixture
+    async def test_route(self, db_session: AsyncSession, test_user: User) -> Route:
+        """Create a test route."""
+        route = Route(
+            user_id=test_user.id,
+            name="Test Route",
+            active=True,
+        )
+        db_session.add(route)
+        await db_session.commit()
+        await db_session.refresh(route)
+        return route
+
+    @pytest.fixture
+    async def verified_email(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> EmailAddress:
+        """Create a verified email."""
+        email = EmailAddress(
+            user_id=test_user.id,
+            email=make_unique_email(),
+            verified=True,
+            is_primary=True,
+        )
+        db_session.add(email)
+        await db_session.commit()
+        await db_session.refresh(email)
+        return email
+
+    @pytest.fixture
+    async def verified_phone(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> PhoneNumber:
+        """Create a verified phone."""
+        phone = PhoneNumber(
+            user_id=test_user.id,
+            phone=make_unique_phone(),
+            verified=True,
+            is_primary=True,
+        )
+        db_session.add(phone)
+        await db_session.commit()
+        await db_session.refresh(phone)
+        return phone
+
+    @pytest.mark.asyncio
+    async def test_create_preference_no_targets_direct(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+        test_route: Route,
+    ) -> None:
+        """Test creating preference with no targets (bypassing Pydantic)."""
+        service = NotificationPreferenceService(db_session)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.create_preference(
+                route_id=test_route.id,
+                user_id=test_user.id,
+                method=NotificationMethod.EMAIL,
+                target_email_id=None,
+                target_phone_id=None,
+            )
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Exactly one" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_update_preference_both_targets_direct(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+        test_route: Route,
+        verified_email: EmailAddress,
+        verified_phone: PhoneNumber,
+    ) -> None:
+        """Test updating preference with both targets (bypassing Pydantic)."""
+        service = NotificationPreferenceService(db_session)
+
+        # Create initial preference
+        pref = await service.create_preference(
+            route_id=test_route.id,
+            user_id=test_user.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=verified_email.id,
+            target_phone_id=None,
+        )
+
+        # Try to update with both targets
+        with pytest.raises(HTTPException) as exc_info:
+            await service.update_preference(
+                preference_id=pref.id,
+                user_id=test_user.id,
+                method=None,
+                target_email_id=verified_email.id,
+                target_phone_id=verified_phone.id,
+            )
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert "both" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_update_preference_method_change_without_target(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+        test_route: Route,
+        verified_email: EmailAddress,
+    ) -> None:
+        """Test changing method without providing matching target."""
+        service = NotificationPreferenceService(db_session)
+
+        # Create initial preference with email
+        pref = await service.create_preference(
+            route_id=test_route.id,
+            user_id=test_user.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=verified_email.id,
+            target_phone_id=None,
+        )
+
+        # Try to change method to SMS without providing phone target
+        # This leaves email set but method as SMS, which is invalid
+        with pytest.raises(HTTPException) as exc_info:
+            await service.update_preference(
+                preference_id=pref.id,
+                user_id=test_user.id,
+                method=NotificationMethod.SMS,
+                target_email_id=None,
+                target_phone_id=None,
+            )
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert "SMS method requires target_phone_id" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_update_preference_email_method_change_without_target(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+        test_route: Route,
+        verified_phone: PhoneNumber,
+    ) -> None:
+        """Test changing from SMS to EMAIL method without providing email target."""
+        service = NotificationPreferenceService(db_session)
+
+        # Create initial preference with phone
+        pref = await service.create_preference(
+            route_id=test_route.id,
+            user_id=test_user.id,
+            method=NotificationMethod.SMS,
+            target_email_id=None,
+            target_phone_id=verified_phone.id,
+        )
+
+        # Try to change method to EMAIL without providing email target
+        # This leaves phone set but method as EMAIL, which is invalid
+        with pytest.raises(HTTPException) as exc_info:
+            await service.update_preference(
+                preference_id=pref.id,
+                user_id=test_user.id,
+                method=NotificationMethod.EMAIL,
+                target_email_id=None,
+                target_phone_id=None,
+            )
+
+        assert exc_info.value.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Email method requires target_email_id" in exc_info.value.detail

--- a/backend/tests/test_notification_preferences_api.py
+++ b/backend/tests/test_notification_preferences_api.py
@@ -1,0 +1,1210 @@
+"""Tests for notification preferences API endpoints."""
+
+import uuid
+from collections.abc import AsyncGenerator
+
+import pytest
+from app.core.config import settings
+from app.core.database import get_db
+from app.main import app
+from app.models.notification import NotificationMethod, NotificationPreference
+from app.models.route import Route
+from app.models.user import EmailAddress, PhoneNumber, User
+from fastapi import status
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.helpers.test_data import make_unique_email, make_unique_phone
+
+
+class TestNotificationPreferencesAPI:
+    """Test cases for notification preferences API endpoints."""
+
+    @pytest.fixture(autouse=True)
+    async def setup_test(self, db_session: AsyncSession) -> AsyncGenerator[None]:
+        """Set up test database dependency override."""
+
+        async def override_get_db() -> AsyncGenerator[AsyncSession]:
+            yield db_session
+
+        app.dependency_overrides[get_db] = override_get_db
+        yield
+        app.dependency_overrides.clear()
+
+    @pytest.fixture
+    async def test_route(self, db_session: AsyncSession, test_user: User) -> Route:
+        """Create a test route for the test user."""
+        route = Route(
+            user_id=test_user.id,
+            name="Test Commute",
+            description="Test route",
+            active=True,
+        )
+        db_session.add(route)
+        await db_session.commit()
+        await db_session.refresh(route)
+        return route
+
+    @pytest.fixture
+    async def other_user_route(
+        self,
+        db_session: AsyncSession,
+        another_user: User,
+    ) -> Route:
+        """Create a test route for another user."""
+        route = Route(
+            user_id=another_user.id,
+            name="Other User Commute",
+            active=True,
+        )
+        db_session.add(route)
+        await db_session.commit()
+        await db_session.refresh(route)
+        return route
+
+    @pytest.fixture
+    async def verified_email(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> EmailAddress:
+        """Create a verified email for test user."""
+        email = EmailAddress(
+            user_id=test_user.id,
+            email=make_unique_email(),
+            verified=True,
+            is_primary=True,
+        )
+        db_session.add(email)
+        await db_session.commit()
+        await db_session.refresh(email)
+        return email
+
+    @pytest.fixture
+    async def unverified_email(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> EmailAddress:
+        """Create an unverified email for test user."""
+        email = EmailAddress(
+            user_id=test_user.id,
+            email=make_unique_email(),
+            verified=False,
+            is_primary=False,
+        )
+        db_session.add(email)
+        await db_session.commit()
+        await db_session.refresh(email)
+        return email
+
+    @pytest.fixture
+    async def verified_phone(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> PhoneNumber:
+        """Create a verified phone for test user."""
+        phone = PhoneNumber(
+            user_id=test_user.id,
+            phone=make_unique_phone(),
+            verified=True,
+            is_primary=True,
+        )
+        db_session.add(phone)
+        await db_session.commit()
+        await db_session.refresh(phone)
+        return phone
+
+    @pytest.fixture
+    async def unverified_phone(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> PhoneNumber:
+        """Create an unverified phone for test user."""
+        phone = PhoneNumber(
+            user_id=test_user.id,
+            phone=make_unique_phone(),
+            verified=False,
+            is_primary=False,
+        )
+        db_session.add(phone)
+        await db_session.commit()
+        await db_session.refresh(phone)
+        return phone
+
+    @pytest.fixture
+    async def other_user_email(
+        self,
+        db_session: AsyncSession,
+        another_user: User,
+    ) -> EmailAddress:
+        """Create an email for another user."""
+        email = EmailAddress(
+            user_id=another_user.id,
+            email=make_unique_email(),
+            verified=True,
+            is_primary=True,
+        )
+        db_session.add(email)
+        await db_session.commit()
+        await db_session.refresh(email)
+        return email
+
+    # ==================== List Preferences Tests ====================
+
+    @pytest.mark.asyncio
+    async def test_list_preferences_empty(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+    ) -> None:
+        """Test listing preferences when none exist."""
+        response = await async_client.get(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+
+    @pytest.mark.asyncio
+    async def test_list_preferences_with_data(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_email: EmailAddress,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test listing preferences with existing preferences."""
+        # Create a preference
+        pref = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=verified_email.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+
+        response = await async_client.get(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["method"] == "email"
+        assert data[0]["target_email_id"] == str(verified_email.id)
+        assert data[0]["target_phone_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_list_preferences_route_not_found(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+    ) -> None:
+        """Test listing preferences for non-existent route."""
+        fake_id = uuid.uuid4()
+        response = await async_client.get(
+            f"/api/v1/routes/{fake_id}/notifications",
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert "Route not found" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_list_preferences_other_users_route(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        other_user_route: Route,
+    ) -> None:
+        """Test listing preferences for another user's route."""
+        response = await async_client.get(
+            f"/api/v1/routes/{other_user_route.id}/notifications",
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_list_preferences_requires_auth(
+        self,
+        async_client: AsyncClient,
+        test_route: Route,
+    ) -> None:
+        """Test that listing requires authentication."""
+        response = await async_client.get(
+            f"/api/v1/routes/{test_route.id}/notifications",
+        )
+
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]
+
+    # ==================== Create Preference Tests ====================
+
+    @pytest.mark.asyncio
+    async def test_create_preference_email_success(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_email: EmailAddress,
+    ) -> None:
+        """Test successfully creating an email notification preference."""
+        response = await async_client.post(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            json={
+                "method": "email",
+                "target_email_id": str(verified_email.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["method"] == "email"
+        assert data["target_email_id"] == str(verified_email.id)
+        assert data["target_phone_id"] is None
+        assert data["route_id"] == str(test_route.id)
+
+    @pytest.mark.asyncio
+    async def test_create_preference_sms_success(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_phone: PhoneNumber,
+    ) -> None:
+        """Test successfully creating an SMS notification preference."""
+        response = await async_client.post(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            json={
+                "method": "sms",
+                "target_phone_id": str(verified_phone.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        data = response.json()
+        assert data["method"] == "sms"
+        assert data["target_phone_id"] == str(verified_phone.id)
+        assert data["target_email_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_create_preference_no_target(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+    ) -> None:
+        """Test creating preference without target fails validation."""
+        response = await async_client.post(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            json={
+                "method": "email",
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    @pytest.mark.asyncio
+    async def test_create_preference_both_targets(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_email: EmailAddress,
+        verified_phone: PhoneNumber,
+    ) -> None:
+        """Test creating preference with both targets fails validation."""
+        response = await async_client.post(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            json={
+                "method": "email",
+                "target_email_id": str(verified_email.id),
+                "target_phone_id": str(verified_phone.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    @pytest.mark.asyncio
+    async def test_create_preference_email_method_requires_email_target(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_phone: PhoneNumber,
+    ) -> None:
+        """Test that email method requires email target."""
+        response = await async_client.post(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            json={
+                "method": "email",
+                "target_phone_id": str(verified_phone.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Email method requires target_email_id" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_create_preference_sms_method_requires_phone_target(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_email: EmailAddress,
+    ) -> None:
+        """Test that SMS method requires phone target."""
+        response = await async_client.post(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            json={
+                "method": "sms",
+                "target_email_id": str(verified_email.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "SMS method requires target_phone_id" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_create_preference_unverified_email(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        unverified_email: EmailAddress,
+    ) -> None:
+        """Test creating preference with unverified email fails."""
+        response = await async_client.post(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            json={
+                "method": "email",
+                "target_email_id": str(unverified_email.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "must be verified" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_create_preference_unverified_phone(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        unverified_phone: PhoneNumber,
+    ) -> None:
+        """Test creating preference with unverified phone fails."""
+        response = await async_client.post(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            json={
+                "method": "sms",
+                "target_phone_id": str(unverified_phone.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "must be verified" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_create_preference_email_not_found(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+    ) -> None:
+        """Test creating preference with non-existent email."""
+        fake_id = uuid.uuid4()
+        response = await async_client.post(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            json={
+                "method": "email",
+                "target_email_id": str(fake_id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert "Email address not found" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_create_preference_phone_not_found(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+    ) -> None:
+        """Test creating preference with non-existent phone."""
+        fake_id = uuid.uuid4()
+        response = await async_client.post(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            json={
+                "method": "sms",
+                "target_phone_id": str(fake_id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert "Phone number not found" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_create_preference_other_users_email(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        other_user_email: EmailAddress,
+    ) -> None:
+        """Test creating preference with another user's email fails."""
+        response = await async_client.post(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            json={
+                "method": "email",
+                "target_email_id": str(other_user_email.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_create_preference_duplicate(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_email: EmailAddress,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test creating duplicate preference fails."""
+        # Create first preference
+        pref = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=verified_email.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+
+        # Attempt to create duplicate
+        response = await async_client.post(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            json={
+                "method": "email",
+                "target_email_id": str(verified_email.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert "already exists" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_create_preference_max_limit(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        test_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test creating preference fails when limit is reached."""
+        # Create max number of preferences
+        for i in range(settings.MAX_NOTIFICATION_PREFERENCES_PER_ROUTE):
+            email = EmailAddress(
+                user_id=test_user.id,
+                email=make_unique_email(),
+                verified=True,
+                is_primary=i == 0,
+            )
+            db_session.add(email)
+            await db_session.flush()
+
+            pref = NotificationPreference(
+                route_id=test_route.id,
+                method=NotificationMethod.EMAIL,
+                target_email_id=email.id,
+            )
+            db_session.add(pref)
+
+        await db_session.commit()
+
+        # Create one more email for the attempt
+        extra_email = EmailAddress(
+            user_id=test_user.id,
+            email=make_unique_email(),
+            verified=True,
+            is_primary=False,
+        )
+        db_session.add(extra_email)
+        await db_session.commit()
+        await db_session.refresh(extra_email)
+
+        # Attempt to create one more preference
+        response = await async_client.post(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            json={
+                "method": "email",
+                "target_email_id": str(extra_email.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Maximum" in response.json()["detail"]
+        assert str(settings.MAX_NOTIFICATION_PREFERENCES_PER_ROUTE) in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_create_preference_route_not_found(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        verified_email: EmailAddress,
+    ) -> None:
+        """Test creating preference for non-existent route."""
+        fake_id = uuid.uuid4()
+        response = await async_client.post(
+            f"/api/v1/routes/{fake_id}/notifications",
+            json={
+                "method": "email",
+                "target_email_id": str(verified_email.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert "Route not found" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_create_preference_requires_auth(
+        self,
+        async_client: AsyncClient,
+        test_route: Route,
+        verified_email: EmailAddress,
+    ) -> None:
+        """Test that creating preference requires authentication."""
+        response = await async_client.post(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            json={
+                "method": "email",
+                "target_email_id": str(verified_email.id),
+            },
+        )
+
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]
+
+    # ==================== Update Preference Tests ====================
+
+    @pytest.mark.asyncio
+    async def test_update_preference_change_method(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_phone: PhoneNumber,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test updating preference method."""
+        # Create preference with SMS
+        pref = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.SMS,
+            target_phone_id=verified_phone.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+        await db_session.refresh(pref)
+
+        # Update to EMAIL (but this should fail because phone is set)
+        # So let's just change the phone target
+        another_phone = PhoneNumber(
+            user_id=test_route.user_id,
+            phone=make_unique_phone(),
+            verified=True,
+            is_primary=False,
+        )
+        db_session.add(another_phone)
+        await db_session.commit()
+        await db_session.refresh(another_phone)
+
+        response = await async_client.patch(
+            f"/api/v1/routes/{test_route.id}/notifications/{pref.id}",
+            json={
+                "target_phone_id": str(another_phone.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["target_phone_id"] == str(another_phone.id)
+
+    @pytest.mark.asyncio
+    async def test_update_preference_change_target(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_email: EmailAddress,
+        test_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test updating preference target."""
+        # Create preference
+        pref = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=verified_email.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+        await db_session.refresh(pref)
+
+        # Create another email
+        another_email = EmailAddress(
+            user_id=test_user.id,
+            email=make_unique_email(),
+            verified=True,
+            is_primary=False,
+        )
+        db_session.add(another_email)
+        await db_session.commit()
+        await db_session.refresh(another_email)
+
+        # Update target
+        response = await async_client.patch(
+            f"/api/v1/routes/{test_route.id}/notifications/{pref.id}",
+            json={
+                "target_email_id": str(another_email.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["target_email_id"] == str(another_email.id)
+
+    @pytest.mark.asyncio
+    async def test_update_preference_both_targets_fails(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_email: EmailAddress,
+        verified_phone: PhoneNumber,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test updating preference with both targets fails."""
+        # Create preference
+        pref = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=verified_email.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+        await db_session.refresh(pref)
+
+        # Try to set both targets
+        response = await async_client.patch(
+            f"/api/v1/routes/{test_route.id}/notifications/{pref.id}",
+            json={
+                "target_email_id": str(verified_email.id),
+                "target_phone_id": str(verified_phone.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    @pytest.mark.asyncio
+    async def test_update_preference_switch_from_email_to_sms(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_email: EmailAddress,
+        verified_phone: PhoneNumber,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test switching from email to SMS notification."""
+        # Create email preference
+        pref = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=verified_email.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+        await db_session.refresh(pref)
+
+        # Switch to SMS
+        response = await async_client.patch(
+            f"/api/v1/routes/{test_route.id}/notifications/{pref.id}",
+            json={
+                "method": "sms",
+                "target_phone_id": str(verified_phone.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["method"] == "sms"
+        assert data["target_phone_id"] == str(verified_phone.id)
+        assert data["target_email_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_update_preference_unverified_email(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_email: EmailAddress,
+        unverified_email: EmailAddress,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test updating to unverified email fails."""
+        # Create preference
+        pref = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=verified_email.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+        await db_session.refresh(pref)
+
+        # Try to update to unverified email
+        response = await async_client.patch(
+            f"/api/v1/routes/{test_route.id}/notifications/{pref.id}",
+            json={
+                "target_email_id": str(unverified_email.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "must be verified" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_update_preference_to_duplicate(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        test_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test updating preference to create duplicate fails."""
+        # Create two emails
+        email1 = EmailAddress(
+            user_id=test_user.id,
+            email=make_unique_email(),
+            verified=True,
+            is_primary=True,
+        )
+        email2 = EmailAddress(
+            user_id=test_user.id,
+            email=make_unique_email(),
+            verified=True,
+            is_primary=False,
+        )
+        db_session.add_all([email1, email2])
+        await db_session.commit()
+
+        # Create two preferences
+        pref1 = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=email1.id,
+        )
+        pref2 = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=email2.id,
+        )
+        db_session.add_all([pref1, pref2])
+        await db_session.commit()
+        await db_session.refresh(pref2)
+
+        # Try to update pref2 to use email1 (duplicate)
+        response = await async_client.patch(
+            f"/api/v1/routes/{test_route.id}/notifications/{pref2.id}",
+            json={
+                "target_email_id": str(email1.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert "already exists" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_update_preference_not_found(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_email: EmailAddress,
+    ) -> None:
+        """Test updating non-existent preference."""
+        fake_id = uuid.uuid4()
+        response = await async_client.patch(
+            f"/api/v1/routes/{test_route.id}/notifications/{fake_id}",
+            json={
+                "target_email_id": str(verified_email.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_update_preference_other_users_preference(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        other_user_route: Route,
+        other_user_email: EmailAddress,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test updating another user's preference fails."""
+        # Create preference for other user
+        pref = NotificationPreference(
+            route_id=other_user_route.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=other_user_email.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+        await db_session.refresh(pref)
+
+        # Try to update it
+        response = await async_client.patch(
+            f"/api/v1/routes/{other_user_route.id}/notifications/{pref.id}",
+            json={
+                "method": "sms",
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_update_preference_requires_auth(
+        self,
+        async_client: AsyncClient,
+        test_route: Route,
+        verified_email: EmailAddress,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that updating requires authentication."""
+        # Create preference
+        pref = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=verified_email.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+        await db_session.refresh(pref)
+
+        response = await async_client.patch(
+            f"/api/v1/routes/{test_route.id}/notifications/{pref.id}",
+            json={
+                "method": "sms",
+            },
+        )
+
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_update_preference_email_method_mismatch(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_phone: PhoneNumber,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test updating to email method with phone target fails."""
+        # Create SMS preference
+        pref = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.SMS,
+            target_phone_id=verified_phone.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+        await db_session.refresh(pref)
+
+        # Try to change method to email without changing target
+        response = await async_client.patch(
+            f"/api/v1/routes/{test_route.id}/notifications/{pref.id}",
+            json={
+                "method": "email",
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "Email method requires target_email_id" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_update_preference_sms_method_mismatch(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_email: EmailAddress,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test updating to SMS method with email target fails."""
+        # Create email preference
+        pref = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=verified_email.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+        await db_session.refresh(pref)
+
+        # Try to change method to SMS without changing target
+        response = await async_client.patch(
+            f"/api/v1/routes/{test_route.id}/notifications/{pref.id}",
+            json={
+                "method": "sms",
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "SMS method requires target_phone_id" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_update_preference_unverified_phone(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_phone: PhoneNumber,
+        unverified_phone: PhoneNumber,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test updating to unverified phone fails."""
+        # Create SMS preference
+        pref = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.SMS,
+            target_phone_id=verified_phone.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+        await db_session.refresh(pref)
+
+        # Try to update to unverified phone
+        response = await async_client.patch(
+            f"/api/v1/routes/{test_route.id}/notifications/{pref.id}",
+            json={
+                "target_phone_id": str(unverified_phone.id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "must be verified" in response.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_update_preference_phone_not_found(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_phone: PhoneNumber,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test updating to non-existent phone."""
+        # Create preference
+        pref = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.SMS,
+            target_phone_id=verified_phone.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+        await db_session.refresh(pref)
+
+        fake_id = uuid.uuid4()
+        response = await async_client.patch(
+            f"/api/v1/routes/{test_route.id}/notifications/{pref.id}",
+            json={
+                "target_phone_id": str(fake_id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_update_preference_contact_not_found(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_email: EmailAddress,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test updating to non-existent contact."""
+        # Create preference
+        pref = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=verified_email.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+        await db_session.refresh(pref)
+
+        fake_id = uuid.uuid4()
+        response = await async_client.patch(
+            f"/api/v1/routes/{test_route.id}/notifications/{pref.id}",
+            json={
+                "target_email_id": str(fake_id),
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    # ==================== Delete Preference Tests ====================
+
+    @pytest.mark.asyncio
+    async def test_delete_preference_success(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+        verified_email: EmailAddress,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test successfully deleting a preference."""
+        # Create preference
+        pref = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=verified_email.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+        await db_session.refresh(pref)
+
+        response = await async_client.delete(
+            f"/api/v1/routes/{test_route.id}/notifications/{pref.id}",
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+
+        # Verify deletion
+        list_response = await async_client.get(
+            f"/api/v1/routes/{test_route.id}/notifications",
+            headers=auth_headers_for_user,
+        )
+        assert list_response.json() == []
+
+    @pytest.mark.asyncio
+    async def test_delete_preference_not_found(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_route: Route,
+    ) -> None:
+        """Test deleting non-existent preference."""
+        fake_id = uuid.uuid4()
+        response = await async_client.delete(
+            f"/api/v1/routes/{test_route.id}/notifications/{fake_id}",
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_delete_preference_other_users_preference(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        other_user_route: Route,
+        other_user_email: EmailAddress,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test deleting another user's preference fails."""
+        # Create preference for other user
+        pref = NotificationPreference(
+            route_id=other_user_route.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=other_user_email.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+        await db_session.refresh(pref)
+
+        response = await async_client.delete(
+            f"/api/v1/routes/{other_user_route.id}/notifications/{pref.id}",
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_delete_preference_requires_auth(
+        self,
+        async_client: AsyncClient,
+        test_route: Route,
+        verified_email: EmailAddress,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that deleting requires authentication."""
+        # Create preference
+        pref = NotificationPreference(
+            route_id=test_route.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=verified_email.id,
+        )
+        db_session.add(pref)
+        await db_session.commit()
+        await db_session.refresh(pref)
+
+        response = await async_client.delete(
+            f"/api/v1/routes/{test_route.id}/notifications/{pref.id}",
+        )
+
+        assert response.status_code in [
+            status.HTTP_401_UNAUTHORIZED,
+            status.HTTP_403_FORBIDDEN,
+        ]


### PR DESCRIPTION
## Summary by Sourcery

Add phase 7 notification preferences feature: introduce service, models, API endpoints, configuration, and comprehensive testing to support user-specific notification preference management with robust validation and limits.

New Features:
- Introduce full CRUD API for managing notification preferences under /routes/{route_id}/notifications
- Implement NotificationPreferenceService with validations for ownership, contact verification, duplicate prevention, and per-route limits
- Add Pydantic request and response schemas for notification preference operations

Enhancements:
- Add configurable MAX_NOTIFICATION_PREFERENCES_PER_ROUTE setting
- Set up cascade delete relationship between Route and NotificationPreference
- Include notification preferences router in application setup

Tests:
- Add extensive integration tests for API endpoints covering create, list, update, and delete scenarios
- Add service-level tests for direct validation of notification preference logic