### PR TITLE
Feature/fix build graph station population

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -612,6 +612,21 @@ See [Architecture Decision Records](./docs/adr/README.md) for all architectural 
 - Historical disruption analytics
 - Integration with other transit systems
 
+### Deferred Code Quality Improvements
+
+The following refactoring suggestions were identified during code review but deferred following KISS principles for this hobby project. These could be revisited in the future if the codebase grows or if additional complexity is added:
+
+**TfL Service Refactoring (Phase 5)**:
+- **Encapsulate `pending_connections`**: Currently passed through 2 method signatures (`build_station_graph` → `_process_route_sequence` → `_process_station_pair`). Could be encapsulated into a helper class or context object if more methods need this pattern in the future.
+- **Split `build_station_graph` method**: Currently handles fetching, validation, deletion, processing, and commit in one method (~120 lines). Could be split into smaller private methods (e.g., `_fetch_and_validate_data()`, `_clear_existing_connections()`, `_process_all_lines()`) if the method becomes harder to maintain.
+- **Transaction context manager**: Currently uses manual `commit()` and `rollback()` in exception handlers. Could create a custom context manager for automatic rollback on errors, though current pattern works well and is explicit.
+
+**Rationale for deferring**:
+- `pending_connections` only used in 2 methods - encapsulation would add complexity without clear benefit
+- `build_station_graph` is readable as-is and well-tested (96%+ coverage)
+- Manual transaction management is explicit and easy to understand for a hobby project
+- Following YAGNI principle - add complexity only when needed
+
 ## Progress Tracking
 
 This document will be updated as phases are completed. Each phase will be marked with completion status and any relevant notes about implementation decisions or deviations from the original plan.

--- a/backend/app/services/tfl_service.py
+++ b/backend/app/services/tfl_service.py
@@ -1074,7 +1074,9 @@ class TfLService:
 
             # Clear existing connections (within transaction - will rollback if building fails)
             await self.db.execute(delete(StationConnection))
-            await self.db.flush()  # Ensure DELETE is executed before adding new connections
+            # Required: flush prevents unique constraint violations when rebuilding connections.
+            # Without this, SQLAlchemy may reorder operations causing duplicate key errors.
+            await self.db.flush()
             logger.info("existing_connections_cleared")
 
             stations_set: set[str] = set()


### PR DESCRIPTION
## Summary by Sourcery

Improve station graph builder by preloading and validating stations, deduplicating connections with an in-memory set, and enhancing error handling and rollback. Update tests to cover station fetching, failure conditions, duplicate prevention, and internal method signature changes.

New Features:
- Fail fast with HTTP 500 if no stations are fetched before building the graph
- Rollback the transaction and surface HTTP 500 when graph building encounters an unexpected error

Enhancements:
- Prefetch stations for all lines and validate non-zero station count before constructing connections
- Use an in-transaction pending_connections set to dedupe bidirectional station connections instead of querying the database repeatedly
- Clear existing station connections within the same transaction and flush before adding new ones

Tests:
- Update core build_graph test to mock station fetching and verify station creation
- Add tests for failure when no stations are returned, for rollback on error, and for preventing duplicate connections
- Adjust internal _process_station_pair and _process_route_sequence tests to include pending_connections parameter