### PR TITLE
feat: Store route sequences for frontend route building (#29)

### DIFF
--- a/backend/alembic/versions/941d95fee6c2_add_routes_to_lines.py
+++ b/backend/alembic/versions/941d95fee6c2_add_routes_to_lines.py
@@ -1,0 +1,39 @@
+"""add_routes_to_lines
+
+Revision ID: 941d95fee6c2
+Revises: 2bae05497678
+Create Date: 2025-11-08 15:24:50.273645
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "941d95fee6c2"
+down_revision: str | Sequence[str] | None = "2bae05497678"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Add routes JSON column to lines table to store ordered route sequences
+    (station lists for each route variant). This enables the frontend to show
+    users only reachable stations on specific route variants.
+    """
+    op.add_column(
+        "lines",
+        sa.Column("routes", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Remove routes column from lines table.
+    """
+    op.drop_column("lines", "routes")

--- a/backend/app/models/tfl.py
+++ b/backend/app/models/tfl.py
@@ -2,6 +2,7 @@
 
 import uuid
 from datetime import datetime
+from typing import Any
 
 from sqlalchemy import (
     JSON,
@@ -41,6 +42,11 @@ class Line(BaseModel):
         String(50),  # Transport mode: "tube", "overground", "dlr", "elizabeth-line", etc.
         nullable=False,
         default="tube",
+    )
+    routes: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON,  # Stores ordered route sequences (station lists for each route variant)
+        nullable=True,
+        default=None,
     )
     last_updated: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/backend/app/schemas/tfl.py
+++ b/backend/app/schemas/tfl.py
@@ -59,6 +59,49 @@ class StationDisruptionResponse(BaseModel):
     created_at_source: datetime  # When disruption was created at source
 
 
+class RouteVariant(BaseModel):
+    """Schema for a single route variant (ordered station sequence)."""
+
+    name: str = Field(..., description="Route name (e.g., 'Edgware → Morden via Bank')")
+    service_type: str = Field(..., description="Service type (e.g., 'Regular', 'Night')")
+    direction: str = Field(..., description="Direction: 'inbound' or 'outbound'")
+    stations: list[str] = Field(
+        ...,
+        description="Ordered list of TfL station IDs on this route variant",
+    )
+
+
+class LineRouteResponse(BaseModel):
+    """Response schema for line route variants."""
+
+    line_tfl_id: str = Field(..., description="TfL line ID (e.g., 'victoria')")
+    routes: list[RouteVariant] = Field(
+        ...,
+        description="List of route variants for this line",
+    )
+
+
+class StationRouteInfo(BaseModel):
+    """Schema for route information for a station."""
+
+    line_tfl_id: str = Field(..., description="TfL line ID")
+    line_name: str = Field(..., description="Line name")
+    route_name: str = Field(..., description="Route variant name")
+    service_type: str = Field(..., description="Service type")
+    direction: str = Field(..., description="Direction")
+
+
+class StationRouteResponse(BaseModel):
+    """Response schema for routes passing through a station."""
+
+    station_tfl_id: str = Field(..., description="TfL station ID")
+    station_name: str = Field(..., description="Station name")
+    routes: list[StationRouteInfo] = Field(
+        ...,
+        description="Routes passing through this station",
+    )
+
+
 # ==================== Request Schemas ====================
 
 

--- a/backend/app/services/tfl_service.py
+++ b/backend/app/services/tfl_service.py
@@ -1687,18 +1687,17 @@ class TfLService:
                     continue
 
                 routes = line.routes.get("routes", [])
-                for route in routes:
-                    # Check if this station is on this route
-                    if station_tfl_id in route.get("stations", []):
-                        station_routes.append(
-                            {
-                                "line_tfl_id": line.tfl_id,
-                                "line_name": line.name,
-                                "route_name": route.get("name", "Unknown"),
-                                "service_type": route.get("service_type", "Unknown"),
-                                "direction": route.get("direction", "Unknown"),
-                            }
-                        )
+                station_routes.extend(
+                    {
+                        "line_tfl_id": line.tfl_id,
+                        "line_name": line.name,
+                        "route_name": route.get("name", "Unknown"),
+                        "service_type": route.get("service_type", "Unknown"),
+                        "direction": route.get("direction", "Unknown"),
+                    }
+                    for route in routes
+                    if station_tfl_id in route.get("stations", [])
+                )
 
             # Check if any routes were found
             if not station_routes and lines:

--- a/backend/tests/test_tfl_api.py
+++ b/backend/tests/test_tfl_api.py
@@ -552,3 +552,354 @@ async def test_get_network_graph_unexpected_error(
 # Note: Full integration tests removed per YAGNI principle
 # Route validation is thoroughly tested at service layer (5 tests)
 # API layer is tested with mocked services above
+
+
+# ==================== GET /tfl/lines/{line_id}/routes Tests ====================
+
+
+@patch("app.services.tfl_service.TfLService.get_line_routes")
+async def test_get_line_routes_success(
+    mock_get_line_routes: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test successful retrieval of line route variants."""
+    # Mock successful route retrieval
+    mock_get_line_routes.return_value = {
+        "line_tfl_id": "victoria",
+        "routes": [
+            {
+                "name": "Walthamstow Central → Brixton",
+                "service_type": "Regular",
+                "direction": "inbound",
+                "stations": ["940GZZLUWAC", "940GZZLUVIC", "940GZZLUBXN"],
+            },
+            {
+                "name": "Brixton → Walthamstow Central",
+                "service_type": "Regular",
+                "direction": "outbound",
+                "stations": ["940GZZLUBXN", "940GZZLUVIC", "940GZZLUWAC"],
+            },
+        ],
+    }
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/lines/victoria/routes"))
+
+    # Verify
+    assert response.status_code == 200
+    data = response.json()
+    assert data["line_tfl_id"] == "victoria"
+    assert len(data["routes"]) == 2
+    assert data["routes"][0]["name"] == "Walthamstow Central → Brixton"
+    assert data["routes"][0]["direction"] == "inbound"
+    assert data["routes"][0]["stations"] == ["940GZZLUWAC", "940GZZLUVIC", "940GZZLUBXN"]
+    assert data["routes"][1]["name"] == "Brixton → Walthamstow Central"
+    assert data["routes"][1]["direction"] == "outbound"
+
+    # Verify service was called with correct line_id
+    mock_get_line_routes.assert_called_once_with("victoria")
+
+
+@patch("app.services.tfl_service.TfLService.get_line_routes")
+async def test_get_line_routes_line_not_found(
+    mock_get_line_routes: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test get_line_routes endpoint when line does not exist."""
+    # Mock 404 error
+    mock_get_line_routes.side_effect = HTTPException(
+        status_code=404,
+        detail="Line 'nonexistent' not found.",
+    )
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/lines/nonexistent/routes"))
+
+    # Verify
+    assert response.status_code == 404
+    assert "Line 'nonexistent' not found" in response.json()["detail"]
+
+
+@patch("app.services.tfl_service.TfLService.get_line_routes")
+async def test_get_line_routes_routes_not_built(
+    mock_get_line_routes: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test get_line_routes endpoint when routes haven't been built yet."""
+    # Mock 503 error
+    mock_get_line_routes.side_effect = HTTPException(
+        status_code=503,
+        detail="Route data has not been built yet. Please contact administrator.",
+    )
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/lines/victoria/routes"))
+
+    # Verify
+    assert response.status_code == 503
+    assert "Route data has not been built yet" in response.json()["detail"]
+
+
+@patch("app.services.tfl_service.TfLService.get_line_routes")
+async def test_get_line_routes_empty_routes(
+    mock_get_line_routes: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test get_line_routes endpoint when line has no routes."""
+    # Mock empty routes
+    mock_get_line_routes.return_value = {
+        "line_tfl_id": "victoria",
+        "routes": [],
+    }
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/lines/victoria/routes"))
+
+    # Verify
+    assert response.status_code == 200
+    data = response.json()
+    assert data["line_tfl_id"] == "victoria"
+    assert data["routes"] == []
+
+
+async def test_get_line_routes_unauthenticated(
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test that unauthenticated requests to get_line_routes are rejected."""
+    # Create client without auth headers
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(build_api_url("/tfl/lines/victoria/routes"))
+
+    assert response.status_code == 403
+
+
+@patch("app.services.tfl_service.TfLService.get_line_routes")
+async def test_get_line_routes_server_error(
+    mock_get_line_routes: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test get_line_routes endpoint when server error occurs."""
+    # Mock 500 error
+    mock_get_line_routes.side_effect = HTTPException(
+        status_code=500,
+        detail="Failed to fetch routes for line 'victoria'.",
+    )
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/lines/victoria/routes"))
+
+    # Verify
+    assert response.status_code == 500
+    assert "Failed to fetch routes" in response.json()["detail"]
+
+
+# ==================== GET /tfl/stations/{station_tfl_id}/routes Tests ====================
+
+
+@patch("app.services.tfl_service.TfLService.get_station_routes")
+async def test_get_station_routes_success(
+    mock_get_station_routes: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test successful retrieval of routes passing through a station."""
+    # Mock successful station routes retrieval
+    mock_get_station_routes.return_value = {
+        "station_tfl_id": "940GZZLUVIC",
+        "station_name": "Victoria",
+        "routes": [
+            {
+                "line_tfl_id": "victoria",
+                "line_name": "Victoria",
+                "route_name": "Walthamstow Central → Brixton",
+                "service_type": "Regular",
+                "direction": "inbound",
+            },
+            {
+                "line_tfl_id": "district",
+                "line_name": "District",
+                "route_name": "Upminster → Ealing Broadway",
+                "service_type": "Regular",
+                "direction": "inbound",
+            },
+        ],
+    }
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/stations/940GZZLUVIC/routes"))
+
+    # Verify
+    assert response.status_code == 200
+    data = response.json()
+    assert data["station_tfl_id"] == "940GZZLUVIC"
+    assert data["station_name"] == "Victoria"
+    assert len(data["routes"]) == 2
+
+    # Verify first route
+    assert data["routes"][0]["line_tfl_id"] == "victoria"
+    assert data["routes"][0]["line_name"] == "Victoria"
+    assert data["routes"][0]["route_name"] == "Walthamstow Central → Brixton"
+    assert data["routes"][0]["service_type"] == "Regular"
+    assert data["routes"][0]["direction"] == "inbound"
+
+    # Verify second route
+    assert data["routes"][1]["line_tfl_id"] == "district"
+    assert data["routes"][1]["line_name"] == "District"
+
+    # Verify service was called with correct station_tfl_id
+    mock_get_station_routes.assert_called_once_with("940GZZLUVIC")
+
+
+@patch("app.services.tfl_service.TfLService.get_station_routes")
+async def test_get_station_routes_station_not_found(
+    mock_get_station_routes: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test get_station_routes endpoint when station does not exist."""
+    # Mock 404 error
+    mock_get_station_routes.side_effect = HTTPException(
+        status_code=404,
+        detail="Station '940GZZLUNONEXISTENT' not found.",
+    )
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/stations/940GZZLUNONEXISTENT/routes"))
+
+    # Verify
+    assert response.status_code == 404
+    assert "Station '940GZZLUNONEXISTENT' not found" in response.json()["detail"]
+
+
+@patch("app.services.tfl_service.TfLService.get_station_routes")
+async def test_get_station_routes_routes_not_built(
+    mock_get_station_routes: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test get_station_routes endpoint when routes haven't been built yet."""
+    # Mock 503 error
+    mock_get_station_routes.side_effect = HTTPException(
+        status_code=503,
+        detail="Route data has not been built yet. Please contact administrator.",
+    )
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/stations/940GZZLUVIC/routes"))
+
+    # Verify
+    assert response.status_code == 503
+    assert "Route data has not been built yet" in response.json()["detail"]
+
+
+@patch("app.services.tfl_service.TfLService.get_station_routes")
+async def test_get_station_routes_no_lines(
+    mock_get_station_routes: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test get_station_routes endpoint when station has no lines."""
+    # Mock empty routes (station exists but no lines)
+    mock_get_station_routes.return_value = {
+        "station_tfl_id": "940GZZLUVIC",
+        "station_name": "Victoria",
+        "routes": [],
+    }
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/stations/940GZZLUVIC/routes"))
+
+    # Verify
+    assert response.status_code == 200
+    data = response.json()
+    assert data["station_tfl_id"] == "940GZZLUVIC"
+    assert data["station_name"] == "Victoria"
+    assert data["routes"] == []
+
+
+async def test_get_station_routes_unauthenticated(
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test that unauthenticated requests to get_station_routes are rejected."""
+    # Create client without auth headers
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get(build_api_url("/tfl/stations/940GZZLUVIC/routes"))
+
+    assert response.status_code == 403
+
+
+@patch("app.services.tfl_service.TfLService.get_station_routes")
+async def test_get_station_routes_server_error(
+    mock_get_station_routes: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test get_station_routes endpoint when server error occurs."""
+    # Mock 500 error
+    mock_get_station_routes.side_effect = HTTPException(
+        status_code=500,
+        detail="Failed to fetch routes for station '940GZZLUVIC'.",
+    )
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/stations/940GZZLUVIC/routes"))
+
+    # Verify
+    assert response.status_code == 500
+    assert "Failed to fetch routes" in response.json()["detail"]
+
+
+@patch("app.services.tfl_service.TfLService.get_station_routes")
+async def test_get_station_routes_multiple_routes_same_line(
+    mock_get_station_routes: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test get_station_routes when station is on multiple route variants of same line."""
+    # Mock multiple routes on same line (like Northern line branches)
+    mock_get_station_routes.return_value = {
+        "station_tfl_id": "940GZZLUCTN",
+        "station_name": "Camden Town",
+        "routes": [
+            {
+                "line_tfl_id": "northern",
+                "line_name": "Northern",
+                "route_name": "Edgware → Morden via Bank",
+                "service_type": "Regular",
+                "direction": "inbound",
+            },
+            {
+                "line_tfl_id": "northern",
+                "line_name": "Northern",
+                "route_name": "High Barnet → Morden via Bank",
+                "service_type": "Regular",
+                "direction": "inbound",
+            },
+            {
+                "line_tfl_id": "northern",
+                "line_name": "Northern",
+                "route_name": "Morden → Edgware via Bank",
+                "service_type": "Regular",
+                "direction": "outbound",
+            },
+        ],
+    }
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/stations/940GZZLUCTN/routes"))
+
+    # Verify
+    assert response.status_code == 200
+    data = response.json()
+    assert data["station_tfl_id"] == "940GZZLUCTN"
+    assert data["station_name"] == "Camden Town"
+    assert len(data["routes"]) == 3
+
+    # Verify all routes are for Northern line
+    assert all(route["line_tfl_id"] == "northern" for route in data["routes"])
+
+    # Verify route names
+    route_names = [route["route_name"] for route in data["routes"]]
+    assert "Edgware → Morden via Bank" in route_names
+    assert "High Barnet → Morden via Bank" in route_names
+    assert "Morden → Edgware via Bank" in route_names

--- a/backend/tests/test_tfl_service.py
+++ b/backend/tests/test_tfl_service.py
@@ -3563,32 +3563,7 @@ async def test_fetch_stations_api_error_handling(
 
 
 # ==================== Route Sequences Tests ====================
-
-
-class MockOrderedRoute:
-    """Mock for orderedLineRoutes data from TfL API."""
-
-    def __init__(
-        self,
-        name: str = "Route 1",
-        service_type: str = "Regular",
-        naptan_ids: list[str] | None = None,
-    ) -> None:
-        self.name = name
-        self.serviceType = service_type
-        self.naptanIds = naptan_ids if naptan_ids is not None else ["940GZZLUVIC", "940GZZLUGPK"]
-
-
-class MockRouteSequenceData:
-    """Mock for RouteSequence data from TfL API."""
-
-    def __init__(
-        self,
-        ordered_routes: list[MockOrderedRoute] | None = None,
-        stop_point_sequences: list[Any] | None = None,
-    ) -> None:
-        self.orderedLineRoutes = ordered_routes
-        self.stopPointSequences = stop_point_sequences
+# Note: MockOrderedRoute and MockRouteSequence are defined at the top of this file
 
 
 # ==================== _store_line_routes Tests ====================
@@ -3622,8 +3597,8 @@ async def test_store_line_routes_regular_service(db_session: AsyncSession) -> No
             naptan_ids=["940GZZLUBXN", "940GZZLUVIC", "940GZZLUWAC"],
         )
     ]
-    inbound_data = MockRouteSequenceData(ordered_routes=inbound_routes)
-    outbound_data = MockRouteSequenceData(ordered_routes=outbound_routes)
+    inbound_data = MockRouteSequence(orderedLineRoutes=inbound_routes)
+    outbound_data = MockRouteSequence(orderedLineRoutes=outbound_routes)
 
     # Execute
     tfl_service = TfLService(db_session)
@@ -3676,7 +3651,7 @@ async def test_store_line_routes_skip_night_service(db_session: AsyncSession) ->
             naptan_ids=["940GZZLUVIC", "940GZZLUGPK"],
         ),
     ]
-    inbound_data = MockRouteSequenceData(ordered_routes=inbound_routes)
+    inbound_data = MockRouteSequence(orderedLineRoutes=inbound_routes)
 
     # Execute
     tfl_service = TfLService(db_session)
@@ -3725,7 +3700,7 @@ async def test_store_line_routes_empty_ordered_routes(db_session: AsyncSession) 
     await db_session.commit()
 
     # Create route data with empty orderedLineRoutes
-    inbound_data = MockRouteSequenceData(ordered_routes=[])
+    inbound_data = MockRouteSequence(orderedLineRoutes=[])
 
     # Execute
     tfl_service = TfLService(db_session)
@@ -3756,7 +3731,7 @@ async def test_store_line_routes_no_naptan_ids(db_session: AsyncSession) -> None
             naptan_ids=[],
         )
     ]
-    inbound_data = MockRouteSequenceData(ordered_routes=inbound_routes)
+    inbound_data = MockRouteSequence(orderedLineRoutes=inbound_routes)
 
     # Execute
     tfl_service = TfLService(db_session)
@@ -3814,7 +3789,7 @@ async def test_store_line_routes_only_inbound(db_session: AsyncSession) -> None:
             naptan_ids=["940GZZLUVIC", "940GZZLUGPK"],
         )
     ]
-    inbound_data = MockRouteSequenceData(ordered_routes=inbound_routes)
+    inbound_data = MockRouteSequence(orderedLineRoutes=inbound_routes)
 
     # Execute
     tfl_service = TfLService(db_session)
@@ -3848,7 +3823,7 @@ async def test_store_line_routes_only_outbound(db_session: AsyncSession) -> None
             naptan_ids=["940GZZLUGPK", "940GZZLUVIC"],
         )
     ]
-    outbound_data = MockRouteSequenceData(ordered_routes=outbound_routes)
+    outbound_data = MockRouteSequence(orderedLineRoutes=outbound_routes)
 
     # Execute
     tfl_service = TfLService(db_session)


### PR DESCRIPTION
## Summary
Implements route sequence storage and retrieval to enable frontend route building functionality. Extracts ordered station lists from TfL API RouteSequence data and exposes them via new API endpoints.

Closes #29

## Changes

### Database
- **Migration**: `941d95fee6c2_add_routes_to_lines.py` - adds `routes` JSON column to `lines` table
- **Model**: Updated `Line` model with `routes: Mapped[dict[str, Any] | None]` field

### API Endpoints
- `GET /tfl/lines/{line_id}/routes` - returns route variants for a specific line
  - Uses TfL line ID (e.g., "victoria", "northern")
  - Returns ordered station sequences for each route variant
- `GET /tfl/stations/{station_tfl_id}/routes` - returns routes passing through a station
  - Uses TfL station ID (e.g., "940GZZLUVIC")
  - Shows which route variants serve the station

### Service Layer
- **Modified** `_fetch_route_sequence()` - now returns full RouteSequence object
- **Modified** `_process_route_sequence()` - returns tuple of (connections_count, route_data)
- **New** `_store_line_routes()` - extracts and stores route variants (Regular service only)
- **Updated** `build_station_graph()` - populates routes during graph build (zero additional API calls)
- **New** `get_line_routes(line_tfl_id)` - retrieves routes for a line
- **New** `get_station_routes(station_tfl_id)` - retrieves routes passing through a station

### Schemas
- `RouteVariant` - individual route variant (name, service_type, direction, stations)
- `LineRouteResponse` - response for line routes endpoint
- `StationRouteInfo` - route info for station
- `StationRouteResponse` - response for station routes endpoint

## Data Structure
Routes stored as JSON in `lines.routes` column:
```json
{
  "routes": [
    {
      "name": "Edgware → Morden via Bank",
      "service_type": "Regular",
      "direction": "inbound",
      "stations": ["940GZZLUEGW", "940GZZLUBKO", "940GZZLUMDN"]
    }
  ]
}
```

## Key Decisions
- ✅ Only "Regular" service types stored (Night services deferred for MVP)
- ✅ `service_type` attribute included for clarity and future extensibility
- ✅ TfL identifiers used for endpoints (not database UUIDs)
- ✅ Zero additional API calls (data extracted from existing RouteSequence fetches)

## Testing
- **Service Layer**: 20 tests covering all methods and edge cases
- **API Endpoints**: 13 tests covering success, error paths, and edge cases
- **Coverage**: 100% on new code
- **All tests passing**: ✅

## Quality Checks
- ✅ Migration applied successfully
- ✅ All pre-commit hooks passing (ruff, mypy, prettier, eslint, tsc)
- ✅ Type safety verified with mypy
- ✅ Code formatted and linted

## Example Usage

### Get routes for a line
```bash
GET /api/v1/tfl/lines/northern/routes
```

### Get routes for a station
```bash
GET /api/v1/tfl/stations/940GZZLUCTN/routes
```

## Breaking Changes
None - all changes are additive.

## Migration Required
Yes - run `alembic upgrade head` to add the `routes` column to the `lines` table.

## Dependencies
Depends on issue #28 being closed (completed).

## Summary by Sourcery

Enable frontend route-building by storing ordered station lists for each line route variant.
Add a JSON 'routes' field to the Line model and migration, extend the service layer to fetch, process, filter (Regular services only), and persist route sequences during graph construction, and add new service methods and API endpoints to retrieve route variants by line or station.

New Features:
- Add JSON 'routes' column to Line model and corresponding database migration to store ordered route sequences
- Introduce _store_line_routes service method to extract and persist Regular service route variants for each line
- Implement get_line_routes and get_station_routes service methods and expose them via new GET API endpoints

Enhancements:
- Extend _fetch_route_sequence and _process_route_sequence to return full RouteSequence objects
- Integrate route sequence storage into build_station_graph to collect and save variant data during graph building

Build:
- Add Alembic migration to add 'routes' JSON column to lines table

Tests:
- Add service-layer tests for _store_line_routes, get_line_routes, and get_station_routes covering success and error scenarios
- Add API-layer tests for new /tfl/lines/{line_id}/routes and /tfl/stations/{station_tfl_id}/routes endpoints