### PR TITLE
feat: Add hub NaPTAN code and common name fields to support cross-mode interchanges

### DIFF
--- a/backend/alembic/versions/90d1c387ce78_add_hub_naptan_and_common_name_to_.py
+++ b/backend/alembic/versions/90d1c387ce78_add_hub_naptan_and_common_name_to_.py
@@ -1,0 +1,58 @@
+"""add_hub_naptan_and_common_name_to_stations
+
+Revision ID: 90d1c387ce78
+Revises: e5dfdd8388bc
+Create Date: 2025-11-09 13:49:07.621945
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "90d1c387ce78"
+down_revision: str | Sequence[str] | None = "e5dfdd8388bc"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema: Add hub NaPTAN code fields to stations table.
+
+    Adds hub_naptan_code and hub_common_name fields to support cross-mode
+    interchange detection. These fields link stations at the same physical
+    location (e.g., Seven Sisters rail and tube stations).
+    """
+    op.add_column(
+        "stations",
+        sa.Column(
+            "hub_naptan_code",
+            sa.String(length=50),
+            nullable=True,
+            comment="TfL hub NaPTAN code for interchange stations",
+        ),
+    )
+    op.add_column(
+        "stations",
+        sa.Column(
+            "hub_common_name",
+            sa.String(length=255),
+            nullable=True,
+            comment="Common name for the hub (e.g., 'Seven Sisters')",
+        ),
+    )
+    op.create_index(
+        op.f("ix_stations_hub_naptan_code"),
+        "stations",
+        ["hub_naptan_code"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema: Remove hub NaPTAN code fields from stations table."""
+    op.drop_index(op.f("ix_stations_hub_naptan_code"), table_name="stations")
+    op.drop_column("stations", "hub_common_name")
+    op.drop_column("stations", "hub_naptan_code")

--- a/backend/app/models/tfl.py
+++ b/backend/app/models/tfl.py
@@ -98,6 +98,18 @@ class Station(BaseModel):
         DateTime(timezone=True),
         nullable=False,
     )
+    # Hub information for cross-mode interchanges
+    hub_naptan_code: Mapped[str | None] = mapped_column(
+        String(50),
+        nullable=True,
+        index=True,  # For fast hub lookups during validation
+        comment="TfL hub NaPTAN code for interchange stations",
+    )
+    hub_common_name: Mapped[str | None] = mapped_column(
+        String(255),
+        nullable=True,
+        comment="Common name for the hub (e.g., 'Seven Sisters')",
+    )
 
     # Relationships
     connections_from: Mapped[list["StationConnection"]] = relationship(

--- a/backend/app/schemas/tfl.py
+++ b/backend/app/schemas/tfl.py
@@ -50,6 +50,8 @@ class StationResponse(BaseModel):
     longitude: float
     lines: list[str]  # List of line TfL IDs (e.g., ["victoria", "northern"])
     last_updated: datetime
+    hub_naptan_code: str | None  # TfL hub NaPTAN code (e.g., 'HUBSVS' for Seven Sisters)
+    hub_common_name: str | None  # Hub common name (e.g., 'Seven Sisters')
 
 
 class DisruptionResponse(BaseModel):

--- a/backend/app/services/tfl_service.py
+++ b/backend/app/services/tfl_service.py
@@ -600,8 +600,16 @@ class TfLService:
                         if line_tfl_id not in station.lines:
                             station.lines = [*station.lines, line_tfl_id]
                         station.last_updated = datetime.now(UTC)
+                        # Update hub information if present (Place doesn't have hubNaptanCode, only StopPoint does)
+                        hub_code = getattr(stop_point, "hubNaptanCode", None)
+                        station.hub_naptan_code = hub_code
+                        if hub_code:
+                            # Use commonName as hub name when hub code exists
+                            station.hub_common_name = stop_point.commonName
                     else:
                         # Create new station
+                        # Place objects don't have hubNaptanCode, only StopPoint objects do
+                        hub_code = getattr(stop_point, "hubNaptanCode", None)
                         station = Station(
                             tfl_id=stop_point.id,
                             name=stop_point.commonName,
@@ -609,6 +617,8 @@ class TfLService:
                             longitude=stop_point.lon,
                             lines=[line_tfl_id],
                             last_updated=datetime.now(UTC),
+                            hub_naptan_code=hub_code,
+                            hub_common_name=stop_point.commonName if hub_code else None,
                         )
                         self.db.add(station)
 

--- a/docs/adr/03-database.md
+++ b/docs/adr/03-database.md
@@ -174,3 +174,79 @@ Backend validation enforces this rule. Frontend automatically sets the last segm
 - `test_validate_route_with_null_intermediate_line_id` - validates NULL on intermediate segment (invalid)
 - `test_upsert_segments_with_null_destination_line` - API integration test with NULL destination
 - All tests achieve 100% coverage on nullable line_tfl_id logic
+
+---
+
+## Hub NaPTAN Code for Cross-Mode Interchanges
+
+### Status
+Active (Implemented 2025-11-09)
+
+### Context
+Some TfL stations have multiple entries in the station list for different transport modes at the same physical location. For example, Seven Sisters has two station IDs:
+- `910GSEVNSIS` (London Overground - Weaver line)
+- `940GZZLUSVS` (London Underground - Victoria line)
+
+These represent the same physical interchange station. Users should be able to create routes that change between modes at these locations (e.g., Overground → Tube). TfL provides a `hubNaptanCode` field that links related stations together (e.g., both Seven Sisters stations have hub code `HUBSVS`).
+
+Without hub codes, route validation would reject valid cross-mode interchanges because the station IDs differ.
+
+### Decision
+Add two nullable fields to the `stations` table:
+- `hub_naptan_code` (String(50), indexed): TfL's hub identifier linking stations at the same physical location
+- `hub_common_name` (String(255)): User-friendly name for the hub (e.g., "Seven Sisters")
+
+Fields are nullable because not all stations are hubs - only major interchange stations with multiple modes have hub codes.
+
+An index on `hub_naptan_code` enables fast lookups during route validation to check if two different station IDs represent the same physical interchange.
+
+### Consequences
+**Easier:**
+- Route validation can recognize cross-mode interchanges at the same physical location
+- Users can create journeys that change between modes (e.g., Overground → Tube at Seven Sisters)
+- Hub common names improve user experience (display "Seven Sisters" instead of separate station names)
+- Nullable design is flexible (works for both hub and non-hub stations)
+- Index on hub_naptan_code enables fast validation lookups
+
+**More Difficult:**
+- Route validation logic must check both direct connections AND hub-based connections
+- Need to populate hub data from TfL API (Issue #51)
+- Slightly increased database size (two additional columns per station)
+- Must handle NULL values in validation and display logic
+
+### Implementation Details
+
+**Database Schema:**
+- Migration `90d1c387ce78` adds columns to `stations` table
+- `hub_naptan_code`: String(50), nullable, indexed
+- `hub_common_name`: String(255), nullable
+- Index: `ix_stations_hub_naptan_code` for fast lookups
+
+**Model:**
+- `Station.hub_naptan_code: Mapped[str | None]` (backend/app/models/tfl.py)
+- `Station.hub_common_name: Mapped[str | None]`
+
+**API Schema:**
+- `StationResponse.hub_naptan_code: str | None` (backend/app/schemas/tfl.py)
+- `StationResponse.hub_common_name: str | None`
+
+**Data Population:**
+- Fields will be populated in Issue #51 by fetching `hubNaptanCode` from TfL API
+- Until then, fields remain NULL (does not break existing functionality)
+
+**Route Validation:**
+- Updated in Issue #52 to allow interchanges when stations share the same hub code
+- Validation checks: direct connection OR same hub_naptan_code
+
+**Test Coverage:**
+- `test_create_station_with_hub_fields` - creates station with hub fields
+- `test_create_station_without_hub_fields` - verifies nullable fields work correctly
+- Comprehensive validation tests in Issue #53
+
+**Related Issues:**
+- Issue #50: Add fields (this ADR)
+- Issue #51: Fetch and populate hub data from TfL API
+- Issue #52: Update route validation to support hub interchanges
+- Issue #53: Comprehensive testing of hub interchange functionality
+- Issue #54: Frontend display of hub names
+- Issue #55: Documentation updates


### PR DESCRIPTION
closes #50

## Summary by Sourcery

Implement support for cross-mode interchanges by adding hub NaPTAN code and common name fields to stations, updating fetch logic to extract and persist this hub information, refactoring station-fetching into reusable helpers, and extending database schema, API models, documentation, and test coverage accordingly.

New Features:
- Add nullable hub_naptan_code and hub_common_name columns to the stations table (indexed) via an Alembic migration
- Include hub_naptan_code and hub_common_name in the Station ORM model and API response schema
- Extract and persist hub fields during station fetch to link related stations for cross-mode interchanges

Enhancements:
- Refactor fetch_stations into helper methods (_extract_hub_fields, _update_existing_station, _create_new_station, _fetch_stations_from_api)
- Simplify fetch_stations to delegate API fetch and database updates to the new helpers

Build:
- Add migration to add hub fields and create index on hub_naptan_code

Documentation:
- Update ADR to document hub NaPTAN code design and cross-mode interchange support

Tests:
- Add unit tests for hub field extraction, station creation/update with hub fields, and error handling in fetch methods
- Add model tests for persisting nullable hub fields
- Add integration and coverage tests for station-fetching and exception paths