### PR TITLE
feat: Add hub NaPTAN code support for route validation (#65)

### DIFF
--- a/backend/app/helpers/__init__.py
+++ b/backend/app/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Helper modules for pure functions and utilities."""

--- a/backend/app/helpers/station_resolution.py
+++ b/backend/app/helpers/station_resolution.py
@@ -1,0 +1,161 @@
+"""
+Station resolution helpers for hub NaPTAN code support.
+
+These pure functions enable testable, functional-style station resolution logic
+without requiring database access. They are used by TfLService.resolve_station_or_hub()
+and response serialization for canonical hub code representation.
+
+Issue #65: Support hub NaPTAN codes as station_tfl_id in route validation
+"""
+
+from __future__ import annotations
+
+from app.models.tfl import Station
+
+
+def filter_stations_by_line(stations: list[Station], line_tfl_id: str) -> list[Station]:
+    """
+    Filter stations that serve the specified line.
+
+    Pure function for filtering stations by line context. Used when resolving
+    hub codes with line_tfl_id context.
+
+    Args:
+        stations: List of Station objects to filter
+        line_tfl_id: TfL line ID to filter by (e.g., 'victoria', 'northern')
+
+    Returns:
+        List of stations that have line_tfl_id in their lines array
+
+    Examples:
+        >>> station1 = Station(tfl_id="ABC", lines=["victoria", "northern"])
+        >>> station2 = Station(tfl_id="DEF", lines=["piccadilly"])
+        >>> filter_stations_by_line([station1, station2], "victoria")
+        [station1]
+    """
+    return [s for s in stations if line_tfl_id in s.lines]
+
+
+def select_station_from_candidates(stations: list[Station]) -> Station:
+    """
+    Select a single station from multiple candidates.
+
+    When multiple stations match criteria (e.g., multiple stations in a hub serve
+    the same line), this function provides deterministic selection by choosing the
+    first station alphabetically by tfl_id.
+
+    Pure function - no side effects, deterministic output.
+
+    Args:
+        stations: Non-empty list of Station objects
+
+    Returns:
+        The first station when sorted alphabetically by tfl_id
+
+    Raises:
+        ValueError: If stations list is empty
+
+    Examples:
+        >>> s1 = Station(tfl_id="940GZZLUSVS", name="Seven Sisters Tube")
+        >>> s2 = Station(tfl_id="910GSEVNSIS", name="Seven Sisters Rail")
+        >>> select_station_from_candidates([s1, s2])
+        <Station(tfl_id='910GSEVNSIS', ...)>  # "910..." < "940..." alphabetically
+    """
+    if not stations:
+        msg = "Cannot select from empty station list"
+        raise ValueError(msg)
+
+    return sorted(stations, key=lambda s: s.tfl_id)[0]
+
+
+def should_canonicalize_to_hub(station: Station) -> bool:
+    """
+    Determine if a station should be represented by its hub code in API responses.
+
+    Pure function for canonicalization logic. Returns True if the station has a
+    hub_naptan_code, indicating it should be returned as the hub code rather than
+    the specific station tfl_id.
+
+    This implements the "normalize on read" pattern where hub-capable stations
+    are always returned with their canonical hub representation.
+
+    Args:
+        station: Station object to check
+
+    Returns:
+        True if station has hub_naptan_code (should use hub code)
+        False if station has no hub (should use station tfl_id)
+
+    Examples:
+        >>> station_with_hub = Station(tfl_id="940GZZLUSVS", hub_naptan_code="HUBSVS")
+        >>> should_canonicalize_to_hub(station_with_hub)
+        True
+
+        >>> standalone_station = Station(tfl_id="940GZZLUOXC", hub_naptan_code=None)
+        >>> should_canonicalize_to_hub(standalone_station)
+        False
+    """
+    return station.hub_naptan_code is not None
+
+
+def get_canonical_station_id(station: Station) -> str:
+    """
+    Get the canonical station ID for API responses.
+
+    Returns hub_naptan_code if available (canonical representation), otherwise
+    returns the station's tfl_id. This implements the "normalize on read" pattern.
+
+    Pure function - always returns the same output for the same input.
+
+    Args:
+        station: Station object
+
+    Returns:
+        Hub NaPTAN code if available, otherwise station tfl_id
+
+    Examples:
+        >>> station_with_hub = Station(
+        ...     tfl_id="940GZZLUSVS",
+        ...     hub_naptan_code="HUBSVS"
+        ... )
+        >>> get_canonical_station_id(station_with_hub)
+        'HUBSVS'
+
+        >>> standalone_station = Station(
+        ...     tfl_id="940GZZLUOXC",
+        ...     hub_naptan_code=None
+        ... )
+        >>> get_canonical_station_id(standalone_station)
+        '940GZZLUOXC'
+    """
+    return station.hub_naptan_code or station.tfl_id
+
+
+class StationResolutionError(Exception):
+    """Base exception for station resolution errors."""
+
+    pass
+
+
+class NoMatchingStationsError(StationResolutionError):
+    """Raised when no stations in hub serve the specified line."""
+
+    def __init__(self, hub_code: str, line_tfl_id: str, available_stations: list[str]) -> None:
+        self.hub_code = hub_code
+        self.line_tfl_id = line_tfl_id
+        self.available_stations = available_stations
+        super().__init__(
+            f"Hub '{hub_code}' found, but no station serves line '{line_tfl_id}'. "
+            f"Available stations: {', '.join(available_stations)}"
+        )
+
+
+class StationNotFoundError(StationResolutionError):
+    """Raised when station or hub code is not found."""
+
+    def __init__(self, tfl_id_or_hub: str) -> None:
+        self.tfl_id_or_hub = tfl_id_or_hub
+        super().__init__(
+            f"Station or hub with ID '{tfl_id_or_hub}' not found. "
+            "Please ensure TfL data is imported via /admin/tfl/build-graph endpoint."
+        )

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -3,7 +3,6 @@
 import enum
 import uuid
 from datetime import datetime
-from typing import TYPE_CHECKING
 
 from sqlalchemy import (
     CheckConstraint,
@@ -17,10 +16,8 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import BaseModel
-
-if TYPE_CHECKING:
-    from app.models.route import Route
-    from app.models.user import User
+from app.models.route import Route
+from app.models.user import User
 
 
 class NotificationMethod(str, enum.Enum):

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -3,6 +3,7 @@
 import enum
 import uuid
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from sqlalchemy import (
     CheckConstraint,
@@ -16,8 +17,10 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import BaseModel
-from app.models.route import Route
-from app.models.user import User
+
+if TYPE_CHECKING:  # Avoid circular imports -> route.py imports from app.helpers.station_resolution (line 22)
+    from app.models.route import Route
+    from app.models.user import User
 
 
 class NotificationMethod(str, enum.Enum):

--- a/backend/app/schemas/routes.py
+++ b/backend/app/schemas/routes.py
@@ -134,7 +134,13 @@ class SegmentRequest(BaseModel):
     """Single segment in a route (station + line + sequence)."""
 
     sequence: int = Field(..., ge=0, description="Order of this segment in the route (0-based)")
-    station_tfl_id: str = Field(..., description="TfL station ID (e.g., '940GZZLUOXC')")
+    station_tfl_id: str = Field(
+        ...,
+        description=(
+            "TfL station ID (e.g., '940GZZLUOXC') or hub NaPTAN code (e.g., 'HUBSVS'). "
+            "Hub codes are resolved to specific stations using line context (Issue #65)."
+        ),
+    )
     line_tfl_id: str | None = Field(
         None, description="TfL line ID (e.g., 'victoria', 'northern'). NULL for destination segment (no onward travel)."
     )

--- a/backend/app/services/tfl_service.py
+++ b/backend/app/services/tfl_service.py
@@ -19,6 +19,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from app.core.config import settings
+from app.helpers.station_resolution import (
+    NoMatchingStationsError,
+    StationNotFoundError,
+    filter_stations_by_line,
+    select_station_from_candidates,
+)
 from app.models.tfl import (
     DisruptionCategory,
     Line,
@@ -1660,6 +1666,123 @@ class TfLService:
 
         return station
 
+    async def resolve_station_or_hub(self, tfl_id_or_hub: str, line_tfl_id: str | None = None) -> Station:
+        """
+        Resolve station TfL ID or hub NaPTAN code to a Station.
+
+        This method supports both station TfL IDs (e.g., '940GZZLUSVS') and hub NaPTAN
+        codes (e.g., 'HUBSVS') for improved UX. When a hub code is provided with a
+        line context, it selects the station in that hub that serves the specified line.
+
+        Resolution logic (using pure helper functions from app.helpers.station_resolution):
+        1. Try lookup by tfl_id first (backward compatibility)
+        2. If not found, try lookup by hub_naptan_code
+        3. If hub found and line_tfl_id provided, filter stations that serve that line
+        4. If hub found and line_tfl_id is None (destination segment), return first station
+
+        Args:
+            tfl_id_or_hub: Either a station TfL ID or a hub NaPTAN code
+            line_tfl_id: Optional line TfL ID for line-context resolution
+
+        Returns:
+            Station object from database
+
+        Raises:
+            HTTPException(404): If station/hub not found or no station serves line
+
+        Examples:
+            # Station ID (backward compatible)
+            >>> await resolve_station_or_hub("940GZZLUSVS", "victoria")
+            <Station(tfl_id='940GZZLUSVS', name='Seven Sisters Underground')>
+
+            # Hub code with line context
+            >>> await resolve_station_or_hub("HUBSVS", "victoria")
+            <Station(tfl_id='940GZZLUSVS', name='Seven Sisters Underground')>
+
+            # Hub code as destination (no line)
+            >>> await resolve_station_or_hub("HUBSVS", None)
+            <Station(tfl_id='910GSEVNSIS', ...)>  # Returns any station in hub
+        """
+        # Step 1: Try direct station lookup first (backward compatibility)
+        result = await self.db.execute(select(Station).where(Station.tfl_id == tfl_id_or_hub))
+        station = result.scalar_one_or_none()
+
+        if station is not None:
+            logger.debug(
+                "station_resolved_by_tfl_id",
+                tfl_id=tfl_id_or_hub,
+                station_name=station.name,
+                line_tfl_id=line_tfl_id,
+            )
+            return station
+
+        # Step 2: Try hub code lookup
+        result = await self.db.execute(select(Station).where(Station.hub_naptan_code == tfl_id_or_hub))
+        hub_stations = list(result.scalars().all())
+
+        if not hub_stations:
+            logger.warning(
+                "station_or_hub_not_found",
+                tfl_id_or_hub=tfl_id_or_hub,
+                line_tfl_id=line_tfl_id,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=str(StationNotFoundError(tfl_id_or_hub)),
+            )
+
+        # Step 3: Filter by line context if provided (using pure helper function)
+        if line_tfl_id is not None:
+            matching_stations = filter_stations_by_line(hub_stations, line_tfl_id)
+
+            if not matching_stations:
+                logger.warning(
+                    "hub_no_station_serves_line",
+                    hub_code=tfl_id_or_hub,
+                    line_tfl_id=line_tfl_id,
+                    hub_stations=[s.tfl_id for s in hub_stations],
+                )
+                error = NoMatchingStationsError(
+                    tfl_id_or_hub,
+                    line_tfl_id,
+                    [s.tfl_id for s in hub_stations],
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=str(error),
+                )
+
+            # Use pure function to select station (deterministic)
+            if len(matching_stations) > 1:
+                logger.info(
+                    "hub_multiple_stations_serve_line",
+                    hub_code=tfl_id_or_hub,
+                    line_tfl_id=line_tfl_id,
+                    matching_stations=[s.tfl_id for s in matching_stations],
+                )
+
+            resolved_station = select_station_from_candidates(matching_stations)
+
+            logger.info(
+                "hub_resolved_with_line_context",
+                hub_code=tfl_id_or_hub,
+                line_tfl_id=line_tfl_id,
+                resolved_tfl_id=resolved_station.tfl_id,
+                resolved_name=resolved_station.name,
+            )
+            return resolved_station
+
+        # Step 4: No line context (destination segment) - use pure helper function
+        resolved_station = select_station_from_candidates(hub_stations)
+        logger.info(
+            "hub_resolved_without_line_context",
+            hub_code=tfl_id_or_hub,
+            resolved_tfl_id=resolved_station.tfl_id,
+            resolved_name=resolved_station.name,
+            hub_stations=[s.tfl_id for s in hub_stations],
+        )
+        return resolved_station
+
     async def get_line_by_tfl_id(self, tfl_id: str) -> Line:
         """
         Get line from database by TfL ID.
@@ -1799,15 +1922,19 @@ class TfLService:
             Tuple of (stations_map, lines_map, hub_map)
         """
         # Bulk fetch all stations and lines to avoid redundant lookups
-        unique_station_ids = {seg.station_tfl_id for seg in segments}
         # Filter out None values from line_tfl_ids (destination segments have no line)
         unique_line_ids = {seg.line_tfl_id for seg in segments if seg.line_tfl_id is not None}
 
-        # Fetch all stations
+        # Fetch all stations - use resolve_station_or_hub to support both station IDs and hub codes
+        # We need to pair station IDs with their line contexts from the segments
+        station_line_pairs = [(seg.station_tfl_id, seg.line_tfl_id) for seg in segments]
+
         stations_map = {}
-        for tfl_id in unique_station_ids:
-            station = await self.get_station_by_tfl_id(tfl_id)
-            stations_map[tfl_id] = station
+        for tfl_id_or_hub, line_context in station_line_pairs:
+            if tfl_id_or_hub not in stations_map:
+                # resolve_station_or_hub supports both station TfL IDs and hub codes
+                station = await self.resolve_station_or_hub(tfl_id_or_hub, line_context)
+                stations_map[tfl_id_or_hub] = station
 
         # Fetch all lines
         lines_map = {}

--- a/backend/tests/test_routes_api.py
+++ b/backend/tests/test_routes_api.py
@@ -1644,3 +1644,383 @@ class TestRoutesAPI:
         data = response.json()
         assert data["start_time"] == "09:00:00"
         assert data["days_of_week"] == ["MON", "TUE"]  # Unchanged
+
+
+# ==================== Hub NaPTAN Code Integration Tests (Issue #65) ====================
+
+
+@pytest.mark.asyncio
+class TestRouteSegmentsWithHubCodes:
+    """Integration tests for creating routes with hub NaPTAN codes (Issue #65)."""
+
+    @pytest.fixture(autouse=True)
+    async def setup_test(self, db_session: AsyncSession) -> AsyncGenerator[None]:
+        """Set up test database dependency override."""
+
+        async def override_get_db() -> AsyncGenerator[AsyncSession]:
+            yield db_session
+
+        app.dependency_overrides[get_db] = override_get_db
+        yield
+        app.dependency_overrides.clear()
+
+    @pytest.fixture
+    async def hub_test_data(self, db_session: AsyncSession) -> dict[str, Station | Line]:
+        """Create simple hub test data with clear conceptual model.
+
+        Hub "HUBTEST" has two stations:
+        - line1-hub-station (serves line1)
+        - line2-hub-station (serves line2)
+
+        Routes:
+        - Line1: line1-start → line1-hub-station → line1-end
+        - Line2: line2-start → line2-hub-station → line2-end
+        """
+        # Hub stations (same physical location, different modes/lines)
+        line1_hub_station = Station(
+            tfl_id="line1-hub-station",
+            name="Test Hub Line 1 Station",
+            latitude=51.5,
+            longitude=-0.1,
+            lines=["line1"],
+            hub_naptan_code="HUBTEST",
+            hub_common_name="Test Hub",
+            last_updated=datetime.now(UTC),
+        )
+        line2_hub_station = Station(
+            tfl_id="line2-hub-station",
+            name="Test Hub Line 2 Station",
+            latitude=51.5,
+            longitude=-0.1,
+            lines=["line2"],
+            hub_naptan_code="HUBTEST",
+            hub_common_name="Test Hub",
+            last_updated=datetime.now(UTC),
+        )
+
+        # Other stations on line1
+        line1_start = Station(
+            tfl_id="line1-start",
+            name="Line 1 Start",
+            latitude=51.4,
+            longitude=-0.1,
+            lines=["line1"],
+            last_updated=datetime.now(UTC),
+        )
+        line1_end = Station(
+            tfl_id="line1-end",
+            name="Line 1 End",
+            latitude=51.6,
+            longitude=-0.1,
+            lines=["line1"],
+            last_updated=datetime.now(UTC),
+        )
+
+        # Other stations on line2
+        line2_start = Station(
+            tfl_id="line2-start",
+            name="Line 2 Start",
+            latitude=51.5,
+            longitude=-0.2,
+            lines=["line2"],
+            last_updated=datetime.now(UTC),
+        )
+        line2_end = Station(
+            tfl_id="line2-end",
+            name="Line 2 End",
+            latitude=51.5,
+            longitude=0.0,
+            lines=["line2"],
+            last_updated=datetime.now(UTC),
+        )
+
+        # Lines with route sequences
+        line1 = Line(
+            tfl_id="line1",
+            name="Line 1",
+            color="#FF0000",
+            mode="tube",
+            last_updated=datetime.now(UTC),
+            routes={
+                "routes": [
+                    {
+                        "name": "Line 1 Route",
+                        "stations": ["line1-start", "line1-hub-station", "line1-end"],
+                    }
+                ]
+            },
+        )
+        line2 = Line(
+            tfl_id="line2",
+            name="Line 2",
+            color="#0000FF",
+            mode="overground",
+            last_updated=datetime.now(UTC),
+            routes={
+                "routes": [
+                    {
+                        "name": "Line 2 Route",
+                        "stations": ["line2-start", "line2-hub-station", "line2-end"],
+                    }
+                ]
+            },
+        )
+
+        db_session.add_all(
+            [
+                line1_hub_station,
+                line2_hub_station,
+                line1_start,
+                line1_end,
+                line2_start,
+                line2_end,
+                line1,
+                line2,
+            ]
+        )
+        await db_session.commit()
+
+        return {
+            "line1_hub_station": line1_hub_station,
+            "line2_hub_station": line2_hub_station,
+            "line1_start": line1_start,
+            "line1_end": line1_end,
+            "line2_start": line2_start,
+            "line2_end": line2_end,
+            "line1": line1,
+            "line2": line2,
+        }
+
+    async def test_create_route_with_hub_codes(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_user: User,
+        db_session: AsyncSession,
+        hub_test_data: dict[str, Station | Line],
+    ) -> None:
+        """Test creating route segments using hub NaPTAN codes instead of station IDs.
+
+        Route: line1-start → HUBTEST (via line1) → line2-end
+        - Start on line1
+        - Use hub code "HUBTEST" to specify interchange (resolves to line2-hub-station with line2 context)
+        - Destination on line2
+        """
+        # Create route
+        route = Route(user_id=test_user.id, name="Cross-Mode Hub Route", active=True)
+        db_session.add(route)
+        await db_session.commit()
+
+        # Upsert segments using hub code "HUBTEST" instead of specific station ID
+        segments_data = {
+            "segments": [
+                {"sequence": 0, "station_tfl_id": "line1-start", "line_tfl_id": "line1"},
+                {"sequence": 1, "station_tfl_id": "HUBTEST", "line_tfl_id": "line2"},  # Hub code!
+                {"sequence": 2, "station_tfl_id": "line2-end", "line_tfl_id": None},
+            ]
+        }
+
+        response = await async_client.put(
+            f"/api/v1/routes/{route.id}/segments",
+            json=segments_data,
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+
+        # Response should canonicalize to hub code (normalize on read)
+        assert len(data) == 3
+        assert data[1]["station_tfl_id"] == "HUBTEST"  # Canonical representation
+        assert data[1]["line_tfl_id"] == "line2"
+
+    async def test_create_route_with_mixed_hub_and_station_ids(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_user: User,
+        db_session: AsyncSession,
+        hub_test_data: dict[str, Station | Line],
+    ) -> None:
+        """Test creating route with mix of hub codes and regular station IDs."""
+        route = Route(user_id=test_user.id, name="Mixed Route", active=True)
+        db_session.add(route)
+        await db_session.commit()
+
+        segments_data = {
+            "segments": [
+                {"sequence": 0, "station_tfl_id": "HUBTEST", "line_tfl_id": "line1"},  # Hub code
+                {"sequence": 1, "station_tfl_id": "line1-end", "line_tfl_id": None},  # Station ID
+            ]
+        }
+
+        response = await async_client.put(
+            f"/api/v1/routes/{route.id}/segments",
+            json=segments_data,
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data[0]["station_tfl_id"] == "HUBTEST"  # Has hub, returns hub code
+        assert data[1]["station_tfl_id"] == "line1-end"  # No hub, returns station ID
+
+    async def test_create_route_hub_code_invalid_line(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_user: User,
+        db_session: AsyncSession,
+        hub_test_data: dict[str, Station | Line],
+    ) -> None:
+        """Test error when hub code used with line that doesn't serve it."""
+        # Create a line3 that doesn't serve the hub
+        line3 = Line(
+            tfl_id="line3",
+            name="Line 3",
+            color="#00FF00",
+            mode="dlr",
+            last_updated=datetime.now(UTC),
+            routes={"routes": [{"name": "Line 3 Route", "stations": ["other-station"]}]},
+        )
+        other_station = Station(
+            tfl_id="other-station",
+            name="Other Station",
+            latitude=51.6,
+            longitude=0.1,
+            lines=["line3"],
+            last_updated=datetime.now(UTC),
+        )
+        db_session.add_all([line3, other_station])
+        await db_session.commit()
+
+        route = Route(user_id=test_user.id, name="Invalid Route", active=True)
+        db_session.add(route)
+        await db_session.commit()
+
+        segments_data = {
+            "segments": [
+                {"sequence": 0, "station_tfl_id": "HUBTEST", "line_tfl_id": "line3"},  # Hub doesn't serve line3
+                {"sequence": 1, "station_tfl_id": "other-station", "line_tfl_id": None},
+            ]
+        }
+
+        response = await async_client.put(
+            f"/api/v1/routes/{route.id}/segments",
+            json=segments_data,
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert "HUBTEST" in response.json()["detail"]
+        assert "line3" in response.json()["detail"]
+
+    async def test_update_segment_with_hub_code(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_user: User,
+        db_session: AsyncSession,
+        hub_test_data: dict[str, Station | Line],
+    ) -> None:
+        """Test updating an existing segment to use a hub code."""
+        route = Route(user_id=test_user.id, name="Update Test Route", active=True)
+        db_session.add(route)
+        await db_session.commit()
+
+        # Create initial segments: line1-start → line1-hub-station → line1-end (all on line1)
+        segments_data = {
+            "segments": [
+                {"sequence": 0, "station_tfl_id": "line1-start", "line_tfl_id": "line1"},
+                {"sequence": 1, "station_tfl_id": "line1-end", "line_tfl_id": None},
+            ]
+        }
+        await async_client.put(
+            f"/api/v1/routes/{route.id}/segments",
+            json=segments_data,
+            headers=auth_headers_for_user,
+        )
+
+        # Update first segment to use hub code (changes the station at the start)
+        update_data = {"station_tfl_id": "HUBTEST"}  # Keep line1, just change station to hub
+
+        response = await async_client.patch(
+            f"/api/v1/routes/{route.id}/segments/0",
+            json=update_data,
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data["station_tfl_id"] == "HUBTEST"  # Returns hub code
+        assert data["line_tfl_id"] == "line1"
+
+    async def test_get_route_returns_canonical_hub_codes(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_user: User,
+        db_session: AsyncSession,
+        hub_test_data: dict[str, Station | Line],
+    ) -> None:
+        """Test GET route returns hub codes (canonicalize on read)."""
+        route = Route(user_id=test_user.id, name="Canonical Test Route", active=True)
+        db_session.add(route)
+        await db_session.commit()
+
+        # Create segments using station ID (line2-hub-station)
+        segments_data = {
+            "segments": [
+                {"sequence": 0, "station_tfl_id": "line2-hub-station", "line_tfl_id": "line2"},  # Station ID with hub
+                {"sequence": 1, "station_tfl_id": "line2-end", "line_tfl_id": None},
+            ]
+        }
+        await async_client.put(
+            f"/api/v1/routes/{route.id}/segments",
+            json=segments_data,
+            headers=auth_headers_for_user,
+        )
+
+        # GET route - should return hub code not station ID
+        response = await async_client.get(
+            f"/api/v1/routes/{route.id}",
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data["segments"]) == 2
+        assert data["segments"][0]["station_tfl_id"] == "HUBTEST"  # Canonicalized to hub code
+
+    async def test_backward_compatibility_station_ids_still_work(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_user: User,
+        db_session: AsyncSession,
+        hub_test_data: dict[str, Station | Line],
+    ) -> None:
+        """Test that existing routes using station IDs continue to work."""
+        route = Route(user_id=test_user.id, name="Backward Compat Route", active=True)
+        db_session.add(route)
+        await db_session.commit()
+
+        # Use station IDs directly (no hub codes)
+        segments_data = {
+            "segments": [
+                {"sequence": 0, "station_tfl_id": "line1-start", "line_tfl_id": "line1"},
+                {"sequence": 1, "station_tfl_id": "line1-end", "line_tfl_id": None},
+            ]
+        }
+
+        response = await async_client.put(
+            f"/api/v1/routes/{route.id}/segments",
+            json=segments_data,
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        # No hubs involved, should return station IDs
+        assert data[0]["station_tfl_id"] == "line1-start"
+        assert data[1]["station_tfl_id"] == "line1-end"

--- a/backend/tests/test_station_resolution_helpers.py
+++ b/backend/tests/test_station_resolution_helpers.py
@@ -1,0 +1,280 @@
+"""
+Unit tests for station resolution helper functions.
+
+These are pure functions, so tests are simple and don't require database access.
+"""
+
+import pytest
+from app.helpers.station_resolution import (
+    NoMatchingStationsError,
+    StationNotFoundError,
+    StationResolutionError,
+    filter_stations_by_line,
+    get_canonical_station_id,
+    select_station_from_candidates,
+    should_canonicalize_to_hub,
+)
+from app.models.tfl import Station
+
+
+class TestFilterStationsByLine:
+    """Tests for filter_stations_by_line() pure function."""
+
+    def test_filter_stations_by_line_single_match(self):
+        """Should return only stations that serve the specified line."""
+        station1 = Station(
+            tfl_id="ABC",
+            name="Station A",
+            latitude=0.0,
+            longitude=0.0,
+            lines=["victoria", "northern"],
+        )
+        station2 = Station(
+            tfl_id="DEF",
+            name="Station B",
+            latitude=0.0,
+            longitude=0.0,
+            lines=["piccadilly"],
+        )
+        station3 = Station(
+            tfl_id="GHI",
+            name="Station C",
+            latitude=0.0,
+            longitude=0.0,
+            lines=["victoria", "circle"],
+        )
+
+        result = filter_stations_by_line([station1, station2, station3], "victoria")
+
+        assert len(result) == 2
+        assert station1 in result
+        assert station3 in result
+        assert station2 not in result
+
+    def test_filter_stations_by_line_no_matches(self):
+        """Should return empty list when no stations serve the line."""
+        station1 = Station(
+            tfl_id="ABC",
+            name="Station A",
+            latitude=0.0,
+            longitude=0.0,
+            lines=["northern"],
+        )
+        station2 = Station(
+            tfl_id="DEF",
+            name="Station B",
+            latitude=0.0,
+            longitude=0.0,
+            lines=["piccadilly"],
+        )
+
+        result = filter_stations_by_line([station1, station2], "victoria")
+
+        assert result == []
+
+    def test_filter_stations_by_line_all_match(self):
+        """Should return all stations if they all serve the line."""
+        station1 = Station(
+            tfl_id="ABC",
+            name="Station A",
+            latitude=0.0,
+            longitude=0.0,
+            lines=["victoria"],
+        )
+        station2 = Station(
+            tfl_id="DEF",
+            name="Station B",
+            latitude=0.0,
+            longitude=0.0,
+            lines=["victoria", "northern"],
+        )
+
+        result = filter_stations_by_line([station1, station2], "victoria")
+
+        assert len(result) == 2
+        assert station1 in result
+        assert station2 in result
+
+    def test_filter_stations_by_line_empty_input(self):
+        """Should return empty list for empty input."""
+        result = filter_stations_by_line([], "victoria")
+        assert result == []
+
+
+class TestSelectStationFromCandidates:
+    """Tests for select_station_from_candidates() pure function."""
+
+    def test_select_station_from_candidates_single(self):
+        """Should return the only station when given one candidate."""
+        station = Station(
+            tfl_id="ABC",
+            name="Station A",
+            latitude=0.0,
+            longitude=0.0,
+            lines=["victoria"],
+        )
+
+        result = select_station_from_candidates([station])
+
+        assert result == station
+
+    def test_select_station_from_candidates_multiple_alphabetical(self):
+        """Should return first station alphabetically by tfl_id."""
+        station1 = Station(
+            tfl_id="940GZZLUSVS",  # Tube station (940...)
+            name="Seven Sisters Tube",
+            latitude=0.0,
+            longitude=0.0,
+            lines=["victoria"],
+        )
+        station2 = Station(
+            tfl_id="910GSEVNSIS",  # Rail station (910...)
+            name="Seven Sisters Rail",
+            latitude=0.0,
+            longitude=0.0,
+            lines=["overground"],
+        )
+
+        result = select_station_from_candidates([station1, station2])
+
+        # "910..." < "940..." alphabetically
+        assert result == station2
+
+    def test_select_station_from_candidates_deterministic(self):
+        """Should always return the same result for the same input (deterministic)."""
+        stations = [
+            Station(tfl_id="C", name="C", latitude=0.0, longitude=0.0, lines=[]),
+            Station(tfl_id="A", name="A", latitude=0.0, longitude=0.0, lines=[]),
+            Station(tfl_id="B", name="B", latitude=0.0, longitude=0.0, lines=[]),
+        ]
+
+        result1 = select_station_from_candidates(stations)
+        result2 = select_station_from_candidates(stations)
+        result3 = select_station_from_candidates(stations)
+
+        assert result1 == result2 == result3
+        assert result1.tfl_id == "A"  # First alphabetically
+
+    def test_select_station_from_candidates_empty_raises_error(self):
+        """Should raise ValueError for empty list."""
+        with pytest.raises(ValueError, match="Cannot select from empty station list"):
+            select_station_from_candidates([])
+
+
+class TestShouldCanonicalizeToHub:
+    """Tests for should_canonicalize_to_hub() pure function."""
+
+    def test_should_canonicalize_to_hub_with_hub_code(self):
+        """Should return True when station has hub_naptan_code."""
+        station = Station(
+            tfl_id="940GZZLUSVS",
+            name="Seven Sisters",
+            latitude=0.0,
+            longitude=0.0,
+            lines=["victoria"],
+            hub_naptan_code="HUBSVS",
+        )
+
+        assert should_canonicalize_to_hub(station) is True
+
+    def test_should_canonicalize_to_hub_without_hub_code(self):
+        """Should return False when station has no hub_naptan_code."""
+        station = Station(
+            tfl_id="940GZZLUOXC",
+            name="Oxford Circus",
+            latitude=0.0,
+            longitude=0.0,
+            lines=["victoria", "central"],
+            hub_naptan_code=None,
+        )
+
+        assert should_canonicalize_to_hub(station) is False
+
+
+class TestGetCanonicalStationId:
+    """Tests for get_canonical_station_id() pure function."""
+
+    def test_get_canonical_station_id_with_hub_code(self):
+        """Should return hub code when available."""
+        station = Station(
+            tfl_id="940GZZLUSVS",
+            name="Seven Sisters",
+            latitude=0.0,
+            longitude=0.0,
+            lines=["victoria"],
+            hub_naptan_code="HUBSVS",
+        )
+
+        result = get_canonical_station_id(station)
+
+        assert result == "HUBSVS"
+
+    def test_get_canonical_station_id_without_hub_code(self):
+        """Should return tfl_id when no hub code."""
+        station = Station(
+            tfl_id="940GZZLUOXC",
+            name="Oxford Circus",
+            latitude=0.0,
+            longitude=0.0,
+            lines=["victoria", "central"],
+            hub_naptan_code=None,
+        )
+
+        result = get_canonical_station_id(station)
+
+        assert result == "940GZZLUOXC"
+
+    def test_get_canonical_station_id_deterministic(self):
+        """Should always return the same result (pure function)."""
+        station = Station(
+            tfl_id="940GZZLUSVS",
+            name="Seven Sisters",
+            latitude=0.0,
+            longitude=0.0,
+            lines=["victoria"],
+            hub_naptan_code="HUBSVS",
+        )
+
+        result1 = get_canonical_station_id(station)
+        result2 = get_canonical_station_id(station)
+
+        assert result1 == result2 == "HUBSVS"
+
+
+class TestStationResolutionExceptions:
+    """Tests for custom exception classes."""
+
+    def test_station_not_found_error(self):
+        """Should create StationNotFoundError with correct message."""
+        error = StationNotFoundError("HUBXYZ")
+
+        assert "HUBXYZ" in str(error)
+        assert "not found" in str(error)
+        assert error.tfl_id_or_hub == "HUBXYZ"
+
+    def test_no_matching_stations_error(self):
+        """Should create NoMatchingStationsError with correct message."""
+        error = NoMatchingStationsError("HUBSVS", "victoria", ["910GSEVNSIS", "940GZZLUSVS"])
+
+        assert "HUBSVS" in str(error)
+        assert "victoria" in str(error)
+        assert "910GSEVNSIS" in str(error)
+        assert "940GZZLUSVS" in str(error)
+        assert error.hub_code == "HUBSVS"
+        assert error.line_tfl_id == "victoria"
+        assert error.available_stations == ["910GSEVNSIS", "940GZZLUSVS"]
+
+    def test_station_resolution_error_base_class(self):
+        """Should be able to catch all resolution errors with base class."""
+        hub_code = "HUBSVS"
+        line_id = "victoria"
+        station_id = "ABC"
+        try:
+            raise NoMatchingStationsError(hub_code, line_id, [])
+        except StationResolutionError:
+            pass  # Should catch
+
+        try:
+            raise StationNotFoundError(station_id)
+        except StationResolutionError:
+            pass  # Should catch


### PR DESCRIPTION
Enable users to specify hub codes (e.g., 'HUBSVS') as station_tfl_id in route
  segments instead of requiring specific station IDs. Implements "normalize on
  write, canonicalize on read" pattern: accepts both formats, resolves hub codes
  to stations using line context, stores UUIDs internally, returns canonical hub
  codes in API responses.

  Key changes:
  - Add pure helper functions for station resolution (100% test coverage)
  - Implement TfLService.resolve_station_or_hub() with line-context resolution
  - Update RouteService to use hub resolution for segment operations
  - Add response canonicalization to return hub codes when available
  - Fix circular import between route and notification models
  - Add comprehensive tests (33 new tests, all passing)
  - Update ADR 07-external-apis.md with architectural decision

  Backward compatible - existing routes using station IDs continue to work.

closes #65

## Summary by Sourcery

Enable support for hub NaPTAN codes in route validation by accepting hub codes on write, resolving them to specific stations based on line context, and returning canonical hub identifiers on read while maintaining backward compatibility with existing station IDs.

New Features:
- Allow specifying hub NaPTAN codes as station identifiers in route segment requests
- Automatically resolve hub codes to the correct station using line context
- Return hub NaPTAN codes as the canonical station ID in API responses

Bug Fixes:
- Fix circular import between route and notification models

Enhancements:
- Add pure helper functions for station resolution and canonicalization
- Integrate resolve_station_or_hub into TflService and RouteService for segment creation and updates
- Extend route schemas and models to accept hub NaPTAN codes alongside station IDs
- Implement "normalize on write, canonicalize on read" pattern for hub code support

Documentation:
- Update ADR 07-external-apis.md with hub NaPTAN code support

Tests:
- Add unit tests for station resolution helper functions
- Add integration tests for route segment operations with hub codes
- Add tests for TflService.resolve_station_or_hub method