### PR TITLE
feat: Implement deduplication of stations by hub in TfLService

### DIFF
--- a/backend/app/helpers/station_resolution.py
+++ b/backend/app/helpers/station_resolution.py
@@ -6,9 +6,12 @@ without requiring database access. They are used by TfLService.resolve_station_o
 and response serialization for canonical hub code representation.
 
 Issue #65: Support hub NaPTAN codes as station_tfl_id in route validation
+Issue #67: Deduplication helpers for hub-grouped station responses
 """
 
 from __future__ import annotations
+
+from datetime import datetime
 
 from app.models.tfl import Station
 
@@ -159,3 +162,196 @@ class StationNotFoundError(StationResolutionError):
             f"Station or hub with ID '{tfl_id_or_hub}' not found. "
             "Please ensure TfL data is imported via /admin/tfl/build-graph endpoint."
         )
+
+
+# Deduplication helpers (Issue #67)
+
+
+def group_stations_by_hub(
+    stations: list[Station],
+) -> tuple[dict[str, list[Station]], list[Station]]:
+    """
+    Group stations into hub groups and standalone stations.
+
+    Pure function that partitions a list of stations into:
+    1. Hub groups: dict mapping hub_naptan_code to list of stations in that hub
+    2. Standalone stations: list of stations without hub_naptan_code
+
+    Used for deduplicating stations by hub in API responses.
+
+    Args:
+        stations: List of Station objects to group
+
+    Returns:
+        Tuple of (hub_groups, standalone_stations) where:
+        - hub_groups: dict[hub_code, list[Station]] for all hub stations
+        - standalone_stations: list[Station] for all non-hub stations
+
+    Examples:
+        >>> hub_station1 = Station(tfl_id="940GZZLUSVS", hub_naptan_code="HUBSVS")
+        >>> hub_station2 = Station(tfl_id="910GSEVNSIS", hub_naptan_code="HUBSVS")
+        >>> standalone = Station(tfl_id="940GZZLUOXC", hub_naptan_code=None)
+        >>> hubs, standalone_list = group_stations_by_hub([hub_station1, hub_station2, standalone])
+        >>> hubs["HUBSVS"]
+        [hub_station1, hub_station2]
+        >>> standalone_list
+        [standalone]
+    """
+    hub_groups: dict[str, list[Station]] = {}
+    standalone_stations: list[Station] = []
+
+    for station in stations:
+        if should_canonicalize_to_hub(station):
+            hub_code = station.hub_naptan_code
+            assert hub_code is not None  # Type narrowing - already checked by should_canonicalize_to_hub
+            if hub_code not in hub_groups:
+                hub_groups[hub_code] = []
+            hub_groups[hub_code].append(station)
+        else:
+            standalone_stations.append(station)
+
+    return hub_groups, standalone_stations
+
+
+def aggregate_station_lines(stations: list[Station]) -> list[str]:
+    """
+    Aggregate unique lines from multiple stations.
+
+    Pure function that collects all unique line IDs from a list of stations
+    and returns them as a sorted list. Used when creating a hub representative
+    station that aggregates lines from all child stations.
+
+    Args:
+        stations: List of Station objects to aggregate lines from
+
+    Returns:
+        Sorted list of unique line IDs from all stations
+
+    Examples:
+        >>> station1 = Station(tfl_id="ABC", lines=["victoria", "northern"])
+        >>> station2 = Station(tfl_id="DEF", lines=["victoria", "piccadilly"])
+        >>> aggregate_station_lines([station1, station2])
+        ['northern', 'piccadilly', 'victoria']
+    """
+    all_lines = set()
+    for station in stations:
+        all_lines.update(station.lines)
+    return sorted(all_lines)
+
+
+def get_latest_update_time(stations: list[Station]) -> datetime:
+    """
+    Get the most recent update timestamp from a list of stations.
+
+    Pure function that finds the maximum last_updated timestamp among
+    a list of stations. Used when creating a hub representative station.
+
+    Args:
+        stations: Non-empty list of Station objects
+
+    Returns:
+        The most recent last_updated datetime from all stations
+
+    Raises:
+        ValueError: If stations list is empty
+
+    Examples:
+        >>> from datetime import datetime
+        >>> station1 = Station(tfl_id="ABC", last_updated=datetime(2025, 1, 1))
+        >>> station2 = Station(tfl_id="DEF", last_updated=datetime(2025, 1, 15))
+        >>> get_latest_update_time([station1, station2])
+        datetime(2025, 1, 15, 0, 0)
+    """
+    if not stations:
+        msg = "Cannot get latest update time from empty station list"
+        raise ValueError(msg)
+
+    return max(station.last_updated for station in stations)
+
+
+def create_hub_representative(hub_children: list[Station], preferred_child: Station | None = None) -> Station:
+    """
+    Create a representative station from hub child stations.
+
+    Pure function that aggregates data from multiple stations in a hub
+    into a single canonical representative station. Uses the preferred child
+    (if provided) or first child as a template and aggregates data from all children.
+
+    The representative station has:
+    - id: from preferred_child (if provided) or first child
+    - tfl_id: hub_naptan_code (canonical ID)
+    - name: hub_common_name (or first child's name as fallback)
+    - lines: aggregated from all children (sorted, deduplicated)
+    - last_updated: most recent timestamp from all children
+    - latitude/longitude: from preferred_child or first child (same location for all hub children)
+
+    Args:
+        hub_children: Non-empty list of Station objects sharing the same hub
+        preferred_child: Optional Station to use as template (e.g., station serving queried line).
+                        Must be in hub_children list. If None, uses first child.
+
+    Returns:
+        A new Station object representing the entire hub
+
+    Raises:
+        ValueError: If hub_children is empty or preferred_child not in hub_children
+
+    Examples:
+        >>> rail = Station(
+        ...     id=uuid4(),
+        ...     tfl_id="910GSEVNSIS",
+        ...     name="Seven Sisters (Rail)",
+        ...     hub_naptan_code="HUBSVS",
+        ...     hub_common_name="Seven Sisters",
+        ...     lines=["overground"],
+        ...     last_updated=datetime(2025, 1, 1),
+        ...     latitude=51.58,
+        ...     longitude=-0.07,
+        ... )
+        >>> tube = Station(
+        ...     id=uuid4(),
+        ...     tfl_id="940GZZLUSVS",
+        ...     name="Seven Sisters",
+        ...     hub_naptan_code="HUBSVS",
+        ...     hub_common_name="Seven Sisters",
+        ...     lines=["victoria"],
+        ...     last_updated=datetime(2025, 1, 15),
+        ...     latitude=51.58,
+        ...     longitude=-0.07,
+        ... )
+        >>> representative = create_hub_representative([rail, tube])
+        >>> representative.tfl_id
+        'HUBSVS'
+        >>> representative.name
+        'Seven Sisters'
+        >>> representative.lines
+        ['overground', 'victoria']
+    """
+    if not hub_children:
+        msg = "Cannot create hub representative from empty list"
+        raise ValueError(msg)
+
+    # Validate preferred_child if provided
+    if preferred_child is not None and preferred_child not in hub_children:
+        msg = f"preferred_child {preferred_child.tfl_id} not found in hub_children"
+        raise ValueError(msg)
+
+    # Use preferred child as template, or first child if no preference
+    representative = preferred_child if preferred_child is not None else hub_children[0]
+
+    # Aggregate data from all children
+    aggregated_lines = aggregate_station_lines(hub_children)
+    latest_update = get_latest_update_time(hub_children)
+
+    # Create new Station with aggregated data
+    return Station(
+        id=representative.id,
+        tfl_id=get_canonical_station_id(representative),  # Use hub code as canonical ID
+        name=representative.hub_common_name or representative.name,  # Prefer hub common name
+        latitude=representative.latitude,
+        longitude=representative.longitude,
+        lines=aggregated_lines,
+        last_updated=latest_update,
+        hub_naptan_code=representative.hub_naptan_code,
+        hub_common_name=representative.hub_common_name,
+    )

--- a/backend/app/services/tfl_service.py
+++ b/backend/app/services/tfl_service.py
@@ -832,12 +832,9 @@ class TfLService:
         for hub_children in hub_groups.values():
             # If line filter provided, prefer child serving that line for UUID/coords
             preferred_child = None
-            if line_filter:
-                # Find child station that serves the filtered line
-                matching = [child for child in hub_children if line_filter in child.lines]
-                if matching:
-                    # Use first matching child (deterministic - sorted by tfl_id in helper)
-                    preferred_child = matching[0]
+            # Find child stations that serve the filtered line and sort for deterministic selection
+            if line_filter and (matching := [child for child in hub_children if line_filter in child.lines]):
+                preferred_child = sorted(matching, key=lambda s: s.tfl_id)[0]
 
             hub_representative = create_hub_representative(hub_children, preferred_child)
             result.append(hub_representative)

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -27,6 +27,9 @@ from app.core.database import get_db
 from app.core.utils import convert_async_db_url_to_sync
 from app.main import app
 from app.models.admin import AdminRole, AdminUser
+
+# Import for type hints in test factories
+from app.models.tfl import Station
 from app.models.user import User
 from app.services.alert_service import AlertService
 from fastapi.testclient import TestClient
@@ -517,3 +520,170 @@ def settings_fixture() -> Settings:
         Settings instance
     """
     return settings
+
+
+# Test data factories and shared test railway network
+
+
+# Shared test railway network for consistent testing across all test files
+# This fictional network makes tests easier to understand without needing to know real TfL data
+
+
+class TestRailwayNetwork:
+    """
+    Shared test railway network with consistent stations, hubs, and lines.
+
+    This provides a small, controlled test dataset that's reused across all deduplication
+    and station resolution tests, making it easier to understand test behavior without
+    needing knowledge of real TfL stations like Seven Sisters or King's Cross.
+
+    Network structure:
+    - 2 test lines: "line1" and "line2"
+    - 1 hub (HUB_ALPHA) with 2 child stations (Tube + Rail)
+    - 1 hub (HUB_BETA) with 2 child stations (different modes)
+    - 2 standalone stations (no hub)
+    """
+
+    # Line IDs
+    LINE_1 = "line1"
+    LINE_2 = "line2"
+    LINE_3 = "line3"
+
+    # Hub Alpha: Two-mode interchange (Tube + Rail)
+    HUB_ALPHA_CODE = "HUB_ALPHA"
+    HUB_ALPHA_NAME = "Alpha Junction"
+    HUB_ALPHA_TUBE_ID = "TUBE_ALPHA"
+    HUB_ALPHA_TUBE_NAME = "Alpha Junction (Tube)"
+    HUB_ALPHA_RAIL_ID = "RAIL_ALPHA"
+    HUB_ALPHA_RAIL_NAME = "Alpha Junction (Rail)"
+
+    # Hub Beta: Another two-mode interchange
+    HUB_BETA_CODE = "HUB_BETA"
+    HUB_BETA_NAME = "Beta Station"
+    HUB_BETA_CHILD1_ID = "BETA_CHILD_1"
+    HUB_BETA_CHILD1_NAME = "Beta Station Platform A"
+    HUB_BETA_CHILD2_ID = "BETA_CHILD_2"
+    HUB_BETA_CHILD2_NAME = "Beta Station Platform B"
+
+    # Standalone stations
+    STANDALONE_CHARLIE_ID = "STATION_CHARLIE"
+    STANDALONE_CHARLIE_NAME = "Charlie Station"
+    STANDALONE_DELTA_ID = "STATION_DELTA"
+    STANDALONE_DELTA_NAME = "Delta Station"
+
+    @staticmethod
+    def create_hub_alpha_tube() -> Station:
+        """Create Hub Alpha's Tube child station serving line1."""
+        return create_test_station(
+            TestRailwayNetwork.HUB_ALPHA_TUBE_ID,
+            TestRailwayNetwork.HUB_ALPHA_TUBE_NAME,
+            [TestRailwayNetwork.LINE_1],
+            hub_naptan_code=TestRailwayNetwork.HUB_ALPHA_CODE,
+            hub_common_name=TestRailwayNetwork.HUB_ALPHA_NAME,
+        )
+
+    @staticmethod
+    def create_hub_alpha_rail() -> Station:
+        """Create Hub Alpha's Rail child station serving line2."""
+        return create_test_station(
+            TestRailwayNetwork.HUB_ALPHA_RAIL_ID,
+            TestRailwayNetwork.HUB_ALPHA_RAIL_NAME,
+            [TestRailwayNetwork.LINE_2],
+            hub_naptan_code=TestRailwayNetwork.HUB_ALPHA_CODE,
+            hub_common_name=TestRailwayNetwork.HUB_ALPHA_NAME,
+        )
+
+    @staticmethod
+    def create_hub_beta_child1() -> Station:
+        """Create Hub Beta's first child station serving line1."""
+        return create_test_station(
+            TestRailwayNetwork.HUB_BETA_CHILD1_ID,
+            TestRailwayNetwork.HUB_BETA_CHILD1_NAME,
+            [TestRailwayNetwork.LINE_1],
+            hub_naptan_code=TestRailwayNetwork.HUB_BETA_CODE,
+            hub_common_name=TestRailwayNetwork.HUB_BETA_NAME,
+        )
+
+    @staticmethod
+    def create_hub_beta_child2() -> Station:
+        """Create Hub Beta's second child station serving line2."""
+        return create_test_station(
+            TestRailwayNetwork.HUB_BETA_CHILD2_ID,
+            TestRailwayNetwork.HUB_BETA_CHILD2_NAME,
+            [TestRailwayNetwork.LINE_2],
+            hub_naptan_code=TestRailwayNetwork.HUB_BETA_CODE,
+            hub_common_name=TestRailwayNetwork.HUB_BETA_NAME,
+        )
+
+    @staticmethod
+    def create_standalone_charlie() -> Station:
+        """Create standalone Charlie station serving line1."""
+        return create_test_station(
+            TestRailwayNetwork.STANDALONE_CHARLIE_ID,
+            TestRailwayNetwork.STANDALONE_CHARLIE_NAME,
+            [TestRailwayNetwork.LINE_1],
+        )
+
+    @staticmethod
+    def create_standalone_delta() -> Station:
+        """Create standalone Delta station serving line2."""
+        return create_test_station(
+            TestRailwayNetwork.STANDALONE_DELTA_ID,
+            TestRailwayNetwork.STANDALONE_DELTA_NAME,
+            [TestRailwayNetwork.LINE_2],
+        )
+
+
+def create_test_station(
+    tfl_id: str,
+    name: str,
+    lines: list[str],
+    latitude: float = 51.5,
+    longitude: float = -0.1,
+    last_updated: datetime | None = None,
+    hub_naptan_code: str | None = None,
+    hub_common_name: str | None = None,
+) -> Station:
+    """
+    Factory for creating Station model instances for testing.
+
+    Provides sensible defaults while allowing customization of key fields.
+    Uses abstract test data by default to avoid coupling tests to real TfL data.
+
+    Args:
+        tfl_id: Station TfL ID (e.g., "STATION_A", "910GTEST1")
+        name: Station name (e.g., "Test Station Alpha")
+        lines: List of line IDs serving this station (e.g., ["line1", "line2"])
+        latitude: Latitude coordinate (defaults to 51.5)
+        longitude: Longitude coordinate (defaults to -0.1)
+        last_updated: Last update timestamp (defaults to 2025-01-01)
+        hub_naptan_code: Hub NaPTAN code if part of a hub (e.g., "HUB1")
+        hub_common_name: Hub common name if part of a hub (e.g., "Test Hub Alpha")
+
+    Returns:
+        Station model instance ready for testing
+
+    Examples:
+        >>> # Standalone station
+        >>> station = create_test_station("STATION_A", "Alpha Station", ["line1"])
+
+        >>> # Hub station
+        >>> hub_station = create_test_station(
+        ...     "STATION_B",
+        ...     "Beta Station",
+        ...     ["line2"],
+        ...     hub_naptan_code="HUB1",
+        ...     hub_common_name="Test Hub"
+        ... )
+    """
+    return Station(
+        id=uuid.uuid4(),
+        tfl_id=tfl_id,
+        name=name,
+        latitude=latitude,
+        longitude=longitude,
+        lines=lines,
+        last_updated=last_updated or datetime(2025, 1, 1, tzinfo=UTC),
+        hub_naptan_code=hub_naptan_code,
+        hub_common_name=hub_common_name,
+    )

--- a/backend/tests/test_station_resolution_helpers.py
+++ b/backend/tests/test_station_resolution_helpers.py
@@ -21,7 +21,6 @@ from app.helpers.station_resolution import (
     select_station_from_candidates,
     should_canonicalize_to_hub,
 )
-from app.models.tfl import Station
 
 from tests.conftest import create_test_station
 
@@ -93,9 +92,9 @@ class TestSelectStationFromCandidates:
     def test_select_station_from_candidates_deterministic(self):
         """Should always return the same result for the same input (deterministic)."""
         stations = [
-            Station(tfl_id="C", name="C", latitude=0.0, longitude=0.0, lines=[]),
-            Station(tfl_id="A", name="A", latitude=0.0, longitude=0.0, lines=[]),
-            Station(tfl_id="B", name="B", latitude=0.0, longitude=0.0, lines=[]),
+            create_test_station("C", "C", []),
+            create_test_station("A", "A", []),
+            create_test_station("B", "B", []),
         ]
 
         result1 = select_station_from_candidates(stations)
@@ -257,15 +256,9 @@ class TestGroupStationsByHub:
 
     def test_group_stations_by_hub_multiple_hubs(self):
         """Should correctly group stations into multiple separate hubs."""
-        hub1_station1 = Station(
-            tfl_id="A1", name="Hub1 A", latitude=0.0, longitude=0.0, lines=["line1"], hub_naptan_code="HUB1"
-        )
-        hub1_station2 = Station(
-            tfl_id="A2", name="Hub1 B", latitude=0.0, longitude=0.0, lines=["line2"], hub_naptan_code="HUB1"
-        )
-        hub2_station1 = Station(
-            tfl_id="B1", name="Hub2 A", latitude=0.0, longitude=0.0, lines=["line3"], hub_naptan_code="HUB2"
-        )
+        hub1_station1 = create_test_station("A1", "Hub1 A", ["line1"], hub_naptan_code="HUB1")
+        hub1_station2 = create_test_station("A2", "Hub1 B", ["line2"], hub_naptan_code="HUB1")
+        hub2_station1 = create_test_station("B1", "Hub2 A", ["line3"], hub_naptan_code="HUB2")
 
         hub_groups, standalone_stations = group_stations_by_hub([hub1_station1, hub1_station2, hub2_station1])
 
@@ -289,8 +282,8 @@ class TestAggregateStationLines:
 
     def test_aggregate_station_lines_multiple_stations(self):
         """Should aggregate and deduplicate lines from multiple stations."""
-        station1 = Station(tfl_id="A", name="Station A", latitude=0.0, longitude=0.0, lines=["line1", "line2"])
-        station2 = Station(tfl_id="B", name="Station B", latitude=0.0, longitude=0.0, lines=["line1", "line3"])
+        station1 = create_test_station("A", "Station A", ["line1", "line2"])
+        station2 = create_test_station("B", "Station B", ["line1", "line3"])
 
         result = aggregate_station_lines([station1, station2])
 
@@ -298,8 +291,8 @@ class TestAggregateStationLines:
 
     def test_aggregate_station_lines_no_duplicates(self):
         """Should return sorted unique lines when no duplicates exist."""
-        station1 = Station(tfl_id="A", name="Station A", latitude=0.0, longitude=0.0, lines=["line2"])
-        station2 = Station(tfl_id="B", name="Station B", latitude=0.0, longitude=0.0, lines=["line3"])
+        station1 = create_test_station("A", "Station A", ["line2"])
+        station2 = create_test_station("B", "Station B", ["line3"])
 
         result = aggregate_station_lines([station1, station2])
 
@@ -307,8 +300,8 @@ class TestAggregateStationLines:
 
     def test_aggregate_station_lines_all_same(self):
         """Should deduplicate when all stations serve same lines."""
-        station1 = Station(tfl_id="A", name="Station A", latitude=0.0, longitude=0.0, lines=["line1"])
-        station2 = Station(tfl_id="B", name="Station B", latitude=0.0, longitude=0.0, lines=["line1"])
+        station1 = create_test_station("A", "Station A", ["line1"])
+        station2 = create_test_station("B", "Station B", ["line1"])
 
         result = aggregate_station_lines([station1, station2])
 
@@ -316,7 +309,7 @@ class TestAggregateStationLines:
 
     def test_aggregate_station_lines_single_station(self):
         """Should return station's lines when only one station provided."""
-        station = Station(tfl_id="A", name="Station A", latitude=0.0, longitude=0.0, lines=["line1", "line2"])
+        station = create_test_station("A", "Station A", ["line1", "line2"])
 
         result = aggregate_station_lines([station])
 
@@ -361,12 +354,8 @@ class TestGetLatestUpdateTime:
     def test_get_latest_update_time_all_same(self):
         """Should handle all stations having same timestamp."""
         timestamp = datetime(2025, 1, 1, tzinfo=UTC)
-        station1 = Station(
-            tfl_id="A", name="Station A", latitude=0.0, longitude=0.0, lines=["line1"], last_updated=timestamp
-        )
-        station2 = Station(
-            tfl_id="B", name="Station B", latitude=0.0, longitude=0.0, lines=["line2"], last_updated=timestamp
-        )
+        station1 = create_test_station("A", "Station A", ["line1"], last_updated=timestamp)
+        station2 = create_test_station("B", "Station B", ["line2"], last_updated=timestamp)
 
         result = get_latest_update_time([station1, station2])
 

--- a/backend/tests/test_station_resolution_helpers.py
+++ b/backend/tests/test_station_resolution_helpers.py
@@ -2,19 +2,28 @@
 Unit tests for station resolution helper functions.
 
 These are pure functions, so tests are simple and don't require database access.
+Uses abstract test data via create_test_station() factory for clarity and maintainability.
 """
+
+from datetime import UTC, datetime
 
 import pytest
 from app.helpers.station_resolution import (
     NoMatchingStationsError,
     StationNotFoundError,
     StationResolutionError,
+    aggregate_station_lines,
+    create_hub_representative,
     filter_stations_by_line,
     get_canonical_station_id,
+    get_latest_update_time,
+    group_stations_by_hub,
     select_station_from_candidates,
     should_canonicalize_to_hub,
 )
 from app.models.tfl import Station
+
+from tests.conftest import create_test_station
 
 
 class TestFilterStationsByLine:
@@ -22,29 +31,11 @@ class TestFilterStationsByLine:
 
     def test_filter_stations_by_line_single_match(self):
         """Should return only stations that serve the specified line."""
-        station1 = Station(
-            tfl_id="ABC",
-            name="Station A",
-            latitude=0.0,
-            longitude=0.0,
-            lines=["victoria", "northern"],
-        )
-        station2 = Station(
-            tfl_id="DEF",
-            name="Station B",
-            latitude=0.0,
-            longitude=0.0,
-            lines=["piccadilly"],
-        )
-        station3 = Station(
-            tfl_id="GHI",
-            name="Station C",
-            latitude=0.0,
-            longitude=0.0,
-            lines=["victoria", "circle"],
-        )
+        station1 = create_test_station("STATION_A", "Alpha Station", ["line1", "line2"])
+        station2 = create_test_station("STATION_B", "Beta Station", ["line3"])
+        station3 = create_test_station("STATION_C", "Charlie Station", ["line1", "line4"])
 
-        result = filter_stations_by_line([station1, station2, station3], "victoria")
+        result = filter_stations_by_line([station1, station2, station3], "line1")
 
         assert len(result) == 2
         assert station1 in result
@@ -53,43 +44,19 @@ class TestFilterStationsByLine:
 
     def test_filter_stations_by_line_no_matches(self):
         """Should return empty list when no stations serve the line."""
-        station1 = Station(
-            tfl_id="ABC",
-            name="Station A",
-            latitude=0.0,
-            longitude=0.0,
-            lines=["northern"],
-        )
-        station2 = Station(
-            tfl_id="DEF",
-            name="Station B",
-            latitude=0.0,
-            longitude=0.0,
-            lines=["piccadilly"],
-        )
+        station1 = create_test_station("STATION_A", "Alpha Station", ["line2"])
+        station2 = create_test_station("STATION_B", "Beta Station", ["line3"])
 
-        result = filter_stations_by_line([station1, station2], "victoria")
+        result = filter_stations_by_line([station1, station2], "line1")
 
         assert result == []
 
     def test_filter_stations_by_line_all_match(self):
         """Should return all stations if they all serve the line."""
-        station1 = Station(
-            tfl_id="ABC",
-            name="Station A",
-            latitude=0.0,
-            longitude=0.0,
-            lines=["victoria"],
-        )
-        station2 = Station(
-            tfl_id="DEF",
-            name="Station B",
-            latitude=0.0,
-            longitude=0.0,
-            lines=["victoria", "northern"],
-        )
+        station1 = create_test_station("STATION_A", "Alpha Station", ["line1"])
+        station2 = create_test_station("STATION_B", "Beta Station", ["line1", "line2"])
 
-        result = filter_stations_by_line([station1, station2], "victoria")
+        result = filter_stations_by_line([station1, station2], "line1")
 
         assert len(result) == 2
         assert station1 in result
@@ -97,7 +64,7 @@ class TestFilterStationsByLine:
 
     def test_filter_stations_by_line_empty_input(self):
         """Should return empty list for empty input."""
-        result = filter_stations_by_line([], "victoria")
+        result = filter_stations_by_line([], "line1")
         assert result == []
 
 
@@ -106,13 +73,7 @@ class TestSelectStationFromCandidates:
 
     def test_select_station_from_candidates_single(self):
         """Should return the only station when given one candidate."""
-        station = Station(
-            tfl_id="ABC",
-            name="Station A",
-            latitude=0.0,
-            longitude=0.0,
-            lines=["victoria"],
-        )
+        station = create_test_station("STATION_A", "Alpha Station", ["line1"])
 
         result = select_station_from_candidates([station])
 
@@ -120,24 +81,13 @@ class TestSelectStationFromCandidates:
 
     def test_select_station_from_candidates_multiple_alphabetical(self):
         """Should return first station alphabetically by tfl_id."""
-        station1 = Station(
-            tfl_id="940GZZLUSVS",  # Tube station (940...)
-            name="Seven Sisters Tube",
-            latitude=0.0,
-            longitude=0.0,
-            lines=["victoria"],
-        )
-        station2 = Station(
-            tfl_id="910GSEVNSIS",  # Rail station (910...)
-            name="Seven Sisters Rail",
-            latitude=0.0,
-            longitude=0.0,
-            lines=["overground"],
-        )
+        # Use IDs where alphabetical order is clear: B < C
+        station1 = create_test_station("STATION_C", "Charlie Station", ["line1"])
+        station2 = create_test_station("STATION_B", "Beta Station", ["line2"])
 
         result = select_station_from_candidates([station1, station2])
 
-        # "910..." < "940..." alphabetically
+        # "STATION_B" < "STATION_C" alphabetically
         assert result == station2
 
     def test_select_station_from_candidates_deterministic(self):
@@ -166,27 +116,15 @@ class TestShouldCanonicalizeToHub:
 
     def test_should_canonicalize_to_hub_with_hub_code(self):
         """Should return True when station has hub_naptan_code."""
-        station = Station(
-            tfl_id="940GZZLUSVS",
-            name="Seven Sisters",
-            latitude=0.0,
-            longitude=0.0,
-            lines=["victoria"],
-            hub_naptan_code="HUBSVS",
+        station = create_test_station(
+            "STATION_A", "Alpha Station", ["line1"], hub_naptan_code="HUB1", hub_common_name="Hub Alpha"
         )
 
         assert should_canonicalize_to_hub(station) is True
 
     def test_should_canonicalize_to_hub_without_hub_code(self):
         """Should return False when station has no hub_naptan_code."""
-        station = Station(
-            tfl_id="940GZZLUOXC",
-            name="Oxford Circus",
-            latitude=0.0,
-            longitude=0.0,
-            lines=["victoria", "central"],
-            hub_naptan_code=None,
-        )
+        station = create_test_station("STATION_B", "Beta Station", ["line1", "line2"])
 
         assert should_canonicalize_to_hub(station) is False
 
@@ -196,49 +134,32 @@ class TestGetCanonicalStationId:
 
     def test_get_canonical_station_id_with_hub_code(self):
         """Should return hub code when available."""
-        station = Station(
-            tfl_id="940GZZLUSVS",
-            name="Seven Sisters",
-            latitude=0.0,
-            longitude=0.0,
-            lines=["victoria"],
-            hub_naptan_code="HUBSVS",
+        station = create_test_station(
+            "STATION_A", "Alpha Station", ["line1"], hub_naptan_code="HUB1", hub_common_name="Hub Alpha"
         )
 
         result = get_canonical_station_id(station)
 
-        assert result == "HUBSVS"
+        assert result == "HUB1"
 
     def test_get_canonical_station_id_without_hub_code(self):
         """Should return tfl_id when no hub code."""
-        station = Station(
-            tfl_id="940GZZLUOXC",
-            name="Oxford Circus",
-            latitude=0.0,
-            longitude=0.0,
-            lines=["victoria", "central"],
-            hub_naptan_code=None,
-        )
+        station = create_test_station("STATION_B", "Beta Station", ["line1", "line2"])
 
         result = get_canonical_station_id(station)
 
-        assert result == "940GZZLUOXC"
+        assert result == "STATION_B"
 
     def test_get_canonical_station_id_deterministic(self):
         """Should always return the same result (pure function)."""
-        station = Station(
-            tfl_id="940GZZLUSVS",
-            name="Seven Sisters",
-            latitude=0.0,
-            longitude=0.0,
-            lines=["victoria"],
-            hub_naptan_code="HUBSVS",
+        station = create_test_station(
+            "STATION_A", "Alpha Station", ["line1"], hub_naptan_code="HUB1", hub_common_name="Hub Alpha"
         )
 
         result1 = get_canonical_station_id(station)
         result2 = get_canonical_station_id(station)
 
-        assert result1 == result2 == "HUBSVS"
+        assert result1 == result2 == "HUB1"
 
 
 class TestStationResolutionExceptions:
@@ -246,29 +167,29 @@ class TestStationResolutionExceptions:
 
     def test_station_not_found_error(self):
         """Should create StationNotFoundError with correct message."""
-        error = StationNotFoundError("HUBXYZ")
+        error = StationNotFoundError("STATION_XYZ")
 
-        assert "HUBXYZ" in str(error)
+        assert "STATION_XYZ" in str(error)
         assert "not found" in str(error)
-        assert error.tfl_id_or_hub == "HUBXYZ"
+        assert error.tfl_id_or_hub == "STATION_XYZ"
 
     def test_no_matching_stations_error(self):
         """Should create NoMatchingStationsError with correct message."""
-        error = NoMatchingStationsError("HUBSVS", "victoria", ["910GSEVNSIS", "940GZZLUSVS"])
+        error = NoMatchingStationsError("HUB1", "line1", ["STATION_A", "STATION_B"])
 
-        assert "HUBSVS" in str(error)
-        assert "victoria" in str(error)
-        assert "910GSEVNSIS" in str(error)
-        assert "940GZZLUSVS" in str(error)
-        assert error.hub_code == "HUBSVS"
-        assert error.line_tfl_id == "victoria"
-        assert error.available_stations == ["910GSEVNSIS", "940GZZLUSVS"]
+        assert "HUB1" in str(error)
+        assert "line1" in str(error)
+        assert "STATION_A" in str(error)
+        assert "STATION_B" in str(error)
+        assert error.hub_code == "HUB1"
+        assert error.line_tfl_id == "line1"
+        assert error.available_stations == ["STATION_A", "STATION_B"]
 
     def test_station_resolution_error_base_class(self):
         """Should be able to catch all resolution errors with base class."""
-        hub_code = "HUBSVS"
-        line_id = "victoria"
-        station_id = "ABC"
+        hub_code = "HUB1"
+        line_id = "line1"
+        station_id = "STATION_A"
         try:
             raise NoMatchingStationsError(hub_code, line_id, [])
         except StationResolutionError:
@@ -278,3 +199,311 @@ class TestStationResolutionExceptions:
             raise StationNotFoundError(station_id)
         except StationResolutionError:
             pass  # Should catch
+
+
+# Tests for deduplication helpers (Issue #67)
+
+
+class TestGroupStationsByHub:
+    """Tests for group_stations_by_hub() pure function."""
+
+    def test_group_stations_by_hub_with_mixed_stations(self):
+        """Should correctly partition hub and standalone stations."""
+        hub_station1 = create_test_station(
+            "HUB1_CHILD_A", "Hub 1 Alpha", ["line1"], hub_naptan_code="HUB1", hub_common_name="Hub Alpha"
+        )
+        hub_station2 = create_test_station(
+            "HUB1_CHILD_B", "Hub 1 Beta", ["line2"], hub_naptan_code="HUB1", hub_common_name="Hub Alpha"
+        )
+        standalone = create_test_station("STATION_C", "Charlie Station", ["line3"])
+
+        hub_groups, standalone_stations = group_stations_by_hub([hub_station1, hub_station2, standalone])
+
+        assert len(hub_groups) == 1
+        assert "HUB1" in hub_groups
+        assert len(hub_groups["HUB1"]) == 2
+        assert hub_station1 in hub_groups["HUB1"]
+        assert hub_station2 in hub_groups["HUB1"]
+        assert len(standalone_stations) == 1
+        assert standalone in standalone_stations
+
+    def test_group_stations_by_hub_all_standalone(self):
+        """Should return empty hub_groups when all stations are standalone."""
+        station1 = create_test_station("STATION_A", "Alpha Station", ["line1"])
+        station2 = create_test_station("STATION_B", "Beta Station", ["line2"])
+
+        hub_groups, standalone_stations = group_stations_by_hub([station1, station2])
+
+        assert hub_groups == {}
+        assert len(standalone_stations) == 2
+        assert station1 in standalone_stations
+        assert station2 in standalone_stations
+
+    def test_group_stations_by_hub_all_hub_stations(self):
+        """Should return empty standalone_stations when all stations are in hubs."""
+        hub_station1 = create_test_station(
+            "HUB1_CHILD_A", "Hub 1 Alpha", ["line1"], hub_naptan_code="HUB1", hub_common_name="Hub Alpha"
+        )
+        hub_station2 = create_test_station(
+            "HUB1_CHILD_B", "Hub 1 Beta", ["line2"], hub_naptan_code="HUB1", hub_common_name="Hub Alpha"
+        )
+
+        hub_groups, standalone_stations = group_stations_by_hub([hub_station1, hub_station2])
+
+        assert len(hub_groups) == 1
+        assert "HUB1" in hub_groups
+        assert len(hub_groups["HUB1"]) == 2
+        assert standalone_stations == []
+
+    def test_group_stations_by_hub_multiple_hubs(self):
+        """Should correctly group stations into multiple separate hubs."""
+        hub1_station1 = Station(
+            tfl_id="A1", name="Hub1 A", latitude=0.0, longitude=0.0, lines=["line1"], hub_naptan_code="HUB1"
+        )
+        hub1_station2 = Station(
+            tfl_id="A2", name="Hub1 B", latitude=0.0, longitude=0.0, lines=["line2"], hub_naptan_code="HUB1"
+        )
+        hub2_station1 = Station(
+            tfl_id="B1", name="Hub2 A", latitude=0.0, longitude=0.0, lines=["line3"], hub_naptan_code="HUB2"
+        )
+
+        hub_groups, standalone_stations = group_stations_by_hub([hub1_station1, hub1_station2, hub2_station1])
+
+        assert len(hub_groups) == 2
+        assert "HUB1" in hub_groups
+        assert "HUB2" in hub_groups
+        assert len(hub_groups["HUB1"]) == 2
+        assert len(hub_groups["HUB2"]) == 1
+        assert standalone_stations == []
+
+    def test_group_stations_by_hub_empty_list(self):
+        """Should return empty groups and stations for empty input."""
+        hub_groups, standalone_stations = group_stations_by_hub([])
+
+        assert hub_groups == {}
+        assert standalone_stations == []
+
+
+class TestAggregateStationLines:
+    """Tests for aggregate_station_lines() pure function."""
+
+    def test_aggregate_station_lines_multiple_stations(self):
+        """Should aggregate and deduplicate lines from multiple stations."""
+        station1 = Station(tfl_id="A", name="Station A", latitude=0.0, longitude=0.0, lines=["line1", "line2"])
+        station2 = Station(tfl_id="B", name="Station B", latitude=0.0, longitude=0.0, lines=["line1", "line3"])
+
+        result = aggregate_station_lines([station1, station2])
+
+        assert result == ["line1", "line2", "line3"]  # Sorted and deduplicated
+
+    def test_aggregate_station_lines_no_duplicates(self):
+        """Should return sorted unique lines when no duplicates exist."""
+        station1 = Station(tfl_id="A", name="Station A", latitude=0.0, longitude=0.0, lines=["line2"])
+        station2 = Station(tfl_id="B", name="Station B", latitude=0.0, longitude=0.0, lines=["line3"])
+
+        result = aggregate_station_lines([station1, station2])
+
+        assert result == ["line2", "line3"]
+
+    def test_aggregate_station_lines_all_same(self):
+        """Should deduplicate when all stations serve same lines."""
+        station1 = Station(tfl_id="A", name="Station A", latitude=0.0, longitude=0.0, lines=["line1"])
+        station2 = Station(tfl_id="B", name="Station B", latitude=0.0, longitude=0.0, lines=["line1"])
+
+        result = aggregate_station_lines([station1, station2])
+
+        assert result == ["line1"]
+
+    def test_aggregate_station_lines_single_station(self):
+        """Should return station's lines when only one station provided."""
+        station = Station(tfl_id="A", name="Station A", latitude=0.0, longitude=0.0, lines=["line1", "line2"])
+
+        result = aggregate_station_lines([station])
+
+        assert result == ["line1", "line2"]  # Sorted
+
+    def test_aggregate_station_lines_empty_list(self):
+        """Should return empty list for empty input."""
+        result = aggregate_station_lines([])
+
+        assert result == []
+
+
+class TestGetLatestUpdateTime:
+    """Tests for get_latest_update_time() pure function."""
+
+    def test_get_latest_update_time_multiple_stations(self):
+        """Should return most recent timestamp from all stations."""
+        station1 = create_test_station(
+            "STATION_A", "Alpha Station", ["line1"], last_updated=datetime(2025, 1, 1, tzinfo=UTC)
+        )
+        station2 = create_test_station(
+            "STATION_B", "Beta Station", ["line2"], last_updated=datetime(2025, 1, 15, tzinfo=UTC)
+        )
+        station3 = create_test_station(
+            "STATION_C", "Charlie Station", ["line3"], last_updated=datetime(2025, 1, 10, tzinfo=UTC)
+        )
+
+        result = get_latest_update_time([station1, station2, station3])
+
+        assert result == datetime(2025, 1, 15, tzinfo=UTC)
+
+    def test_get_latest_update_time_single_station(self):
+        """Should return timestamp when only one station provided."""
+        station = create_test_station(
+            "STATION_A", "Alpha Station", ["line1"], last_updated=datetime(2025, 1, 1, tzinfo=UTC)
+        )
+
+        result = get_latest_update_time([station])
+
+        assert result == datetime(2025, 1, 1, tzinfo=UTC)
+
+    def test_get_latest_update_time_all_same(self):
+        """Should handle all stations having same timestamp."""
+        timestamp = datetime(2025, 1, 1, tzinfo=UTC)
+        station1 = Station(
+            tfl_id="A", name="Station A", latitude=0.0, longitude=0.0, lines=["line1"], last_updated=timestamp
+        )
+        station2 = Station(
+            tfl_id="B", name="Station B", latitude=0.0, longitude=0.0, lines=["line2"], last_updated=timestamp
+        )
+
+        result = get_latest_update_time([station1, station2])
+
+        assert result == timestamp
+
+    def test_get_latest_update_time_empty_list(self):
+        """Should raise ValueError for empty list."""
+        with pytest.raises(ValueError, match="Cannot get latest update time from empty station list"):
+            get_latest_update_time([])
+
+
+class TestCreateHubRepresentative:
+    """Tests for create_hub_representative() pure function."""
+
+    def test_create_hub_representative_basic(self):
+        """Should create representative with aggregated data from hub children."""
+        child1 = create_test_station(
+            "HUB1_CHILD_A",
+            "Hub 1 Alpha",
+            ["line2"],
+            last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+            hub_naptan_code="HUB1",
+            hub_common_name="Hub Alpha",
+        )
+        child2 = create_test_station(
+            "HUB1_CHILD_B",
+            "Hub 1 Beta",
+            ["line1"],
+            last_updated=datetime(2025, 1, 15, tzinfo=UTC),
+            hub_naptan_code="HUB1",
+            hub_common_name="Hub Alpha",
+        )
+
+        representative = create_hub_representative([child1, child2])
+
+        assert representative.tfl_id == "HUB1"  # Uses hub code
+        assert representative.name == "Hub Alpha"  # Uses hub_common_name
+        assert representative.lines == ["line1", "line2"]  # Aggregated and sorted
+        assert representative.last_updated == datetime(2025, 1, 15, tzinfo=UTC)  # Most recent
+        assert representative.hub_naptan_code == "HUB1"
+        assert representative.hub_common_name == "Hub Alpha"
+
+    def test_create_hub_representative_single_child(self):
+        """Should create representative even with single child."""
+        station = create_test_station(
+            "HUB1_CHILD_A",
+            "Hub 1 Alpha",
+            ["line1"],
+            last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+            hub_naptan_code="HUB1",
+            hub_common_name="Hub Alpha",
+        )
+
+        representative = create_hub_representative([station])
+
+        assert representative.tfl_id == "HUB1"
+        assert representative.name == "Hub Alpha"
+        assert representative.lines == ["line1"]
+
+    def test_create_hub_representative_without_common_name(self):
+        """Should fallback to station name when hub_common_name is None."""
+        station = create_test_station(
+            "HUB1_CHILD_A",
+            "Alpha Station",
+            ["line1"],
+            last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+            hub_naptan_code="HUB1",
+            hub_common_name=None,
+        )
+
+        representative = create_hub_representative([station])
+
+        assert representative.name == "Alpha Station"  # Falls back to station name
+
+    def test_create_hub_representative_many_children(self):
+        """Should handle many hub children correctly."""
+        children = [
+            create_test_station(
+                f"HUB1_CHILD_{i}",
+                f"Hub 1 Child {i}",
+                [f"line{i}"],
+                last_updated=datetime(2025, 1, i + 1, tzinfo=UTC),
+                hub_naptan_code="HUB1",
+                hub_common_name="Hub Alpha",
+            )
+            for i in range(5)
+        ]
+
+        representative = create_hub_representative(children)
+
+        assert representative.tfl_id == "HUB1"
+        assert representative.name == "Hub Alpha"
+        assert len(representative.lines) == 5
+        assert representative.lines == ["line0", "line1", "line2", "line3", "line4"]
+        assert representative.last_updated == datetime(2025, 1, 5, tzinfo=UTC)  # Most recent
+
+    def test_create_hub_representative_empty_list(self):
+        """Should raise ValueError for empty list."""
+        with pytest.raises(ValueError, match="Cannot create hub representative from empty list"):
+            create_hub_representative([])
+
+    def test_create_hub_representative_with_preferred_child(self):
+        """Should use preferred_child as template for UUID and coordinates."""
+        child1 = create_test_station(
+            "HUB1_CHILD_A",
+            "Hub 1 Alpha",
+            ["line1"],
+            latitude=51.0,
+            longitude=-0.1,
+            hub_naptan_code="HUB1",
+            hub_common_name="Hub Alpha",
+        )
+        child2 = create_test_station(
+            "HUB1_CHILD_B",
+            "Hub 1 Beta",
+            ["line2"],
+            latitude=51.0,
+            longitude=-0.1,
+            hub_naptan_code="HUB1",
+            hub_common_name="Hub Alpha",
+        )
+
+        # Use child2 as preferred
+        representative = create_hub_representative([child1, child2], preferred_child=child2)
+
+        assert representative.id == child2.id  # Uses preferred child's UUID
+        assert representative.tfl_id == "HUB1"
+        assert representative.lines == ["line1", "line2"]  # Still aggregates from all
+
+    def test_create_hub_representative_preferred_child_not_in_list(self):
+        """Should raise ValueError if preferred_child not in hub_children list."""
+        child1 = create_test_station(
+            "HUB1_CHILD_A", "Hub 1 Alpha", ["line1"], hub_naptan_code="HUB1", hub_common_name="Hub Alpha"
+        )
+        other_child = create_test_station(
+            "HUB2_CHILD_A", "Hub 2 Alpha", ["line2"], hub_naptan_code="HUB2", hub_common_name="Hub Beta"
+        )
+
+        with pytest.raises(ValueError, match=r"preferred_child .* not found in hub_children"):
+            create_hub_representative([child1], preferred_child=other_child)

--- a/backend/tests/test_tfl_api_dedup.py
+++ b/backend/tests/test_tfl_api_dedup.py
@@ -1,0 +1,364 @@
+"""Integration tests for GET /tfl/stations?deduplicated endpoint (Issue #67)."""
+
+import posixpath
+import uuid
+from collections.abc import AsyncGenerator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from app.core.config import settings
+from app.core.database import get_db
+from app.main import app
+from app.models.tfl import Station
+from app.models.user import User
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def build_api_url(endpoint: str) -> str:
+    """
+    Build API URL by joining API prefix with endpoint path using posixpath.
+
+    Properly handles slashes using standard library path joining.
+
+    Args:
+        endpoint: API endpoint path (e.g., '/tfl/stations')
+
+    Returns:
+        Full API URL with version prefix (e.g., '/api/v1/tfl/stations')
+    """
+    return posixpath.join(settings.API_V1_PREFIX, endpoint.lstrip("/"))
+
+
+@pytest.fixture
+async def async_client_with_auth(
+    test_user: User,
+    auth_headers_for_user: dict[str, str],
+    db_session: AsyncSession,
+) -> AsyncGenerator[AsyncClient]:
+    """Create async client with authentication headers."""
+
+    # Override database dependency to use test database
+    async def override_get_db() -> AsyncGenerator[AsyncSession]:
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            headers=auth_headers_for_user,
+        ) as client:
+            yield client
+    finally:
+        # Clean up override
+        app.dependency_overrides.clear()
+
+
+class TestGetStationsDeduplicated:
+    """Integration tests for GET /tfl/stations?deduplicated parameter."""
+
+    @pytest.mark.asyncio
+    async def test_get_stations_deduplicated_false(self, async_client_with_auth: AsyncClient) -> None:
+        """Should return all stations including hub children when deduplicated=false (default)."""
+        # Mock stations with hub children
+        mock_stations = [
+            Station(
+                id=uuid.uuid4(),
+                tfl_id="910GSEVNSIS",
+                name="Seven Sisters (Rail)",
+                latitude=51.58,
+                longitude=-0.07,
+                lines=["overground"],
+                last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+                hub_naptan_code="HUBSVS",
+                hub_common_name="Seven Sisters",
+            ),
+            Station(
+                id=uuid.uuid4(),
+                tfl_id="940GZZLUSVS",
+                name="Seven Sisters",
+                latitude=51.58,
+                longitude=-0.07,
+                lines=["victoria"],
+                last_updated=datetime(2025, 1, 2, tzinfo=UTC),
+                hub_naptan_code="HUBSVS",
+                hub_common_name="Seven Sisters",
+            ),
+            Station(
+                id=uuid.uuid4(),
+                tfl_id="940GZZLUOXC",
+                name="Oxford Circus",
+                latitude=51.52,
+                longitude=-0.14,
+                lines=["piccadilly", "bakerloo"],
+                last_updated=datetime(2025, 1, 3, tzinfo=UTC),
+                hub_naptan_code=None,
+                hub_common_name=None,
+            ),
+        ]
+
+        with patch("app.services.tfl_service.TfLService.fetch_stations", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_stations
+
+            # Execute with deduplicated=false (default)
+            response = await async_client_with_auth.get(build_api_url("/tfl/stations"))
+
+            # Verify
+            assert response.status_code == 200
+            data = response.json()
+
+            # Should return all 3 stations (2 hub children + 1 standalone)
+            assert len(data) == 3
+
+            # Verify all original tfl_ids are present
+            tfl_ids = {station["tfl_id"] for station in data}
+            assert tfl_ids == {"910GSEVNSIS", "940GZZLUSVS", "940GZZLUOXC"}
+
+    @pytest.mark.asyncio
+    async def test_get_stations_deduplicated_true(self, async_client_with_auth: AsyncClient) -> None:
+        """Should return hub-grouped stations when deduplicated=true."""
+        # Mock stations with hub children
+        mock_stations = [
+            Station(
+                id=uuid.uuid4(),
+                tfl_id="910GSEVNSIS",
+                name="Seven Sisters (Rail)",
+                latitude=51.58,
+                longitude=-0.07,
+                lines=["overground"],
+                last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+                hub_naptan_code="HUBSVS",
+                hub_common_name="Seven Sisters",
+            ),
+            Station(
+                id=uuid.uuid4(),
+                tfl_id="940GZZLUSVS",
+                name="Seven Sisters",
+                latitude=51.58,
+                longitude=-0.07,
+                lines=["victoria"],
+                last_updated=datetime(2025, 1, 2, tzinfo=UTC),
+                hub_naptan_code="HUBSVS",
+                hub_common_name="Seven Sisters",
+            ),
+            Station(
+                id=uuid.uuid4(),
+                tfl_id="940GZZLUOXC",
+                name="Oxford Circus",
+                latitude=51.52,
+                longitude=-0.14,
+                lines=["piccadilly", "bakerloo"],
+                last_updated=datetime(2025, 1, 3, tzinfo=UTC),
+                hub_naptan_code=None,
+                hub_common_name=None,
+            ),
+        ]
+
+        with patch("app.services.tfl_service.TfLService.fetch_stations", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_stations
+
+            # Execute with deduplicated=true
+            response = await async_client_with_auth.get(build_api_url("/tfl/stations?deduplicated=true"))
+
+            # Verify
+            assert response.status_code == 200
+            data = response.json()
+
+            # Should return 2 stations (1 hub representative + 1 standalone)
+            assert len(data) == 2
+
+            # Find hub representative
+            hub_station = next(s for s in data if s["tfl_id"] == "HUBSVS")
+            assert hub_station["name"] == "Seven Sisters"
+            assert hub_station["hub_naptan_code"] == "HUBSVS"
+            assert hub_station["hub_common_name"] == "Seven Sisters"
+            # Lines should be aggregated and sorted
+            assert hub_station["lines"] == ["overground", "victoria"]
+
+            # Find standalone
+            standalone = next(s for s in data if s["tfl_id"] == "940GZZLUOXC")
+            assert standalone["name"] == "Oxford Circus"
+            assert standalone["hub_naptan_code"] is None
+
+    @pytest.mark.asyncio
+    async def test_get_stations_deduplicated_with_line_filter(self, async_client_with_auth: AsyncClient) -> None:
+        """Should fetch all stations, deduplicate, then filter to show hubs with ALL their lines."""
+        # Mock ALL stations including hub children on different lines
+        mock_stations = [
+            # Seven Sisters hub - Tube station on Victoria line
+            Station(
+                id=uuid.uuid4(),
+                tfl_id="940GZZLUSVS",
+                name="Seven Sisters",
+                latitude=51.58,
+                longitude=-0.07,
+                lines=["victoria"],
+                last_updated=datetime(2025, 1, 2, tzinfo=UTC),
+                hub_naptan_code="HUBSVS",
+                hub_common_name="Seven Sisters",
+            ),
+            # Seven Sisters hub - Rail station on Weaver line
+            Station(
+                id=uuid.uuid4(),
+                tfl_id="910GSEVNSIS",
+                name="Seven Sisters (Rail)",
+                latitude=51.58,
+                longitude=-0.07,
+                lines=["weaver"],
+                last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+                hub_naptan_code="HUBSVS",
+                hub_common_name="Seven Sisters",
+            ),
+            # Standalone station on Victoria line
+            Station(
+                id=uuid.uuid4(),
+                tfl_id="940GZZLUOXC",
+                name="Oxford Circus",
+                latitude=51.52,
+                longitude=-0.14,
+                lines=["victoria"],
+                last_updated=datetime(2025, 1, 3, tzinfo=UTC),
+                hub_naptan_code=None,
+                hub_common_name=None,
+            ),
+        ]
+
+        with patch("app.services.tfl_service.TfLService.fetch_stations", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_stations
+
+            # Execute with both line_id and deduplicated
+            response = await async_client_with_auth.get(
+                build_api_url("/tfl/stations?line_id=victoria&deduplicated=true")
+            )
+
+            # Verify
+            assert response.status_code == 200
+            data = response.json()
+
+            # Should return 2 stations: Seven Sisters hub (serves victoria) + Oxford Circus
+            assert len(data) == 2
+
+            # Find Seven Sisters hub in results
+            seven_sisters = next(s for s in data if s["tfl_id"] == "HUBSVS")
+            # Hub should show ALL lines (victoria + weaver), not just victoria
+            assert set(seven_sisters["lines"]) == {"victoria", "weaver"}
+            assert seven_sisters["name"] == "Seven Sisters"
+
+            # Find Oxford Circus
+            oxford_circus = next(s for s in data if s["tfl_id"] == "940GZZLUOXC")
+            assert oxford_circus["lines"] == ["victoria"]
+
+            # Verify fetch_stations was called with line_tfl_id=None (fetch all for deduplication)
+            mock_fetch.assert_called_once_with(line_tfl_id=None)
+
+    @pytest.mark.asyncio
+    async def test_get_stations_deduplicated_all_standalone(self, async_client_with_auth: AsyncClient) -> None:
+        """Should return all stations when none are in hubs."""
+        # Mock only standalone stations
+        mock_stations = [
+            Station(
+                id=uuid.uuid4(),
+                tfl_id="940GZZLUOXC",
+                name="Oxford Circus",
+                latitude=51.52,
+                longitude=-0.14,
+                lines=["piccadilly"],
+                last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+                hub_naptan_code=None,
+            ),
+            Station(
+                id=uuid.uuid4(),
+                tfl_id="940GZZLUPCO",
+                name="Piccadilly Circus",
+                latitude=51.51,
+                longitude=-0.13,
+                lines=["piccadilly"],
+                last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+                hub_naptan_code=None,
+            ),
+        ]
+
+        with patch("app.services.tfl_service.TfLService.fetch_stations", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_stations
+
+            # Execute with deduplicated=true
+            response = await async_client_with_auth.get(build_api_url("/tfl/stations?deduplicated=true"))
+
+            # Verify
+            assert response.status_code == 200
+            data = response.json()
+
+            # Should return all 2 stations (no hubs to deduplicate)
+            assert len(data) == 2
+            tfl_ids = {s["tfl_id"] for s in data}
+            assert tfl_ids == {"940GZZLUOXC", "940GZZLUPCO"}
+
+    @pytest.mark.asyncio
+    async def test_get_stations_deduplicated_empty_list(self, async_client_with_auth: AsyncClient) -> None:
+        """Should handle empty stations list gracefully."""
+        with patch("app.services.tfl_service.TfLService.fetch_stations", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = []
+
+            # Execute with deduplicated=true
+            response = await async_client_with_auth.get(build_api_url("/tfl/stations?deduplicated=true"))
+
+            # Verify
+            assert response.status_code == 200
+            data = response.json()
+            assert data == []
+
+    @pytest.mark.asyncio
+    async def test_get_stations_deduplicated_sorted_alphabetically(self, async_client_with_auth: AsyncClient) -> None:
+        """Should return stations sorted alphabetically by name."""
+        # Mock stations with unsorted names
+        mock_stations = [
+            Station(
+                id=uuid.uuid4(),
+                tfl_id="ZZZ",
+                name="Zebra Station",
+                latitude=51.5,
+                longitude=-0.1,
+                lines=["victoria"],
+                last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+                hub_naptan_code=None,
+            ),
+            Station(
+                id=uuid.uuid4(),
+                tfl_id="AAA",
+                name="Apple Station",
+                latitude=51.5,
+                longitude=-0.1,
+                lines=["northern"],
+                last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+                hub_naptan_code=None,
+            ),
+            Station(
+                id=uuid.uuid4(),
+                tfl_id="MMM",
+                name="Mango Station",
+                latitude=51.5,
+                longitude=-0.1,
+                lines=["piccadilly"],
+                last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+                hub_naptan_code=None,
+            ),
+        ]
+
+        with patch("app.services.tfl_service.TfLService.fetch_stations", new_callable=AsyncMock) as mock_fetch:
+            mock_fetch.return_value = mock_stations
+
+            # Execute with deduplicated=true
+            response = await async_client_with_auth.get(build_api_url("/tfl/stations?deduplicated=true"))
+
+            # Verify
+            assert response.status_code == 200
+            data = response.json()
+
+            # Should be sorted alphabetically
+            assert len(data) == 3
+            assert data[0]["name"] == "Apple Station"
+            assert data[1]["name"] == "Mango Station"
+            assert data[2]["name"] == "Zebra Station"

--- a/backend/tests/test_tfl_service_dedup.py
+++ b/backend/tests/test_tfl_service_dedup.py
@@ -1,0 +1,273 @@
+"""Unit tests for TfLService.deduplicate_stations_by_hub() method (Issue #67)."""
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from app.models.tfl import Station
+from app.services.tfl_service import TfLService
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.fixture
+def tfl_service(db_session: AsyncSession) -> TfLService:
+    """Create TfLService instance for testing."""
+    return TfLService(db_session)
+
+
+class TestDeduplicateStationsByHub:
+    """Tests for deduplicate_stations_by_hub() service method (Issue #67)."""
+
+    def test_deduplicate_stations_by_hub_with_mixed_stations(self, tfl_service: TfLService) -> None:
+        """Should group hub stations and preserve standalone stations."""
+        # Hub stations (Seven Sisters)
+        rail = Station(
+            id=uuid.uuid4(),
+            tfl_id="910GSEVNSIS",
+            name="Seven Sisters (Rail)",
+            latitude=51.58,
+            longitude=-0.07,
+            lines=["overground"],
+            last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+            hub_naptan_code="HUBSVS",
+            hub_common_name="Seven Sisters",
+        )
+        tube = Station(
+            id=uuid.uuid4(),
+            tfl_id="940GZZLUSVS",
+            name="Seven Sisters",
+            latitude=51.58,
+            longitude=-0.07,
+            lines=["victoria"],
+            last_updated=datetime(2025, 1, 15, tzinfo=UTC),
+            hub_naptan_code="HUBSVS",
+            hub_common_name="Seven Sisters",
+        )
+        # Standalone station
+        standalone = Station(
+            id=uuid.uuid4(),
+            tfl_id="940GZZLUOXC",
+            name="Oxford Circus",
+            latitude=51.52,
+            longitude=-0.14,
+            lines=["bakerloo", "piccadilly"],  # Keep in sorted order like TfL data
+            last_updated=datetime(2025, 1, 10, tzinfo=UTC),
+            hub_naptan_code=None,
+            hub_common_name=None,
+        )
+
+        result = tfl_service.deduplicate_stations_by_hub([rail, tube, standalone])
+
+        # Should have 2 stations (1 hub representative + 1 standalone)
+        assert len(result) == 2
+
+        # Find hub representative (by tfl_id == hub code)
+        hub_rep = next(s for s in result if s.tfl_id == "HUBSVS")
+        assert hub_rep.name == "Seven Sisters"
+        assert hub_rep.lines == ["overground", "victoria"]  # Aggregated and sorted
+        assert hub_rep.last_updated == datetime(2025, 1, 15, tzinfo=UTC)  # Most recent
+        assert hub_rep.hub_naptan_code == "HUBSVS"
+        assert hub_rep.hub_common_name == "Seven Sisters"
+
+        # Find standalone
+        standalone_result = next(s for s in result if s.tfl_id == "940GZZLUOXC")
+        assert standalone_result.name == "Oxford Circus"
+        assert standalone_result.lines == ["bakerloo", "piccadilly"]  # Unchanged from input
+
+    def test_deduplicate_stations_by_hub_all_standalone(self, tfl_service: TfLService) -> None:
+        """Should return all stations unchanged when none are in hubs."""
+        station1 = Station(
+            id=uuid.uuid4(),
+            tfl_id="940GZZLUOXC",
+            name="Oxford Circus",
+            latitude=51.52,
+            longitude=-0.14,
+            lines=["piccadilly"],
+            last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+            hub_naptan_code=None,
+        )
+        station2 = Station(
+            id=uuid.uuid4(),
+            tfl_id="940GZZLUPCO",
+            name="Piccadilly Circus",
+            latitude=51.51,
+            longitude=-0.13,
+            lines=["piccadilly"],
+            last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+            hub_naptan_code=None,
+        )
+
+        result = tfl_service.deduplicate_stations_by_hub([station1, station2])
+
+        # Should have both stations (no deduplication occurred)
+        assert len(result) == 2
+        tfl_ids = {s.tfl_id for s in result}
+        assert tfl_ids == {"940GZZLUOXC", "940GZZLUPCO"}
+
+    def test_deduplicate_stations_by_hub_all_hub_stations(self, tfl_service: TfLService) -> None:
+        """Should deduplicate when all stations are in hubs."""
+        rail = Station(
+            id=uuid.uuid4(),
+            tfl_id="910GSEVNSIS",
+            name="Seven Sisters (Rail)",
+            latitude=51.58,
+            longitude=-0.07,
+            lines=["overground"],
+            last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+            hub_naptan_code="HUBSVS",
+            hub_common_name="Seven Sisters",
+        )
+        tube = Station(
+            id=uuid.uuid4(),
+            tfl_id="940GZZLUSVS",
+            name="Seven Sisters",
+            latitude=51.58,
+            longitude=-0.07,
+            lines=["victoria"],
+            last_updated=datetime(2025, 1, 15, tzinfo=UTC),
+            hub_naptan_code="HUBSVS",
+            hub_common_name="Seven Sisters",
+        )
+
+        result = tfl_service.deduplicate_stations_by_hub([rail, tube])
+
+        # Should have 1 station (hub representative only)
+        assert len(result) == 1
+        assert result[0].tfl_id == "HUBSVS"
+        assert result[0].name == "Seven Sisters"
+        assert result[0].lines == ["overground", "victoria"]
+
+    def test_deduplicate_stations_by_hub_multiple_hubs(self, tfl_service: TfLService) -> None:
+        """Should correctly group multiple separate hubs."""
+        # Hub 1: Seven Sisters
+        hub1_station1 = Station(
+            id=uuid.uuid4(),
+            tfl_id="910GSEVNSIS",
+            name="Seven Sisters (Rail)",
+            latitude=51.58,
+            longitude=-0.07,
+            lines=["overground"],
+            last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+            hub_naptan_code="HUBSVS",
+            hub_common_name="Seven Sisters",
+        )
+        hub1_station2 = Station(
+            id=uuid.uuid4(),
+            tfl_id="940GZZLUSVS",
+            name="Seven Sisters",
+            latitude=51.58,
+            longitude=-0.07,
+            lines=["victoria"],
+            last_updated=datetime(2025, 1, 2, tzinfo=UTC),
+            hub_naptan_code="HUBSVS",
+            hub_common_name="Seven Sisters",
+        )
+        # Hub 2: Canada Water (example - made up for testing)
+        hub2_station1 = Station(
+            id=uuid.uuid4(),
+            tfl_id="940GZZLUCWR",
+            name="Canada Water",
+            latitude=51.49,
+            longitude=-0.05,
+            lines=["jubilee"],
+            last_updated=datetime(2025, 1, 3, tzinfo=UTC),
+            hub_naptan_code="HUBCWR",
+            hub_common_name="Canada Water",
+        )
+        hub2_station2 = Station(
+            id=uuid.uuid4(),
+            tfl_id="910GCNDAW",
+            name="Canada Water (Rail)",
+            latitude=51.49,
+            longitude=-0.05,
+            lines=["overground"],
+            last_updated=datetime(2025, 1, 4, tzinfo=UTC),
+            hub_naptan_code="HUBCWR",
+            hub_common_name="Canada Water",
+        )
+
+        result = tfl_service.deduplicate_stations_by_hub([hub1_station1, hub1_station2, hub2_station1, hub2_station2])
+
+        # Should have 2 stations (2 hub representatives)
+        assert len(result) == 2
+
+        # Find Seven Sisters hub
+        seven_sisters = next(s for s in result if s.tfl_id == "HUBSVS")
+        assert seven_sisters.name == "Seven Sisters"
+        assert seven_sisters.lines == ["overground", "victoria"]
+        assert seven_sisters.last_updated == datetime(2025, 1, 2, tzinfo=UTC)  # Most recent
+
+        # Find Canada Water hub
+        canada_water = next(s for s in result if s.tfl_id == "HUBCWR")
+        assert canada_water.name == "Canada Water"
+        assert canada_water.lines == ["jubilee", "overground"]
+        assert canada_water.last_updated == datetime(2025, 1, 4, tzinfo=UTC)  # Most recent
+
+    def test_deduplicate_stations_by_hub_sorting(self, tfl_service: TfLService) -> None:
+        """Should return stations sorted alphabetically by name."""
+        # Create stations with names that would have different sort order
+        zebra = Station(
+            id=uuid.uuid4(),
+            tfl_id="ZZZ",
+            name="Zebra Station",
+            latitude=51.5,
+            longitude=-0.1,
+            lines=["victoria"],
+            last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+            hub_naptan_code=None,
+        )
+        apple = Station(
+            id=uuid.uuid4(),
+            tfl_id="AAA",
+            name="Apple Station",
+            latitude=51.5,
+            longitude=-0.1,
+            lines=["northern"],
+            last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+            hub_naptan_code=None,
+        )
+        mango = Station(
+            id=uuid.uuid4(),
+            tfl_id="MMM",
+            name="Mango Station",
+            latitude=51.5,
+            longitude=-0.1,
+            lines=["piccadilly"],
+            last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+            hub_naptan_code=None,
+        )
+
+        result = tfl_service.deduplicate_stations_by_hub([zebra, apple, mango])
+
+        # Should be sorted alphabetically by name
+        assert len(result) == 3
+        assert result[0].name == "Apple Station"
+        assert result[1].name == "Mango Station"
+        assert result[2].name == "Zebra Station"
+
+    def test_deduplicate_stations_by_hub_empty_list(self, tfl_service: TfLService) -> None:
+        """Should handle empty list gracefully."""
+        result = tfl_service.deduplicate_stations_by_hub([])
+
+        assert result == []
+
+    def test_deduplicate_stations_by_hub_single_hub_child(self, tfl_service: TfLService) -> None:
+        """Should still deduplicate hub even if only one child station."""
+        station = Station(
+            id=uuid.uuid4(),
+            tfl_id="940GZZLUSVS",
+            name="Seven Sisters",
+            latitude=51.58,
+            longitude=-0.07,
+            lines=["victoria"],
+            last_updated=datetime(2025, 1, 1, tzinfo=UTC),
+            hub_naptan_code="HUBSVS",
+            hub_common_name="Seven Sisters",
+        )
+
+        result = tfl_service.deduplicate_stations_by_hub([station])
+
+        assert len(result) == 1
+        assert result[0].tfl_id == "HUBSVS"  # Uses hub code even for single child
+        assert result[0].name == "Seven Sisters"
+        assert result[0].lines == ["victoria"]


### PR DESCRIPTION
- Added `deduplicate_stations_by_hub` method to TfLService to group hub children into representative stations.
- Introduced helper functions `create_hub_representative` and `group_stations_by_hub` for modularity and testability.
- Updated tests for station resolution helpers to cover new deduplication logic.
- Created integration tests for the new deduplication endpoint in the TfL API.
- Added unit tests for the `deduplicate_stations_by_hub` method to ensure correct functionality and edge cases.
- Created integration tests for the GET /tfl/stations?deduplicated endpoint, covering various scenarios including deduplication behavior, line filtering, and sorting.
- Implemented unit tests for the TfLService.deduplicate_stations_by_hub() method, validating the deduplication logic for mixed, standalone, and hub stations, as well as handling edge cases like empty lists and single hub children.

resolves #67

## Summary by Sourcery

Add hub-level station deduplication feature by grouping child stations into single representatives in the service and API, supported by modular helper functions and comprehensive unit and integration tests

New Features:
- Implement deduplication of stations by hub in TfLService via deduplicate_stations_by_hub
- Add deduplicated query parameter to GET /tfl/stations endpoint to return hub-grouped stations

Enhancements:
- Introduce pure helper functions for station deduplication: group_stations_by_hub, aggregate_station_lines, get_latest_update_time, and create_hub_representative
- Refactor station resolution tests to use create_test_station factory for consistent test data

Documentation:
- Update API endpoint docstrings to describe hub deduplication behavior

Tests:
- Add unit tests for deduplication helpers and TfLService.deduplicate_stations_by_hub method
- Add integration tests for GET /tfl/stations?deduplicated endpoint covering deduplication, line filtering, and sorting

Chores:
- Extend conftest with TestRailwayNetwork and create_test_station factory for shared test data