### PR TITLE
feat: Display hub common names with interchange badge (#54)

### DIFF
--- a/frontend/src/components/routes/SegmentBuilder.test.tsx
+++ b/frontend/src/components/routes/SegmentBuilder.test.tsx
@@ -25,6 +25,8 @@ describe('SegmentBuilder', () => {
       longitude: -0.1238,
       lines: ['northern'],
       last_updated: '2025-01-01T00:00:00Z',
+      hub_naptan_code: null,
+      hub_common_name: null,
     },
     {
       id: 'station-2',
@@ -34,6 +36,8 @@ describe('SegmentBuilder', () => {
       longitude: -0.1337,
       lines: ['northern'],
       last_updated: '2025-01-01T00:00:00Z',
+      hub_naptan_code: null,
+      hub_common_name: null,
     },
   ]
 

--- a/frontend/src/components/routes/SegmentList.test.tsx
+++ b/frontend/src/components/routes/SegmentList.test.tsx
@@ -31,6 +31,8 @@ describe('SegmentList', () => {
       longitude: -0.1238,
       lines: ['northern', 'victoria'],
       last_updated: '2025-01-01T00:00:00Z',
+      hub_naptan_code: null,
+      hub_common_name: null,
     },
     {
       id: 'station-2',
@@ -40,6 +42,8 @@ describe('SegmentList', () => {
       longitude: -0.1337,
       lines: ['northern'],
       last_updated: '2025-01-01T00:00:00Z',
+      hub_naptan_code: null,
+      hub_common_name: null,
     },
     {
       id: 'station-3',
@@ -49,6 +53,8 @@ describe('SegmentList', () => {
       longitude: -0.1224,
       lines: ['northern'],
       last_updated: '2025-01-01T00:00:00Z',
+      hub_naptan_code: null,
+      hub_common_name: null,
     },
   ]
 

--- a/frontend/src/components/routes/StationCombobox.test.tsx
+++ b/frontend/src/components/routes/StationCombobox.test.tsx
@@ -8,12 +8,14 @@ describe('StationCombobox', () => {
   const mockStations: StationResponse[] = [
     {
       id: 'station-1',
-      tfl_id: '940GZZLUKSX',
+      tfl_id: 'HUBKSX',
       name: "King's Cross St. Pancras",
       latitude: 51.5308,
       longitude: -0.1238,
-      lines: ['northern', 'victoria'],
+      lines: ['northern', 'victoria', 'circle', 'hammersmith-city', 'metropolitan', 'piccadilly'],
       last_updated: '2025-01-01T00:00:00Z',
+      hub_naptan_code: 'HUBKSX',
+      hub_common_name: "King's Cross St. Pancras",
     },
     {
       id: 'station-2',
@@ -23,6 +25,8 @@ describe('StationCombobox', () => {
       longitude: -0.1337,
       lines: ['northern', 'victoria'],
       last_updated: '2025-01-01T00:00:00Z',
+      hub_naptan_code: null,
+      hub_common_name: null,
     },
     {
       id: 'station-3',
@@ -32,6 +36,8 @@ describe('StationCombobox', () => {
       longitude: -0.1224,
       lines: ['northern', 'circle'],
       last_updated: '2025-01-01T00:00:00Z',
+      hub_naptan_code: null,
+      hub_common_name: null,
     },
   ]
 
@@ -174,5 +180,22 @@ describe('StationCombobox', () => {
     expect(screen.getByText("King's Cross St. Pancras")).toBeInTheDocument()
     expect(screen.getByText('Euston')).toBeInTheDocument()
     expect(screen.getByText('Embankment')).toBeInTheDocument()
+  })
+
+  it('should show interchange badge for hub stations only', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+
+    render(<StationCombobox stations={mockStations} value={undefined} onChange={onChange} />)
+
+    // Open combobox
+    await user.click(screen.getByRole('combobox'))
+
+    // King's Cross St. Pancras is a hub station - should have interchange badge
+    const interchangeBadges = screen.getAllByLabelText('Interchange station')
+    expect(interchangeBadges).toHaveLength(1)
+
+    // Non-hub stations (Euston, Embankment) should not have badges
+    // (verified by only 1 badge total when there are 3 stations)
   })
 })

--- a/frontend/src/components/routes/StationCombobox.tsx
+++ b/frontend/src/components/routes/StationCombobox.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Check, ChevronsUpDown } from 'lucide-react'
+import { ArrowLeftRight, Check, ChevronsUpDown } from 'lucide-react'
 import { Button } from '../ui/button'
 import {
   Command,
@@ -118,7 +118,15 @@ export function StationCombobox({
                       value === station.id ? 'opacity-100' : 'opacity-0'
                     )}
                   />
-                  {station.name}
+                  <div className="flex items-center justify-between w-full">
+                    <span>{station.name}</span>
+                    {station.hub_naptan_code && (
+                      <ArrowLeftRight
+                        className="h-3 w-3 text-muted-foreground ml-2 shrink-0"
+                        aria-label="Interchange station"
+                      />
+                    )}
+                  </div>
                 </CommandItem>
               ))}
             </CommandGroup>

--- a/frontend/src/hooks/useTflData.test.ts
+++ b/frontend/src/hooks/useTflData.test.ts
@@ -85,6 +85,8 @@ describe('useTflData', () => {
       longitude: -0.1238,
       lines: ['northern', 'victoria', 'circle'],
       last_updated: '2025-01-01T00:00:00Z',
+      hub_naptan_code: 'HUBKSX',
+      hub_common_name: "King's Cross St. Pancras",
     },
     {
       id: 'station-2',
@@ -94,6 +96,8 @@ describe('useTflData', () => {
       longitude: -0.1337,
       lines: ['northern', 'victoria'],
       last_updated: '2025-01-01T00:00:00Z',
+      hub_naptan_code: null,
+      hub_common_name: null,
     },
     {
       id: 'station-3',
@@ -103,6 +107,8 @@ describe('useTflData', () => {
       longitude: -0.1224,
       lines: ['northern', 'circle'],
       last_updated: '2025-01-01T00:00:00Z',
+      hub_naptan_code: null,
+      hub_common_name: null,
     },
     {
       id: 'station-4',
@@ -112,6 +118,8 @@ describe('useTflData', () => {
       longitude: -0.1948,
       lines: ['northern'],
       last_updated: '2025-01-01T00:00:00Z',
+      hub_naptan_code: null,
+      hub_common_name: null,
     },
     {
       id: 'station-5',
@@ -121,6 +129,8 @@ describe('useTflData', () => {
       longitude: -0.1426,
       lines: ['northern'],
       last_updated: '2025-01-01T00:00:00Z',
+      hub_naptan_code: null,
+      hub_common_name: null,
     },
   ]
 


### PR DESCRIPTION
Implements frontend support for hub station deduplication:

**Changes:**
1. Update getStations() to request deduplicated stations (deduplicated=true)
2. Add interchange badge to StationCombobox for hub stations
3. Update test mocks to include hub_naptan_code and hub_common_name fields
4. Add test for interchange badge display

**Backend Integration:**
- Uses deduplicated endpoint from PR #71
- Hub codes automatically resolved by backend (PR #69)
- Stations grouped by hub with aggregated lines

## Summary by Sourcery

Enable frontend handling of hub station deduplication by requesting deduplicated stations, extending the station response with hub identifiers, and visually marking hub stations with an interchange badge.

New Features:
- Display an interchange badge for hub stations in the StationCombobox component

Enhancements:
- Append deduplicated=true to getStations API calls to group hub stations
- Add hub_naptan_code and hub_common_name fields to the StationResponse interface

Tests:
- Add a unit test to verify interchange badges appear only for hub stations
- Update station mocks in multiple tests to include hub_naptan_code and hub_common_name

resolves #54 