### PR TITLE
Fix/issue 57 route direction validation

### DIFF
--- a/backend/app/helpers/route_validation.py
+++ b/backend/app/helpers/route_validation.py
@@ -1,0 +1,207 @@
+"""
+Route validation helpers for directional validation.
+
+These pure functions enable testable, functional-style route validation logic
+without requiring database access. They are used by TfLService._check_connection()
+for validating station connections on TfL lines.
+
+Issue #57: Route direction validation
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class RouteVariant(TypedDict):
+    """Type definition for a route variant from Line.routes JSON."""
+
+    name: str
+    service_type: str
+    direction: str
+    stations: list[str]
+
+
+class ConnectionResult(TypedDict):
+    """Result of checking a connection in a single route variant."""
+
+    found: bool
+    from_index: int | None
+    to_index: int | None
+    route_name: str | None
+    direction: str | None
+
+
+def check_stations_in_route(
+    from_station_tfl_id: str,
+    to_station_tfl_id: str,
+    stations: list[str],
+) -> tuple[bool, int | None, int | None]:
+    """
+    Check if two stations exist in a route sequence and return their positions.
+
+    Pure function that finds the positions of both stations in the route sequence.
+    Does NOT validate direction - just returns positions for further processing.
+
+    Args:
+        from_station_tfl_id: Starting station TfL ID
+        to_station_tfl_id: Destination station TfL ID
+        stations: Ordered list of station TfL IDs in route sequence
+
+    Returns:
+        Tuple of (both_found, from_index, to_index)
+        - both_found: True if both stations exist in sequence
+        - from_index: Index of from_station (None if not found)
+        - to_index: Index of to_station (None if not found)
+
+    Examples:
+        >>> check_stations_in_route("A", "C", ["A", "B", "C"])
+        (True, 0, 2)
+
+        >>> check_stations_in_route("C", "A", ["A", "B", "C"])
+        (True, 2, 0)
+
+        >>> check_stations_in_route("A", "D", ["A", "B", "C"])
+        (False, 0, None)
+    """
+    try:
+        from_index = stations.index(from_station_tfl_id)
+    except ValueError:
+        return (False, None, None)
+
+    try:
+        to_index = stations.index(to_station_tfl_id)
+    except ValueError:
+        return (False, from_index, None)
+
+    return (True, from_index, to_index)
+
+
+def validate_station_order(from_index: int, to_index: int) -> bool:
+    """
+    Validate that stations appear in forward order (directional validation).
+
+    Pure function that enforces from_station must come BEFORE to_station
+    in the route sequence to prevent backwards travel.
+
+    Args:
+        from_index: Index of starting station
+        to_index: Index of destination station
+
+    Returns:
+        True if to_station comes after from_station (valid forward direction)
+
+    Examples:
+        >>> validate_station_order(0, 2)  # A → C
+        True
+
+        >>> validate_station_order(2, 0)  # C → A (backwards)
+        False
+
+        >>> validate_station_order(1, 1)  # Same station
+        False
+    """
+    return from_index < to_index
+
+
+def check_connection_in_route_variant(
+    from_station_tfl_id: str,
+    to_station_tfl_id: str,
+    route: RouteVariant,
+) -> ConnectionResult:
+    """
+    Check if two stations are connected in correct order within a single route variant.
+
+    Combines station lookup and directional validation for a single route variant.
+    Pure function with no side effects.
+
+    Args:
+        from_station_tfl_id: Starting station TfL ID
+        to_station_tfl_id: Destination station TfL ID
+        route: Route variant dict with 'stations', 'name', 'direction' keys
+
+    Returns:
+        ConnectionResult dict with:
+        - found: True if valid connection exists in correct order
+        - from_index: Position of from_station (None if not found)
+        - to_index: Position of to_station (None if not found)
+        - route_name: Name of route variant
+        - direction: Direction label (inbound/outbound)
+
+    Examples:
+        >>> route = {
+        ...     "name": "A → C",
+        ...     "direction": "inbound",
+        ...     "service_type": "Regular",
+        ...     "stations": ["A", "B", "C"]
+        ... }
+        >>> check_connection_in_route_variant("A", "C", route)
+        {'found': True, 'from_index': 0, 'to_index': 2, 'route_name': 'A → C', 'direction': 'inbound'}
+
+        >>> check_connection_in_route_variant("C", "A", route)  # Backwards
+        {'found': False, 'from_index': 2, 'to_index': 0, 'route_name': 'A → C', 'direction': 'inbound'}
+    """
+    stations = route.get("stations", [])
+    both_found, from_index, to_index = check_stations_in_route(from_station_tfl_id, to_station_tfl_id, stations)
+
+    # If both stations found, validate direction
+    if both_found and from_index is not None and to_index is not None:
+        valid_direction = validate_station_order(from_index, to_index)
+        return ConnectionResult(
+            found=valid_direction,
+            from_index=from_index,
+            to_index=to_index,
+            route_name=route.get("name"),
+            direction=route.get("direction"),
+        )
+
+    # Stations not both found in this route variant
+    return ConnectionResult(
+        found=False,
+        from_index=from_index,
+        to_index=to_index,
+        route_name=route.get("name"),
+        direction=route.get("direction"),
+    )
+
+
+def find_valid_connection_in_routes(
+    from_station_tfl_id: str,
+    to_station_tfl_id: str,
+    routes: list[RouteVariant],
+) -> ConnectionResult | None:
+    """
+    Find the first valid connection across multiple route variants.
+
+    Iterates through route variants and returns the first one where both stations
+    exist in the correct order. Returns None if no valid connection found.
+
+    Performance: O(r * n) where r = number of route variants, n = stations per route.
+    With typical values (2-6 route variants, 20-60 stations each), this is fast.
+
+    Args:
+        from_station_tfl_id: Starting station TfL ID
+        to_station_tfl_id: Destination station TfL ID
+        routes: List of route variant dicts
+
+    Returns:
+        ConnectionResult for first valid connection, or None if none found
+
+    Examples:
+        >>> routes = [
+        ...     {"name": "A → C", "direction": "inbound", "service_type": "Regular", "stations": ["A", "B", "C"]},
+        ...     {"name": "C → A", "direction": "outbound", "service_type": "Regular", "stations": ["C", "B", "A"]},
+        ... ]
+        >>> find_valid_connection_in_routes("A", "C", routes)
+        {'found': True, 'from_index': 0, 'to_index': 2, ...}
+
+        >>> find_valid_connection_in_routes("B", "A", routes)  # Backwards on first, need second route
+        {'found': True, 'from_index': 1, 'to_index': 2, ...}
+    """
+    for route in routes:
+        result = check_connection_in_route_variant(from_station_tfl_id, to_station_tfl_id, route)
+        if result["found"]:
+            return result
+
+    # No valid connection found in any route variant
+    return None

--- a/backend/app/services/tfl_service.py
+++ b/backend/app/services/tfl_service.py
@@ -2375,13 +2375,29 @@ class TfLService:
             )
             return True
 
-        # Stations not found in any common route sequence in correct order
-        logger.debug(
-            "connection_not_found_different_branches",
-            from_station=from_station.name,
-            to_station=to_station.name,
-            line_name=line.name,
-        )
+        # Connection not found - check if it's backwards travel or different branches
+        # If result has indices but found=False, stations exist but in wrong order (backwards)
+        # If result is None or has no indices, stations not in same route (different branches)
+        if result and result["from_index"] is not None and result["to_index"] is not None:
+            # Backwards travel detected
+            logger.debug(
+                "connection_found_but_wrong_direction",
+                route_name=result["route_name"],
+                direction=result["direction"],
+                from_station=from_station.name,
+                to_station=to_station.name,
+                from_index=result["from_index"],
+                to_index=result["to_index"],
+                line_name=line.name,
+            )
+        else:
+            # Stations not in any common route sequence (different branches)
+            logger.debug(
+                "connection_not_found_different_branches",
+                from_station=from_station.name,
+                to_station=to_station.name,
+                line_name=line.name,
+            )
         return False
 
     async def get_line_routes(self, line_tfl_id: str) -> dict[str, Any] | None:

--- a/backend/tests/test_route_validation_helpers.py
+++ b/backend/tests/test_route_validation_helpers.py
@@ -315,3 +315,26 @@ class TestFindValidConnectionInRoutes:
         assert result is not None
         assert result["found"] is True
         assert result["direction"] == "outbound"
+
+    def test_backwards_travel_detection(self) -> None:
+        """Should return backwards result (found=False with indices) vs None for different branches."""
+        routes: list[RouteVariant] = [
+            {
+                "name": "A → C",
+                "service_type": "Regular",
+                "direction": "inbound",
+                "stations": ["A", "B", "C"],
+            },
+        ]
+
+        # Backwards travel: stations found but wrong order
+        result = find_valid_connection_in_routes("C", "A", routes)
+        assert result is not None  # Result returned (not None)
+        assert result["found"] is False  # But not valid
+        assert result["from_index"] == 2  # Indices populated
+        assert result["to_index"] == 0
+        assert result["route_name"] == "A → C"
+
+        # Different branches: station not in route at all
+        result = find_valid_connection_in_routes("A", "X", routes)
+        assert result is None  # No result (completely not found)

--- a/backend/tests/test_route_validation_helpers.py
+++ b/backend/tests/test_route_validation_helpers.py
@@ -1,0 +1,317 @@
+"""
+Unit tests for route validation pure helper functions.
+
+These tests validate the pure functional helpers in app/helpers/route_validation.py
+without requiring database access or async operations. This provides faster,
+more focused testing of the core validation logic.
+
+Issue #57: Route direction validation refactoring
+"""
+
+from app.helpers.route_validation import (
+    RouteVariant,
+    check_connection_in_route_variant,
+    check_stations_in_route,
+    find_valid_connection_in_routes,
+    validate_station_order,
+)
+
+
+class TestCheckStationsInRoute:
+    """Test check_stations_in_route() - station position lookup."""
+
+    def test_both_stations_found_forward_order(self) -> None:
+        """Should find both stations and return their indices."""
+        stations = ["A", "B", "C", "D"]
+        both_found, from_idx, to_idx = check_stations_in_route("A", "C", stations)
+
+        assert both_found is True
+        assert from_idx == 0
+        assert to_idx == 2
+
+    def test_both_stations_found_backwards_order(self) -> None:
+        """Should find both stations regardless of order (doesn't validate direction)."""
+        stations = ["A", "B", "C", "D"]
+        both_found, from_idx, to_idx = check_stations_in_route("C", "A", stations)
+
+        assert both_found is True
+        assert from_idx == 2
+        assert to_idx == 0
+
+    def test_from_station_not_found(self) -> None:
+        """Should return False if from_station not in sequence."""
+        stations = ["A", "B", "C"]
+        both_found, from_idx, to_idx = check_stations_in_route("X", "B", stations)
+
+        assert both_found is False
+        assert from_idx is None
+        assert to_idx is None
+
+    def test_to_station_not_found(self) -> None:
+        """Should return False if to_station not in sequence."""
+        stations = ["A", "B", "C"]
+        both_found, from_idx, to_idx = check_stations_in_route("A", "X", stations)
+
+        assert both_found is False
+        assert from_idx == 0
+        assert to_idx is None
+
+    def test_empty_station_list(self) -> None:
+        """Should handle empty station list."""
+        stations: list[str] = []
+        both_found, from_idx, to_idx = check_stations_in_route("A", "B", stations)
+
+        assert both_found is False
+        assert from_idx is None
+        assert to_idx is None
+
+    def test_same_station(self) -> None:
+        """Should handle case where from and to are same station."""
+        stations = ["A", "B", "C"]
+        both_found, from_idx, to_idx = check_stations_in_route("B", "B", stations)
+
+        assert both_found is True
+        assert from_idx == 1
+        assert to_idx == 1
+
+
+class TestValidateStationOrder:
+    """Test validate_station_order() - directional validation."""
+
+    def test_forward_direction_valid(self) -> None:
+        """Should return True when to_station comes after from_station."""
+        assert validate_station_order(0, 2) is True
+        assert validate_station_order(1, 3) is True
+        assert validate_station_order(0, 1) is True
+
+    def test_backwards_direction_invalid(self) -> None:
+        """Should return False when to_station comes before from_station."""
+        assert validate_station_order(2, 0) is False
+        assert validate_station_order(3, 1) is False
+        assert validate_station_order(1, 0) is False
+
+    def test_same_position_invalid(self) -> None:
+        """Should return False for same station (no movement)."""
+        assert validate_station_order(1, 1) is False
+        assert validate_station_order(0, 0) is False
+
+
+class TestCheckConnectionInRouteVariant:
+    """Test check_connection_in_route_variant() - single route validation."""
+
+    def test_valid_forward_connection(self) -> None:
+        """Should find valid connection in forward direction."""
+        route: RouteVariant = {
+            "name": "A → D",
+            "service_type": "Regular",
+            "direction": "inbound",
+            "stations": ["A", "B", "C", "D"],
+        }
+
+        result = check_connection_in_route_variant("A", "C", route)
+
+        assert result["found"] is True
+        assert result["from_index"] == 0
+        assert result["to_index"] == 2
+        assert result["route_name"] == "A → D"
+        assert result["direction"] == "inbound"
+
+    def test_backwards_connection_rejected(self) -> None:
+        """Should reject backwards connection (wrong direction)."""
+        route: RouteVariant = {
+            "name": "A → D",
+            "service_type": "Regular",
+            "direction": "inbound",
+            "stations": ["A", "B", "C", "D"],
+        }
+
+        result = check_connection_in_route_variant("C", "A", route)
+
+        assert result["found"] is False
+        assert result["from_index"] == 2  # Found but wrong order
+        assert result["to_index"] == 0
+        assert result["route_name"] == "A → D"
+
+    def test_station_not_in_route(self) -> None:
+        """Should handle station not found in route."""
+        route: RouteVariant = {
+            "name": "A → C",
+            "service_type": "Regular",
+            "direction": "inbound",
+            "stations": ["A", "B", "C"],
+        }
+
+        result = check_connection_in_route_variant("A", "X", route)
+
+        assert result["found"] is False
+        assert result["from_index"] == 0
+        assert result["to_index"] is None
+
+    def test_empty_stations_list(self) -> None:
+        """Should handle route with no stations."""
+        route: RouteVariant = {
+            "name": "Empty Route",
+            "service_type": "Regular",
+            "direction": "inbound",
+            "stations": [],
+        }
+
+        result = check_connection_in_route_variant("A", "B", route)
+
+        assert result["found"] is False
+        assert result["from_index"] is None
+        assert result["to_index"] is None
+
+    def test_missing_stations_key(self) -> None:
+        """Should handle route dict without 'stations' key."""
+        route: RouteVariant = {
+            "name": "No Stations",
+            "service_type": "Regular",
+            "direction": "inbound",
+            "stations": [],  # TypedDict requires this, but test the .get() fallback
+        }
+
+        result = check_connection_in_route_variant("A", "B", route)
+
+        assert result["found"] is False
+
+
+class TestFindValidConnectionInRoutes:
+    """Test find_valid_connection_in_routes() - multi-route search."""
+
+    def test_finds_connection_in_first_route(self) -> None:
+        """Should return connection from first matching route."""
+        routes: list[RouteVariant] = [
+            {
+                "name": "A → D",
+                "service_type": "Regular",
+                "direction": "inbound",
+                "stations": ["A", "B", "C", "D"],
+            },
+            {
+                "name": "D → A",
+                "service_type": "Regular",
+                "direction": "outbound",
+                "stations": ["D", "C", "B", "A"],
+            },
+        ]
+
+        result = find_valid_connection_in_routes("A", "C", routes)
+
+        assert result is not None
+        assert result["found"] is True
+        assert result["route_name"] == "A → D"
+        assert result["from_index"] == 0
+        assert result["to_index"] == 2
+
+    def test_finds_connection_in_second_route_when_first_backwards(self) -> None:
+        """Should skip first route if backwards, find connection in second route."""
+        routes: list[RouteVariant] = [
+            {
+                "name": "A → D",
+                "service_type": "Regular",
+                "direction": "inbound",
+                "stations": ["A", "B", "C", "D"],
+            },
+            {
+                "name": "D → A",
+                "service_type": "Regular",
+                "direction": "outbound",
+                "stations": ["D", "C", "B", "A"],
+            },
+        ]
+
+        # C → A is backwards on first route, forward on second route
+        result = find_valid_connection_in_routes("C", "A", routes)
+
+        assert result is not None
+        assert result["found"] is True
+        assert result["route_name"] == "D → A"
+        assert result["from_index"] == 1
+        assert result["to_index"] == 3
+
+    def test_no_valid_connection_in_any_route(self) -> None:
+        """Should return None if no valid connection found."""
+        routes: list[RouteVariant] = [
+            {
+                "name": "A → C",
+                "service_type": "Regular",
+                "direction": "inbound",
+                "stations": ["A", "B", "C"],
+            },
+            {
+                "name": "D → F",
+                "service_type": "Regular",
+                "direction": "inbound",
+                "stations": ["D", "E", "F"],
+            },
+        ]
+
+        # A and X not in same route
+        result = find_valid_connection_in_routes("A", "X", routes)
+
+        assert result is None
+
+    def test_branches_on_same_line(self) -> None:
+        """Should correctly handle branched lines (different routes for different branches)."""
+        routes: list[RouteVariant] = [
+            {
+                "name": "Edgware → Morden via Bank",
+                "service_type": "Regular",
+                "direction": "inbound",
+                "stations": ["EGW", "CMD", "BNK", "MDN"],
+            },
+            {
+                "name": "Edgware → Morden via Charing Cross",
+                "service_type": "Regular",
+                "direction": "inbound",
+                "stations": ["EGW", "CMD", "CHX", "MDN"],
+            },
+        ]
+
+        # Bank → Charing Cross should fail (different branches)
+        result = find_valid_connection_in_routes("BNK", "CHX", routes)
+        assert result is None
+
+        # Camden → Bank should succeed (same branch)
+        result = find_valid_connection_in_routes("CMD", "BNK", routes)
+        assert result is not None
+        assert result["found"] is True
+        assert result["route_name"] == "Edgware → Morden via Bank"
+
+    def test_empty_routes_list(self) -> None:
+        """Should handle empty routes list."""
+        routes: list[RouteVariant] = []
+
+        result = find_valid_connection_in_routes("A", "B", routes)
+
+        assert result is None
+
+    def test_bidirectional_line_support(self) -> None:
+        """Should support bidirectional travel via separate route variants."""
+        routes: list[RouteVariant] = [
+            {
+                "name": "Brixton → Walthamstow",
+                "service_type": "Regular",
+                "direction": "inbound",
+                "stations": ["BXN", "STK", "WTH"],
+            },
+            {
+                "name": "Walthamstow → Brixton",
+                "service_type": "Regular",
+                "direction": "outbound",
+                "stations": ["WTH", "STK", "BXN"],
+            },
+        ]
+
+        # Forward direction (matches first route)
+        result = find_valid_connection_in_routes("BXN", "WTH", routes)
+        assert result is not None
+        assert result["found"] is True
+        assert result["direction"] == "inbound"
+
+        # Reverse direction (matches second route)
+        result = find_valid_connection_in_routes("WTH", "BXN", routes)
+        assert result is not None
+        assert result["found"] is True
+        assert result["direction"] == "outbound"

--- a/backend/tests/test_tfl_service.py
+++ b/backend/tests/test_tfl_service.py
@@ -7197,3 +7197,367 @@ class TestResolveStationOrHub:
         assert isinstance(result, Station)
         assert result.tfl_id == "940GZZLUSVS"  # Station's tfl_id, not hub code
         assert result.hub_naptan_code == "HUBSVS"
+
+
+# Tests for Issue #57: Route Direction Validation
+
+
+async def test_validate_route_backwards_direction_fails(
+    tfl_service: TfLService,
+    db_session: AsyncSession,
+) -> None:
+    """Test that backwards routes are rejected (Issue #57).
+
+    Example: Piccadilly Circus → Arsenal should fail when the route sequence
+    goes Arsenal → Piccadilly Circus.
+    """
+    # Create Piccadilly line with route sequence: Arsenal → Piccadilly Circus
+    line = Line(
+        tfl_id="piccadilly",
+        name="Piccadilly",
+        color="#0019A8",
+        last_updated=datetime.now(UTC),
+        routes={
+            "routes": [
+                {
+                    "name": "Cockfosters → Heathrow",
+                    "service_type": "Regular",
+                    "direction": "inbound",
+                    "stations": ["940GZZLUASL", "940GZZLUPCC"],  # Arsenal, then Piccadilly Circus
+                }
+            ]
+        },
+    )
+    db_session.add(line)
+    await db_session.flush()
+
+    arsenal = Station(
+        tfl_id="940GZZLUASL",
+        name="Arsenal Underground Station",
+        latitude=51.5586,
+        longitude=-0.1059,
+        lines=["piccadilly"],
+        last_updated=datetime.now(UTC),
+    )
+    piccadilly_circus = Station(
+        tfl_id="940GZZLUPCC",
+        name="Piccadilly Circus Underground Station",
+        latitude=51.5099,
+        longitude=-0.1342,
+        lines=["piccadilly"],
+        last_updated=datetime.now(UTC),
+    )
+    db_session.add_all([arsenal, piccadilly_circus])
+    await db_session.commit()
+
+    # Try to validate BACKWARDS route: Piccadilly Circus → Arsenal
+    segments = [
+        RouteSegmentRequest(station_tfl_id="940GZZLUPCC", line_tfl_id="piccadilly"),
+        RouteSegmentRequest(station_tfl_id="940GZZLUASL", line_tfl_id=None),
+    ]
+
+    is_valid, message, invalid_segment = await tfl_service.validate_route(segments)
+
+    # Should fail - this is backwards travel
+    assert is_valid is False
+    # The error message mentions "different branches" but the root cause is backwards travel
+    assert "not connected" in message.lower() or "different branches" in message.lower() or "invalid" in message.lower()
+    assert invalid_segment == 0  # First segment fails because connection to second segment is backwards
+
+
+async def test_validate_route_forward_direction_succeeds(
+    tfl_service: TfLService,
+    db_session: AsyncSession,
+) -> None:
+    """Test that forward routes are accepted.
+
+    Example: Arsenal → Piccadilly Circus should succeed when the route sequence
+    goes Arsenal → Piccadilly Circus.
+    """
+    # Create Piccadilly line with route sequence: Arsenal → Piccadilly Circus
+    line = Line(
+        tfl_id="piccadilly",
+        name="Piccadilly",
+        color="#0019A8",
+        last_updated=datetime.now(UTC),
+        routes={
+            "routes": [
+                {
+                    "name": "Cockfosters → Heathrow",
+                    "service_type": "Regular",
+                    "direction": "inbound",
+                    "stations": ["940GZZLUASL", "940GZZLUPCC"],  # Arsenal, then Piccadilly Circus
+                }
+            ]
+        },
+    )
+    db_session.add(line)
+    await db_session.flush()
+
+    arsenal = Station(
+        tfl_id="940GZZLUASL",
+        name="Arsenal Underground Station",
+        latitude=51.5586,
+        longitude=-0.1059,
+        lines=["piccadilly"],
+        last_updated=datetime.now(UTC),
+    )
+    piccadilly_circus = Station(
+        tfl_id="940GZZLUPCC",
+        name="Piccadilly Circus Underground Station",
+        latitude=51.5099,
+        longitude=-0.1342,
+        lines=["piccadilly"],
+        last_updated=datetime.now(UTC),
+    )
+    db_session.add_all([arsenal, piccadilly_circus])
+    await db_session.commit()
+
+    # Validate FORWARD route: Arsenal → Piccadilly Circus
+    segments = [
+        RouteSegmentRequest(station_tfl_id="940GZZLUASL", line_tfl_id="piccadilly"),
+        RouteSegmentRequest(station_tfl_id="940GZZLUPCC", line_tfl_id=None),
+    ]
+
+    is_valid, message, invalid_segment = await tfl_service.validate_route(segments)
+
+    # Should succeed - this is forward travel
+    assert is_valid is True
+    assert "valid" in message.lower()
+    assert invalid_segment is None
+
+
+async def test_validate_route_bidirectional_both_work(
+    tfl_service: TfLService,
+    db_session: AsyncSession,
+) -> None:
+    """Test that bidirectional lines work correctly with both inbound and outbound routes.
+
+    A typical line has both directions represented as separate route variants.
+    Both A→B and B→A should validate successfully.
+    """
+    # Create Victoria line with BOTH directions
+    line = Line(
+        tfl_id="victoria",
+        name="Victoria",
+        color="#0019A8",
+        last_updated=datetime.now(UTC),
+        routes={
+            "routes": [
+                {
+                    "name": "Brixton → Walthamstow Central",
+                    "service_type": "Regular",
+                    "direction": "inbound",
+                    "stations": ["940GZZLUBXN", "940GZZLUSTK", "940GZZLUWTH"],  # Brixton → Stockwell → Walthamstow
+                },
+                {
+                    "name": "Walthamstow Central → Brixton",
+                    "service_type": "Regular",
+                    "direction": "outbound",
+                    "stations": ["940GZZLUWTH", "940GZZLUSTK", "940GZZLUBXN"],  # Walthamstow → Stockwell → Brixton
+                },
+            ]
+        },
+    )
+    db_session.add(line)
+    await db_session.flush()
+
+    brixton = Station(
+        tfl_id="940GZZLUBXN",
+        name="Brixton Underground Station",
+        latitude=51.4623,
+        longitude=-0.1145,
+        lines=["victoria"],
+        last_updated=datetime.now(UTC),
+    )
+    stockwell = Station(
+        tfl_id="940GZZLUSTK",
+        name="Stockwell Underground Station",
+        latitude=51.4723,
+        longitude=-0.1230,
+        lines=["victoria"],
+        last_updated=datetime.now(UTC),
+    )
+    walthamstow = Station(
+        tfl_id="940GZZLUWTH",
+        name="Walthamstow Central Underground Station",
+        latitude=51.5831,
+        longitude=-0.0197,
+        lines=["victoria"],
+        last_updated=datetime.now(UTC),
+    )
+    db_session.add_all([brixton, stockwell, walthamstow])
+    await db_session.commit()
+
+    # Test direction 1: Brixton → Walthamstow (should match inbound route)
+    segments_inbound = [
+        RouteSegmentRequest(station_tfl_id="940GZZLUBXN", line_tfl_id="victoria"),
+        RouteSegmentRequest(station_tfl_id="940GZZLUSTK", line_tfl_id="victoria"),
+        RouteSegmentRequest(station_tfl_id="940GZZLUWTH", line_tfl_id=None),
+    ]
+
+    is_valid, message, _ = await tfl_service.validate_route(segments_inbound)
+    assert is_valid is True
+    assert "valid" in message.lower()
+
+    # Test direction 2: Walthamstow → Brixton (should match outbound route)
+    segments_outbound = [
+        RouteSegmentRequest(station_tfl_id="940GZZLUWTH", line_tfl_id="victoria"),
+        RouteSegmentRequest(station_tfl_id="940GZZLUSTK", line_tfl_id="victoria"),
+        RouteSegmentRequest(station_tfl_id="940GZZLUBXN", line_tfl_id=None),
+    ]
+
+    is_valid, message, _ = await tfl_service.validate_route(segments_outbound)
+    assert is_valid is True
+    assert "valid" in message.lower()
+
+
+async def test_validate_route_branches_still_blocked(
+    tfl_service: TfLService,
+    db_session: AsyncSession,
+) -> None:
+    """Test that cross-branch validation still works correctly (shouldn't regress issue #39).
+
+    Northern line has branches. Bank → Charing Cross should fail because they're
+    on different branches, even with directional validation.
+    """
+    # Create Northern line with two branches
+    line = Line(
+        tfl_id="northern",
+        name="Northern",
+        color="#000000",
+        last_updated=datetime.now(UTC),
+        routes={
+            "routes": [
+                {
+                    "name": "Edgware → Morden via Bank",
+                    "service_type": "Regular",
+                    "direction": "inbound",
+                    "stations": ["940GZZLUEGW", "940GZZLUCND", "940GZZLUBNK", "940GZZLUMDN"],
+                },
+                {
+                    "name": "Edgware → Morden via Charing Cross",
+                    "service_type": "Regular",
+                    "direction": "inbound",
+                    "stations": ["940GZZLUEGW", "940GZZLUCND", "940GZZLUCHX", "940GZZLUMDN"],
+                },
+            ]
+        },
+    )
+    db_session.add(line)
+    await db_session.flush()
+
+    edgware = Station(
+        tfl_id="940GZZLUEGW",
+        name="Edgware Underground Station",
+        latitude=51.6137,
+        longitude=-0.2752,
+        lines=["northern"],
+        last_updated=datetime.now(UTC),
+    )
+    camden_town = Station(
+        tfl_id="940GZZLUCND",
+        name="Camden Town Underground Station",
+        latitude=51.5392,
+        longitude=-0.1426,
+        lines=["northern"],
+        last_updated=datetime.now(UTC),
+    )
+    bank = Station(
+        tfl_id="940GZZLUBNK",
+        name="Bank Underground Station",
+        latitude=51.5133,
+        longitude=-0.0886,
+        lines=["northern"],
+        last_updated=datetime.now(UTC),
+    )
+    charing_cross = Station(
+        tfl_id="940GZZLUCHX",
+        name="Charing Cross Underground Station",
+        latitude=51.5080,
+        longitude=-0.1247,
+        lines=["northern"],
+        last_updated=datetime.now(UTC),
+    )
+    morden = Station(
+        tfl_id="940GZZLUMDN",
+        name="Morden Underground Station",
+        latitude=51.4022,
+        longitude=-0.1949,
+        lines=["northern"],
+        last_updated=datetime.now(UTC),
+    )
+    db_session.add_all([edgware, camden_town, bank, charing_cross, morden])
+    await db_session.commit()
+
+    # Try to go Bank → Charing Cross (different branches, should fail)
+    segments = [
+        RouteSegmentRequest(station_tfl_id="940GZZLUBNK", line_tfl_id="northern"),
+        RouteSegmentRequest(station_tfl_id="940GZZLUCHX", line_tfl_id=None),
+    ]
+
+    is_valid, message, _ = await tfl_service.validate_route(segments)
+
+    # Should fail - these stations are on different branches
+    assert is_valid is False
+    assert "not connected" in message.lower() or "different branches" in message.lower() or "invalid" in message.lower()
+
+
+async def test_validate_route_same_branch_with_direction(
+    tfl_service: TfLService,
+    db_session: AsyncSession,
+) -> None:
+    """Test that same-branch routes work with directional validation.
+
+    Camden Town → Bank on Northern line via Bank branch should succeed.
+    """
+    # Create Northern line with Bank branch
+    line = Line(
+        tfl_id="northern",
+        name="Northern",
+        color="#000000",
+        last_updated=datetime.now(UTC),
+        routes={
+            "routes": [
+                {
+                    "name": "Edgware → Morden via Bank",
+                    "service_type": "Regular",
+                    "direction": "inbound",
+                    "stations": ["940GZZLUEGW", "940GZZLUCND", "940GZZLUBNK", "940GZZLUMDN"],
+                },
+            ]
+        },
+    )
+    db_session.add(line)
+    await db_session.flush()
+
+    camden_town = Station(
+        tfl_id="940GZZLUCND",
+        name="Camden Town Underground Station",
+        latitude=51.5392,
+        longitude=-0.1426,
+        lines=["northern"],
+        last_updated=datetime.now(UTC),
+    )
+    bank = Station(
+        tfl_id="940GZZLUBNK",
+        name="Bank Underground Station",
+        latitude=51.5133,
+        longitude=-0.0886,
+        lines=["northern"],
+        last_updated=datetime.now(UTC),
+    )
+    db_session.add_all([camden_town, bank])
+    await db_session.commit()
+
+    # Camden Town → Bank (forward direction on Bank branch)
+    segments = [
+        RouteSegmentRequest(station_tfl_id="940GZZLUCND", line_tfl_id="northern"),
+        RouteSegmentRequest(station_tfl_id="940GZZLUBNK", line_tfl_id=None),
+    ]
+
+    is_valid, message, _ = await tfl_service.validate_route(segments)
+
+    # Should succeed - same branch, correct direction
+    assert is_valid is True
+    assert "valid" in message.lower()


### PR DESCRIPTION
fixes #57

## Summary by Sourcery

Implement directional validation for route segments in TfLService by introducing pure helper functions to enforce station order, refactor the connection check logic to detect backwards travel and cross-branch issues, add comprehensive tests, and update documentation to reflect these changes.

New Features:
- Reject backwards travel when validating route segments
- Automatically support bidirectional travel by matching inbound/outbound route variants

Bug Fixes:
- Prevent invalid backwards segment sequences (fixes #57)

Enhancements:
- Refactor `_check_connection` to use pure helper `find_valid_connection_in_routes` for order-aware validation
- Leverage TfL API route sequence JSON for directional validation instead of graph-based lookup

Documentation:
- Update external APIs ADR to include directional validation changes and reference Issue #57

Tests:
- Add integration tests for forward, backward, bidirectional, branch-specific, and same-branch route validation in `test_tfl_service.py`
- Add unit tests for row-validation helper functions in `test_route_validation_helpers.py`