### PR TITLE
Enhance TfL station fetching logic with validation and error handling

### DIFF
--- a/backend/app/api/tfl.py
+++ b/backend/app/api/tfl.py
@@ -68,8 +68,8 @@ async def get_stations(
     """
     Get tube stations, optionally filtered by line and/or deduplicated by hub.
 
-    Returns cached data from Redis or fetches from TfL API if cache expired.
-    Data is cached for 24 hours (or TTL specified by TfL API).
+    Returns cached data from Redis or database. Data is cached for 24 hours.
+    Stations are populated by the admin-controlled /admin/tfl/build-graph endpoint.
 
     When deduplicated=true, stations that share a hub_naptan_code are grouped into
     a single representative station with:
@@ -87,7 +87,9 @@ async def get_stations(
         List of stations with location and line information
 
     Raises:
-        HTTPException: 503 if TfL API is unavailable
+        HTTPException: 503 if TfL data not initialized (run /admin/tfl/build-graph)
+        HTTPException: 404 if line_id provided but line doesn't exist
+        HTTPException: 404 if line exists but no stations found
 
     Examples:
         GET /tfl/stations  # All stations including hub children

--- a/backend/app/helpers/station_fetching.py
+++ b/backend/app/helpers/station_fetching.py
@@ -1,0 +1,169 @@
+"""
+Station fetching helpers for validation and filtering logic.
+
+These pure functions enable testable, functional-style station fetching validation
+without requiring database access. They are used by TfLService.fetch_stations()
+to reduce complexity while maintaining security validation from Issue #38.
+
+Issue #38: Prevent API quota exhaustion with database validation
+"""
+
+from __future__ import annotations
+
+from app.models.tfl import Station
+
+
+def build_station_cache_key(line_tfl_id: str | None) -> str:
+    """
+    Build Redis cache key for station queries.
+
+    Pure function for consistent cache key generation.
+
+    Args:
+        line_tfl_id: Optional line ID for filtering
+
+    Returns:
+        Redis cache key string
+
+    Examples:
+        >>> build_station_cache_key("victoria")
+        'stations:line:victoria'
+
+        >>> build_station_cache_key(None)
+        'stations:all'
+    """
+    return f"stations:line:{line_tfl_id}" if line_tfl_id else "stations:all"
+
+
+def is_database_initialized(station_count: int) -> bool:
+    """
+    Check if TfL database has been initialized.
+
+    Pure function - determines if graph building has occurred by checking
+    if any stations exist in the database.
+
+    Args:
+        station_count: Total number of stations in database
+
+    Returns:
+        True if database initialized (count > 0), False otherwise
+
+    Examples:
+        >>> is_database_initialized(100)
+        True
+
+        >>> is_database_initialized(0)
+        False
+    """
+    return station_count > 0
+
+
+def filter_stations_by_line_tfl_id(
+    stations: list[Station],
+    line_tfl_id: str,
+) -> list[Station]:
+    """
+    Filter stations that serve the specified line.
+
+    Pure function for filtering stations by line TfL ID. Needed because
+    Station.lines is JSON type (not JSONB), so containment operators don't
+    work well in SQL. This allows filtering in Python after fetching.
+
+    Args:
+        stations: List of Station objects to filter
+        line_tfl_id: TfL line ID to filter by (e.g., 'victoria', 'northern')
+
+    Returns:
+        List of stations that have line_tfl_id in their lines array
+
+    Examples:
+        >>> station1 = Station(tfl_id="ABC", lines=["victoria", "northern"])
+        >>> station2 = Station(tfl_id="DEF", lines=["piccadilly"])
+        >>> filter_stations_by_line_tfl_id([station1, station2], "victoria")
+        [station1]
+
+        >>> filter_stations_by_line_tfl_id([station2], "victoria")
+        []
+    """
+    return [s for s in stations if line_tfl_id in s.lines]
+
+
+def validate_stations_exist_for_line(
+    stations: list[Station],
+    line_tfl_id: str,
+) -> None:
+    """
+    Validate that at least one station exists for line.
+
+    Pure validation function that raises domain exception if validation fails.
+    This is a security validation to ensure users only query valid line/station
+    combinations from the database.
+
+    Args:
+        stations: Filtered list of stations
+        line_tfl_id: Line being validated
+
+    Raises:
+        NoStationsForLineError: If stations list is empty
+
+    Examples:
+        >>> validate_stations_exist_for_line([], "victoria")
+        Traceback (most recent call last):
+            ...
+        NoStationsForLineError: No stations found for line 'victoria'.
+
+        >>> station = Station(tfl_id="ABC", lines=["victoria"])
+        >>> validate_stations_exist_for_line([station], "victoria")
+        # No exception raised
+    """
+    if not stations:
+        raise NoStationsForLineError(line_tfl_id)
+
+
+# Custom domain exceptions
+
+
+class StationFetchError(Exception):
+    """Base exception for station fetching errors."""
+
+    pass
+
+
+class DatabaseNotInitializedError(StationFetchError):
+    """
+    Raised when TfL database hasn't been initialized.
+
+    This indicates that the /admin/tfl/build-graph endpoint needs to be run
+    to populate the station and line data from the TfL API.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "TfL data not initialized. Please contact administrator to run /admin/tfl/build-graph endpoint."
+        )
+
+
+class LineNotFoundError(StationFetchError):
+    """
+    Raised when requested line doesn't exist in database.
+
+    This is a security validation to prevent users from querying arbitrary
+    line IDs that might trigger TfL API calls.
+    """
+
+    def __init__(self, line_tfl_id: str) -> None:
+        self.line_tfl_id = line_tfl_id
+        super().__init__(f"Line '{line_tfl_id}' not found.")
+
+
+class NoStationsForLineError(StationFetchError):
+    """
+    Raised when line exists but has no stations.
+
+    This should be rare in practice, but provides better error messaging
+    than returning an empty list.
+    """
+
+    def __init__(self, line_tfl_id: str) -> None:
+        self.line_tfl_id = line_tfl_id
+        super().__init__(f"No stations found for line '{line_tfl_id}'.")

--- a/backend/app/helpers/station_fetching.py
+++ b/backend/app/helpers/station_fetching.py
@@ -69,6 +69,9 @@ def filter_stations_by_line_tfl_id(
     Station.lines is JSON type (not JSONB), so containment operators don't
     work well in SQL. This allows filtering in Python after fetching.
 
+    Defensive: Handles cases where Station.lines might not be a list (e.g.,
+    legacy data, manual DB manipulation, or edge cases during migrations).
+
     Args:
         stations: List of Station objects to filter
         line_tfl_id: TfL line ID to filter by (e.g., 'victoria', 'northern')
@@ -85,7 +88,7 @@ def filter_stations_by_line_tfl_id(
         >>> filter_stations_by_line_tfl_id([station2], "victoria")
         []
     """
-    return [s for s in stations if line_tfl_id in s.lines]
+    return [s for s in stations if isinstance(s.lines, list) and line_tfl_id in s.lines]
 
 
 def validate_stations_exist_for_line(

--- a/backend/app/services/tfl_service.py
+++ b/backend/app/services/tfl_service.py
@@ -830,15 +830,13 @@ class TfLService:
 
                 # Validate at least one station found
                 validate_stations_exist_for_line(stations, line_tfl_id)
-
-                ttl = DEFAULT_STATIONS_CACHE_TTL
             else:
                 # Fetch all stations from database
                 result = await self.db.execute(select(Station))
                 stations = list(result.scalars().all())
-                ttl = DEFAULT_STATIONS_CACHE_TTL
 
             # Cache the results
+            ttl = DEFAULT_STATIONS_CACHE_TTL
             await self.cache.set(cache_key, stations, ttl=ttl)
             logger.info("stations_fetched_and_cached", line_tfl_id=line_tfl_id, count=len(stations), ttl=ttl)
             return stations

--- a/backend/tests/helpers/test_station_fetching.py
+++ b/backend/tests/helpers/test_station_fetching.py
@@ -1,0 +1,292 @@
+"""
+Unit tests for station fetching helper functions.
+
+Tests pure validation and filtering functions used by TfLService.fetch_stations().
+These tests don't require database mocking since all functions are pure.
+"""
+
+from uuid import uuid4
+
+import pytest
+from app.helpers.station_fetching import (
+    DatabaseNotInitializedError,
+    LineNotFoundError,
+    NoStationsForLineError,
+    StationFetchError,
+    build_station_cache_key,
+    filter_stations_by_line_tfl_id,
+    is_database_initialized,
+    validate_stations_exist_for_line,
+)
+from app.models.tfl import Station
+
+
+class TestBuildStationCacheKey:
+    """Tests for build_station_cache_key()."""
+
+    def test_with_line_id(self):
+        """Should build cache key with line ID."""
+        result = build_station_cache_key("victoria")
+        assert result == "stations:line:victoria"
+
+    def test_without_line_id(self):
+        """Should build cache key for all stations."""
+        result = build_station_cache_key(None)
+        assert result == "stations:all"
+
+    def test_different_lines_produce_different_keys(self):
+        """Different lines should produce different cache keys."""
+        victoria = build_station_cache_key("victoria")
+        northern = build_station_cache_key("northern")
+        assert victoria != northern
+        assert victoria == "stations:line:victoria"
+        assert northern == "stations:line:northern"
+
+
+class TestIsDatabaseInitialized:
+    """Tests for is_database_initialized()."""
+
+    def test_with_stations(self):
+        """Should return True when stations exist."""
+        assert is_database_initialized(100) is True
+        assert is_database_initialized(1) is True
+
+    def test_without_stations(self):
+        """Should return False when no stations exist."""
+        assert is_database_initialized(0) is False
+
+    def test_negative_count(self):
+        """Should handle negative counts (edge case)."""
+        # In practice this shouldn't happen, but pure function should handle it
+        assert is_database_initialized(-1) is False
+
+
+class TestFilterStationsByLineTflId:
+    """Tests for filter_stations_by_line_tfl_id()."""
+
+    def test_single_match(self):
+        """Should filter stations serving the specified line."""
+        station1 = Station(
+            id=uuid4(),
+            tfl_id="ABC",
+            name="Station A",
+            latitude=51.5,
+            longitude=-0.1,
+            lines=["victoria", "northern"],
+        )
+        station2 = Station(
+            id=uuid4(),
+            tfl_id="DEF",
+            name="Station B",
+            latitude=51.5,
+            longitude=-0.1,
+            lines=["piccadilly"],
+        )
+
+        result = filter_stations_by_line_tfl_id([station1, station2], "victoria")
+
+        assert len(result) == 1
+        assert result[0].tfl_id == "ABC"
+
+    def test_multiple_matches(self):
+        """Should return all stations serving the line."""
+        station1 = Station(
+            id=uuid4(),
+            tfl_id="ABC",
+            name="Station A",
+            latitude=51.5,
+            longitude=-0.1,
+            lines=["victoria", "northern"],
+        )
+        station2 = Station(
+            id=uuid4(),
+            tfl_id="DEF",
+            name="Station B",
+            latitude=51.5,
+            longitude=-0.1,
+            lines=["victoria"],
+        )
+        station3 = Station(
+            id=uuid4(),
+            tfl_id="GHI",
+            name="Station C",
+            latitude=51.5,
+            longitude=-0.1,
+            lines=["piccadilly"],
+        )
+
+        result = filter_stations_by_line_tfl_id([station1, station2, station3], "victoria")
+
+        assert len(result) == 2
+        assert {s.tfl_id for s in result} == {"ABC", "DEF"}
+
+    def test_no_matches(self):
+        """Should return empty list when no stations serve the line."""
+        station1 = Station(
+            id=uuid4(),
+            tfl_id="ABC",
+            name="Station A",
+            latitude=51.5,
+            longitude=-0.1,
+            lines=["piccadilly"],
+        )
+        station2 = Station(
+            id=uuid4(),
+            tfl_id="DEF",
+            name="Station B",
+            latitude=51.5,
+            longitude=-0.1,
+            lines=["northern"],
+        )
+
+        result = filter_stations_by_line_tfl_id([station1, station2], "victoria")
+
+        assert result == []
+
+    def test_empty_input_list(self):
+        """Should return empty list when input is empty."""
+        result = filter_stations_by_line_tfl_id([], "victoria")
+        assert result == []
+
+    def test_station_with_empty_lines(self):
+        """Should handle stations with no lines."""
+        station = Station(
+            id=uuid4(),
+            tfl_id="ABC",
+            name="Station A",
+            latitude=51.5,
+            longitude=-0.1,
+            lines=[],
+        )
+
+        result = filter_stations_by_line_tfl_id([station], "victoria")
+
+        assert result == []
+
+
+class TestValidateStationsExistForLine:
+    """Tests for validate_stations_exist_for_line()."""
+
+    def test_with_stations(self):
+        """Should not raise when stations exist."""
+        station = Station(
+            id=uuid4(),
+            tfl_id="ABC",
+            name="Station A",
+            latitude=51.5,
+            longitude=-0.1,
+            lines=["victoria"],
+        )
+
+        # Should not raise
+        validate_stations_exist_for_line([station], "victoria")
+
+    def test_with_multiple_stations(self):
+        """Should not raise when multiple stations exist."""
+        stations = [
+            Station(
+                id=uuid4(),
+                tfl_id="ABC",
+                name="Station A",
+                latitude=51.5,
+                longitude=-0.1,
+                lines=["victoria"],
+            ),
+            Station(
+                id=uuid4(),
+                tfl_id="DEF",
+                name="Station B",
+                latitude=51.5,
+                longitude=-0.1,
+                lines=["victoria"],
+            ),
+        ]
+
+        # Should not raise
+        validate_stations_exist_for_line(stations, "victoria")
+
+    def test_with_empty_list(self):
+        """Should raise NoStationsForLineError when no stations provided."""
+        with pytest.raises(NoStationsForLineError) as exc_info:
+            validate_stations_exist_for_line([], "victoria")
+
+        assert exc_info.value.line_tfl_id == "victoria"
+        assert "victoria" in str(exc_info.value)
+
+    def test_error_message_format(self):
+        """Error message should include line ID."""
+        with pytest.raises(NoStationsForLineError) as exc_info:
+            validate_stations_exist_for_line([], "northern")
+
+        error_message = str(exc_info.value)
+        assert "northern" in error_message
+        assert "No stations found" in error_message
+
+
+class TestDatabaseNotInitializedError:
+    """Tests for DatabaseNotInitializedError exception."""
+
+    def test_error_message(self):
+        """Error should have helpful message about initializing database."""
+        error = DatabaseNotInitializedError()
+
+        error_message = str(error)
+        assert "TfL data not initialized" in error_message
+        assert "/admin/tfl/build-graph" in error_message
+
+    def test_is_station_fetch_error(self):
+        """Should be instance of base StationFetchError."""
+        error = DatabaseNotInitializedError()
+        assert isinstance(error, StationFetchError)
+
+
+class TestLineNotFoundError:
+    """Tests for LineNotFoundError exception."""
+
+    def test_error_message(self):
+        """Error should include line ID in message."""
+        error = LineNotFoundError("victoria")
+
+        assert error.line_tfl_id == "victoria"
+        assert "victoria" in str(error)
+        assert "not found" in str(error)
+
+    def test_different_line_ids(self):
+        """Should work with different line IDs."""
+        victoria_error = LineNotFoundError("victoria")
+        northern_error = LineNotFoundError("northern")
+
+        assert victoria_error.line_tfl_id == "victoria"
+        assert northern_error.line_tfl_id == "northern"
+        assert "victoria" in str(victoria_error)
+        assert "northern" in str(northern_error)
+
+    def test_is_station_fetch_error(self):
+        """Should be instance of base StationFetchError."""
+        error = LineNotFoundError("victoria")
+        assert isinstance(error, StationFetchError)
+
+
+class TestNoStationsForLineError:
+    """Tests for NoStationsForLineError exception."""
+
+    def test_error_message(self):
+        """Error should include line ID in message."""
+        error = NoStationsForLineError("victoria")
+
+        assert error.line_tfl_id == "victoria"
+        assert "victoria" in str(error)
+        assert "No stations found" in str(error)
+
+    def test_different_line_ids(self):
+        """Should work with different line IDs."""
+        victoria_error = NoStationsForLineError("victoria")
+        northern_error = NoStationsForLineError("northern")
+
+        assert victoria_error.line_tfl_id == "victoria"
+        assert northern_error.line_tfl_id == "northern"
+
+    def test_is_station_fetch_error(self):
+        """Should be instance of base StationFetchError."""
+        error = NoStationsForLineError("victoria")
+        assert isinstance(error, StationFetchError)

--- a/backend/tests/test_tfl_integration.py
+++ b/backend/tests/test_tfl_integration.py
@@ -57,7 +57,9 @@ async def test_integration_fetch_stations(db_session: AsyncSession, settings_fix
     test_line = lines[0]
 
     # Call real API to fetch stations for this line
-    stations = await service.fetch_stations(line_tfl_id=test_line.tfl_id, use_cache=False)
+    stations = await service.fetch_stations(
+        line_tfl_id=test_line.tfl_id, use_cache=False, skip_database_validation=True
+    )
 
     # Basic assertions
     assert len(stations) > 0, f"Should fetch at least one station for {test_line.name} line"
@@ -187,7 +189,7 @@ async def test_integration_fetch_station_disruptions(db_session: AsyncSession, s
     lines = await service.fetch_lines(use_cache=False)
     if len(lines) > 0:
         # Fetch stations for at least one line to populate the database
-        await service.fetch_stations(line_tfl_id=lines[0].tfl_id, use_cache=False)
+        await service.fetch_stations(line_tfl_id=lines[0].tfl_id, use_cache=False, skip_database_validation=True)
 
     # Call real API
     disruptions = await service.fetch_station_disruptions(use_cache=False)

--- a/backend/tests/test_tfl_service.py
+++ b/backend/tests/test_tfl_service.py
@@ -1380,6 +1380,112 @@ async def test_fetch_stations_all(
     assert "940GZZLUOXC" in tfl_ids
 
 
+async def test_fetch_stations_with_no_data_returns_503(
+    tfl_service: TfLService,
+    db_session: AsyncSession,
+) -> None:
+    """Test fetching stations when database is empty returns 503."""
+    # Execute - no stations in database at all
+    with pytest.raises(HTTPException) as exc_info:
+        await tfl_service.fetch_stations(line_tfl_id="victoria", use_cache=False)
+
+    # Verify 503 error
+    assert exc_info.value.status_code == 503
+    assert "not initialized" in exc_info.value.detail.lower()
+
+
+async def test_fetch_stations_invalid_line_returns_404(
+    tfl_service: TfLService,
+    db_session: AsyncSession,
+) -> None:
+    """Test fetching stations with invalid line_id returns 404."""
+    # Add a station to database (so database is initialized)
+    station = Station(
+        tfl_id="940GZZLUKSX",
+        name="King's Cross",
+        latitude=51.5308,
+        longitude=-0.1238,
+        lines=["victoria"],
+        last_updated=datetime.now(UTC),
+    )
+    db_session.add(station)
+    await db_session.commit()
+
+    # Execute - try to fetch with line that doesn't exist in Line table
+    with pytest.raises(HTTPException) as exc_info:
+        await tfl_service.fetch_stations(line_tfl_id="invalid-line", use_cache=False)
+
+    # Verify 404 error
+    assert exc_info.value.status_code == 404
+    assert "not found" in exc_info.value.detail.lower()
+    assert "invalid-line" in exc_info.value.detail
+
+
+async def test_fetch_stations_valid_line_no_stations_returns_404(
+    tfl_service: TfLService,
+    db_session: AsyncSession,
+) -> None:
+    """Test fetching stations when line exists but has no stations returns 404."""
+    # Add a line to database
+    line = Line(
+        tfl_id="jubilee",
+        name="Jubilee",
+        mode="tube",
+        last_updated=datetime.now(UTC),
+    )
+    db_session.add(line)
+
+    # Add a station for a different line (so database has stations)
+    station = Station(
+        tfl_id="940GZZLUKSX",
+        name="King's Cross",
+        latitude=51.5308,
+        longitude=-0.1238,
+        lines=["victoria"],  # Not jubilee
+        last_updated=datetime.now(UTC),
+    )
+    db_session.add(station)
+    await db_session.commit()
+
+    # Execute - line exists but no stations on it
+    with pytest.raises(HTTPException) as exc_info:
+        await tfl_service.fetch_stations(line_tfl_id="jubilee", use_cache=False)
+
+    # Verify 404 error
+    assert exc_info.value.status_code == 404
+    assert "no stations found" in exc_info.value.detail.lower()
+    assert "jubilee" in exc_info.value.detail
+
+
+async def test_fetch_stations_skip_validation_calls_api(
+    tfl_service: TfLService,
+    db_session: AsyncSession,
+) -> None:
+    """Test skip_database_validation=True allows TfL API calls even with empty database."""
+    with freeze_time("2025-01-01 12:00:00"):
+        # Mock TfL API response
+        mock_stops = [
+            create_mock_place(id="940GZZLUVIC", common_name="Victoria", lat=51.4965, lon=-0.1447),
+        ]
+
+        # Execute with skip_database_validation=True (used during graph building)
+        stations = await assert_fetch_from_api(
+            tfl_service=tfl_service,
+            method_callable=lambda: tfl_service.fetch_stations(
+                line_tfl_id="victoria", use_cache=False, skip_database_validation=True
+            ),
+            mock_data=mock_stops,
+            expected_count=1,
+            cache_key="stations:line:victoria",
+            expected_ttl=86400,
+            shared_expires=datetime(2025, 1, 2, 12, 0, 0, tzinfo=UTC),
+        )
+
+        # Verify station returned from API
+        assert len(stations) == 1
+        assert stations[0].tfl_id == "940GZZLUVIC"
+
+
 # ==================== fetch_disruptions Tests ====================
 
 

--- a/backend/tests/test_tfl_service.py
+++ b/backend/tests/test_tfl_service.py
@@ -1278,7 +1278,9 @@ async def test_fetch_stations_by_line(
         # Execute with helper
         stations = await assert_fetch_from_api(
             tfl_service=tfl_service,
-            method_callable=lambda: tfl_service.fetch_stations(line_tfl_id="victoria", use_cache=False),
+            method_callable=lambda: tfl_service.fetch_stations(
+                line_tfl_id="victoria", use_cache=False, skip_database_validation=True
+            ),
             mock_data=mock_stops,
             expected_count=2,
             cache_key="stations:line:victoria",
@@ -1332,7 +1334,9 @@ async def test_fetch_stations_cache_miss(
         # Execute with helper
         stations = await assert_cache_miss(
             tfl_service=tfl_service,
-            method_callable=lambda: tfl_service.fetch_stations(line_tfl_id="victoria", use_cache=True),
+            method_callable=lambda: tfl_service.fetch_stations(
+                line_tfl_id="victoria", use_cache=True, skip_database_validation=True
+            ),
             mock_data=mock_stops,
             expected_count=1,
             shared_expires=datetime(2025, 1, 2, 12, 0, 0, tzinfo=UTC),
@@ -4721,7 +4725,7 @@ async def test_fetch_stations_api_error_handling(
 
     # Execute and verify proper error handling
     with pytest.raises(HTTPException) as exc_info:
-        await tfl_service.fetch_stations(line_tfl_id="victoria", use_cache=False)
+        await tfl_service.fetch_stations(line_tfl_id="victoria", use_cache=False, skip_database_validation=True)
 
     assert exc_info.value.status_code == 503
     assert "Failed to fetch stations from TfL API" in exc_info.value.detail
@@ -5400,7 +5404,9 @@ async def test_fetch_stations_update_existing_station(
         # Execute with helper - fetch for district line
         stations = await assert_fetch_from_api(
             tfl_service=tfl_service,
-            method_callable=lambda: tfl_service.fetch_stations(line_tfl_id="district", use_cache=False),
+            method_callable=lambda: tfl_service.fetch_stations(
+                line_tfl_id="district", use_cache=False, skip_database_validation=True
+            ),
             mock_data=mock_stops,
             expected_count=1,
             cache_key="stations:line:district",
@@ -5438,7 +5444,9 @@ async def test_fetch_stations_with_hub_fields(
         # Execute with helper
         stations = await assert_fetch_from_api(
             tfl_service=tfl_service,
-            method_callable=lambda: tfl_service.fetch_stations(line_tfl_id="weaver", use_cache=False),
+            method_callable=lambda: tfl_service.fetch_stations(
+                line_tfl_id="weaver", use_cache=False, skip_database_validation=True
+            ),
             mock_data=mock_stops,
             expected_count=1,
             cache_key="stations:line:weaver",
@@ -5473,7 +5481,9 @@ async def test_fetch_stations_without_hub_fields(
         # Execute with helper
         stations = await assert_fetch_from_api(
             tfl_service=tfl_service,
-            method_callable=lambda: tfl_service.fetch_stations(line_tfl_id="district", use_cache=False),
+            method_callable=lambda: tfl_service.fetch_stations(
+                line_tfl_id="district", use_cache=False, skip_database_validation=True
+            ),
             mock_data=mock_stops,
             expected_count=1,
             cache_key="stations:line:district",
@@ -5524,7 +5534,9 @@ async def test_fetch_stations_updates_changed_hub_fields(
         # Execute with helper
         stations = await assert_fetch_from_api(
             tfl_service=tfl_service,
-            method_callable=lambda: tfl_service.fetch_stations(line_tfl_id="victoria", use_cache=False),
+            method_callable=lambda: tfl_service.fetch_stations(
+                line_tfl_id="victoria", use_cache=False, skip_database_validation=True
+            ),
             mock_data=mock_stops,
             expected_count=1,
             cache_key="stations:line:victoria",
@@ -5575,7 +5587,9 @@ async def test_fetch_stations_clears_hub_fields_when_removed(
         # Execute with helper
         stations = await assert_fetch_from_api(
             tfl_service=tfl_service,
-            method_callable=lambda: tfl_service.fetch_stations(line_tfl_id="district", use_cache=False),
+            method_callable=lambda: tfl_service.fetch_stations(
+                line_tfl_id="district", use_cache=False, skip_database_validation=True
+            ),
             mock_data=mock_stops,
             expected_count=1,
             cache_key="stations:line:district",
@@ -5602,7 +5616,7 @@ async def test_fetch_stations_http_exception_reraise(
 
     # Execute and verify HTTPException is re-raised
     with pytest.raises(HTTPException) as exc_info:
-        await tfl_service.fetch_stations(line_tfl_id="victoria", use_cache=False)
+        await tfl_service.fetch_stations(line_tfl_id="victoria", use_cache=False, skip_database_validation=True)
 
     assert exc_info.value.status_code == 429
     assert "Rate limit exceeded" in exc_info.value.detail


### PR DESCRIPTION
- Updated `get_stations` to clarify data source and initialization requirements.
- Modified `fetch_stations` to include validation for line existence and database initialization.
- Added error handling for 404 and 503 responses based on line and station availability.
- Introduced `skip_database_validation` parameter for controlled TfL API access during graph building.
- Expanded tests to cover new validation scenarios and error responses.

resolves #38

## Summary by Sourcery

Enhance TfL station fetching logic by adding validation for database initialization and line existence, splitting public and graph‐building flows, introducing a skip_database_validation flag, and expanding tests and documentation to cover new error handling behaviors.

New Features:
- Add skip_database_validation flag to fetch_stations for controlled TfL API access during graph building
- Introduce pure helper functions and domain exceptions for station fetching validation (cache key builder, initialization check, line filtering, and existence validation)

Enhancements:
- Split fetch_stations into API and database flows with proper validation and error handling (503 on uninitialized DB, 404 on invalid line or no stations)
- Refactor cache key construction and centralize station-fetching logic
- Update get_stations API behavior to read only from database for public endpoints

Documentation:
- Update ADR for external APIs to document line validation decision and error responses
- Revise get_stations endpoint documentation to reflect new validation and error codes

Tests:
- Expand unit tests for new validation helper functions and custom exceptions
- Add integration and unit tests covering 503/404 error scenarios in fetch_stations