### PR TITLE
Extract State Machine Logic from SegmentBuilder (#97)

### DIFF
--- a/frontend/src/components/routes/SegmentBuilder/SegmentBuilder.tsx
+++ b/frontend/src/components/routes/SegmentBuilder/SegmentBuilder.tsx
@@ -197,16 +197,27 @@ export function SegmentBuilder({
   }
 
   const handleNextStationSelect = (stationId: string | undefined) => {
-    if (!stationId || !currentStation || !selectedLine) {
-      setNextStation(null)
+    // Guard clause: missing required state (shouldn't happen in normal operation)
+    if (!currentStation || !selectedLine) return
+
+    // If combobox cleared, go back to select-next-station step
+    if (!stationId) {
+      const newState = transitionBackFromChooseAction(currentStation, selectedLine)
+      applyTransition(newState)
       return
     }
 
     const station = stations.find((s) => s.id === stationId)
-    if (station) {
-      const newState = transitionToChooseAction(currentStation, selectedLine, station)
-      applyTransition(newState)
+    if (!station) {
+      // Station lookup failed - stay in current state with warning
+      if (import.meta.env.DEV) {
+        console.warn('[SegmentBuilder] Station not found:', stationId)
+      }
+      return
     }
+
+    const newState = transitionToChooseAction(currentStation, selectedLine, station)
+    applyTransition(newState)
   }
 
   const handleContinueJourney = (line: LineResponse) => {

--- a/frontend/src/components/routes/SegmentBuilder/segments.ts
+++ b/frontend/src/components/routes/SegmentBuilder/segments.ts
@@ -26,11 +26,25 @@ import { isSameLine } from './utils'
 export interface DeletionResult {
   /** Remaining segments after deletion (resequenced) */
   segments: SegmentRequest[]
-  /** Context for resuming route building after truncation */
+  /**
+   * Context for resuming route building after truncation
+   *
+   * Both fields are null when:
+   * - Deleting from sequence 0 (clears all segments)
+   * - Station/line lookup fails for remaining segments
+   *
+   * When null, UI should transition back to initial state (select-station)
+   */
   resumeFrom: {
-    /** Station to resume from (from last remaining segment) */
+    /**
+     * Station to resume from (from last remaining segment).
+     * Null if no segments remain after deletion.
+     */
     station: StationResponse | null
-    /** Line to resume on (from last remaining segment) */
+    /**
+     * Line to resume on (from last remaining segment).
+     * Null if no segments remain after deletion.
+     */
     line: LineResponse | null
   }
 }

--- a/frontend/src/components/routes/SegmentBuilder/transitions.test.ts
+++ b/frontend/src/components/routes/SegmentBuilder/transitions.test.ts
@@ -1,0 +1,475 @@
+import { describe, it, expect } from 'vitest'
+import {
+  transitionToSelectStation,
+  transitionToSelectLine,
+  transitionToSelectNextStation,
+  transitionToChooseAction,
+  transitionBackFromChooseAction,
+  transitionToResumeFromSegments,
+  computeStateAfterStationSelect,
+  computeStateAfterSegmentUpdate,
+  transitionWithError,
+  transitionClearError,
+  isValidTransition,
+  logTransition,
+} from './transitions'
+import type { StationResponse, LineResponse } from '@/lib/api'
+import type { CoreSegmentBuilderState } from './types'
+
+describe('SegmentBuilder transitions', () => {
+  // Mock stations
+  const mockStationA: StationResponse = {
+    id: '123e4567-e89b-12d3-a456-426614174000',
+    tfl_id: 'station-a',
+    name: 'Station A',
+    latitude: 51.5,
+    longitude: -0.1,
+    lines: ['northern'],
+    last_updated: '2025-01-01T00:00:00Z',
+    hub_naptan_code: null,
+    hub_common_name: null,
+  }
+
+  const mockStationB: StationResponse = {
+    id: '123e4567-e89b-12d3-a456-426614174001',
+    tfl_id: 'station-b',
+    name: 'Station B',
+    latitude: 51.51,
+    longitude: -0.11,
+    lines: ['northern'],
+    last_updated: '2025-01-01T00:00:00Z',
+    hub_naptan_code: null,
+    hub_common_name: null,
+  }
+
+  const mockStationC: StationResponse = {
+    id: '123e4567-e89b-12d3-a456-426614174002',
+    tfl_id: 'station-c',
+    name: 'Station C',
+    latitude: 51.52,
+    longitude: -0.12,
+    lines: ['northern', 'victoria'],
+    last_updated: '2025-01-01T00:00:00Z',
+    hub_naptan_code: null,
+    hub_common_name: null,
+  }
+
+  // Mock lines
+  const mockLineNorthern: LineResponse = {
+    id: '223e4567-e89b-12d3-a456-426614174000',
+    tfl_id: 'northern',
+    name: 'Northern',
+    mode: 'tube',
+    last_updated: '2025-01-01T00:00:00Z',
+  }
+
+  const mockLineVictoria: LineResponse = {
+    id: '223e4567-e89b-12d3-a456-426614174001',
+    tfl_id: 'victoria',
+    name: 'Victoria',
+    mode: 'tube',
+    last_updated: '2025-01-01T00:00:00Z',
+  }
+
+  describe('transitionToSelectStation', () => {
+    it('should return complete initial state', () => {
+      const state = transitionToSelectStation()
+
+      expect(state.currentStation).toBeNull()
+      expect(state.selectedLine).toBeNull()
+      expect(state.nextStation).toBeNull()
+      expect(state.step).toBe('select-station')
+      expect(state.error).toBeNull()
+    })
+
+    it('should clear all previous state', () => {
+      // Verify it returns exactly 5 fields
+      const state = transitionToSelectStation()
+      expect(Object.keys(state)).toEqual([
+        'currentStation',
+        'selectedLine',
+        'nextStation',
+        'step',
+        'error',
+      ])
+    })
+  })
+
+  describe('transitionToSelectLine', () => {
+    it('should set correct state for line selection', () => {
+      const state = transitionToSelectLine(mockStationA)
+
+      expect(state.currentStation).toBe(mockStationA)
+      expect(state.selectedLine).toBeNull()
+      expect(state.nextStation).toBeNull()
+      expect(state.step).toBe('select-line')
+      expect(state.error).toBeNull()
+    })
+
+    it('should preserve station reference', () => {
+      const state = transitionToSelectLine(mockStationB)
+      expect(state.currentStation).toBe(mockStationB)
+    })
+  })
+
+  describe('transitionToSelectNextStation', () => {
+    it('should set correct state for next station selection', () => {
+      const state = transitionToSelectNextStation(mockStationA, mockLineNorthern)
+
+      expect(state.currentStation).toBe(mockStationA)
+      expect(state.selectedLine).toBe(mockLineNorthern)
+      expect(state.nextStation).toBeNull()
+      expect(state.step).toBe('select-next-station')
+      expect(state.error).toBeNull()
+    })
+
+    it('should preserve station and line references', () => {
+      const state = transitionToSelectNextStation(mockStationC, mockLineVictoria)
+      expect(state.currentStation).toBe(mockStationC)
+      expect(state.selectedLine).toBe(mockLineVictoria)
+    })
+  })
+
+  describe('transitionToChooseAction', () => {
+    it('should set correct state for action choice', () => {
+      const state = transitionToChooseAction(mockStationA, mockLineNorthern, mockStationB)
+
+      expect(state.currentStation).toBe(mockStationA)
+      expect(state.selectedLine).toBe(mockLineNorthern)
+      expect(state.nextStation).toBe(mockStationB)
+      expect(state.step).toBe('choose-action')
+      expect(state.error).toBeNull()
+    })
+
+    it('should preserve all three station/line references', () => {
+      const state = transitionToChooseAction(mockStationA, mockLineVictoria, mockStationC)
+      expect(state.currentStation).toBe(mockStationA)
+      expect(state.selectedLine).toBe(mockLineVictoria)
+      expect(state.nextStation).toBe(mockStationC)
+    })
+  })
+
+  describe('transitionBackFromChooseAction', () => {
+    it('should transition back to select-next-station', () => {
+      const state = transitionBackFromChooseAction(mockStationA, mockLineNorthern)
+
+      expect(state.currentStation).toBe(mockStationA)
+      expect(state.selectedLine).toBe(mockLineNorthern)
+      expect(state.nextStation).toBeNull()
+      expect(state.step).toBe('select-next-station')
+      expect(state.error).toBeNull()
+    })
+
+    it('should clear nextStation', () => {
+      const state = transitionBackFromChooseAction(mockStationB, mockLineVictoria)
+      expect(state.nextStation).toBeNull()
+    })
+  })
+
+  describe('transitionToResumeFromSegments', () => {
+    it('should transition to select-next-station when station and line provided', () => {
+      const state = transitionToResumeFromSegments(mockStationA, mockLineNorthern)
+
+      expect(state.step).toBe('select-next-station')
+      expect(state.currentStation).toBe(mockStationA)
+      expect(state.selectedLine).toBe(mockLineNorthern)
+      expect(state.nextStation).toBeNull()
+      expect(state.error).toBeNull()
+    })
+
+    it('should transition to select-station when no station provided', () => {
+      const state = transitionToResumeFromSegments(null, mockLineNorthern)
+
+      expect(state.step).toBe('select-station')
+      expect(state.currentStation).toBeNull()
+      expect(state.selectedLine).toBeNull()
+      expect(state.nextStation).toBeNull()
+    })
+
+    it('should transition to select-station when no line provided', () => {
+      const state = transitionToResumeFromSegments(mockStationA, null)
+
+      expect(state.step).toBe('select-station')
+    })
+
+    it('should transition to select-station when both null', () => {
+      const state = transitionToResumeFromSegments(null, null)
+
+      expect(state.step).toBe('select-station')
+      expect(state.currentStation).toBeNull()
+      expect(state.selectedLine).toBeNull()
+    })
+  })
+
+  describe('computeStateAfterStationSelect', () => {
+    it('should return error state when no lines available', () => {
+      const state = computeStateAfterStationSelect(mockStationA, [])
+
+      expect(state.step).toBe('select-line')
+      expect(state.currentStation).toBe(mockStationA)
+      expect(state.error).toBe('Selected station has no lines available')
+    })
+
+    it('should auto-select line and advance when only one line', () => {
+      const state = computeStateAfterStationSelect(mockStationA, [mockLineNorthern])
+
+      expect(state.step).toBe('select-next-station')
+      expect(state.currentStation).toBe(mockStationA)
+      expect(state.selectedLine).toBe(mockLineNorthern)
+      expect(state.error).toBeNull()
+    })
+
+    it('should transition to select-line when multiple lines available', () => {
+      const state = computeStateAfterStationSelect(mockStationC, [
+        mockLineNorthern,
+        mockLineVictoria,
+      ])
+
+      expect(state.step).toBe('select-line')
+      expect(state.currentStation).toBe(mockStationC)
+      expect(state.selectedLine).toBeNull()
+      expect(state.error).toBeNull()
+    })
+
+    it('should handle three or more lines', () => {
+      const mockLine3: LineResponse = {
+        id: 'line-3',
+        tfl_id: 'jubilee',
+        name: 'Jubilee',
+        mode: 'tube',
+        last_updated: '2025-01-01T00:00:00Z',
+      }
+
+      const state = computeStateAfterStationSelect(mockStationC, [
+        mockLineNorthern,
+        mockLineVictoria,
+        mockLine3,
+      ])
+
+      expect(state.step).toBe('select-line')
+    })
+  })
+
+  describe('computeStateAfterSegmentUpdate', () => {
+    it('should stay at choose-action if at choose-action with segments', () => {
+      const currentState: CoreSegmentBuilderState = {
+        currentStation: mockStationA,
+        selectedLine: mockLineNorthern,
+        nextStation: mockStationB,
+        step: 'choose-action',
+        error: null,
+      }
+
+      const state = computeStateAfterSegmentUpdate(currentState, true)
+
+      expect(state.step).toBe('choose-action')
+      expect(state).toBe(currentState) // Should return same reference
+    })
+
+    it('should transition to select-next-station if has segments and station/line set', () => {
+      const currentState: CoreSegmentBuilderState = {
+        currentStation: mockStationA,
+        selectedLine: mockLineNorthern,
+        nextStation: null,
+        step: 'select-line',
+        error: null,
+      }
+
+      const state = computeStateAfterSegmentUpdate(currentState, true)
+
+      expect(state.step).toBe('select-next-station')
+      expect(state.currentStation).toBe(mockStationA)
+      expect(state.selectedLine).toBe(mockLineNorthern)
+    })
+
+    it('should reset to select-station if no segments', () => {
+      const currentState: CoreSegmentBuilderState = {
+        currentStation: mockStationA,
+        selectedLine: mockLineNorthern,
+        nextStation: mockStationB,
+        step: 'choose-action',
+        error: null,
+      }
+
+      const state = computeStateAfterSegmentUpdate(currentState, false)
+
+      expect(state.step).toBe('select-station')
+      expect(state.currentStation).toBeNull()
+    })
+
+    it('should reset to select-station if has segments but no current station', () => {
+      const currentState: CoreSegmentBuilderState = {
+        currentStation: null,
+        selectedLine: mockLineNorthern,
+        nextStation: null,
+        step: 'select-line',
+        error: null,
+      }
+
+      const state = computeStateAfterSegmentUpdate(currentState, true)
+
+      expect(state.step).toBe('select-station')
+    })
+
+    it('should reset to select-station if has segments but no selected line', () => {
+      const currentState: CoreSegmentBuilderState = {
+        currentStation: mockStationA,
+        selectedLine: null,
+        nextStation: null,
+        step: 'select-line',
+        error: null,
+      }
+
+      const state = computeStateAfterSegmentUpdate(currentState, true)
+
+      expect(state.step).toBe('select-station')
+    })
+  })
+
+  describe('transitionWithError', () => {
+    it('should preserve state and add error', () => {
+      const currentState = transitionToSelectStation()
+      const state = transitionWithError(currentState, 'Test error')
+
+      expect(state.currentStation).toBeNull()
+      expect(state.selectedLine).toBeNull()
+      expect(state.nextStation).toBeNull()
+      expect(state.step).toBe('select-station')
+      expect(state.error).toBe('Test error')
+    })
+
+    it('should preserve complex state', () => {
+      const currentState = transitionToSelectNextStation(mockStationA, mockLineNorthern)
+      const state = transitionWithError(currentState, 'Error message')
+
+      expect(state.currentStation).toBe(mockStationA)
+      expect(state.selectedLine).toBe(mockLineNorthern)
+      expect(state.error).toBe('Error message')
+    })
+
+    it('should preserve choose-action state', () => {
+      const currentState = transitionToChooseAction(mockStationA, mockLineNorthern, mockStationB)
+      const state = transitionWithError(currentState, 'Validation failed')
+
+      expect(state.step).toBe('choose-action')
+      expect(state.nextStation).toBe(mockStationB)
+      expect(state.error).toBe('Validation failed')
+    })
+
+    it('should overwrite previous error', () => {
+      const currentState: CoreSegmentBuilderState = {
+        currentStation: mockStationA,
+        selectedLine: null,
+        nextStation: null,
+        step: 'select-line',
+        error: 'Old error',
+      }
+
+      const state = transitionWithError(currentState, 'New error')
+      expect(state.error).toBe('New error')
+    })
+  })
+
+  describe('transitionClearError', () => {
+    it('should clear error while preserving state', () => {
+      const stateWithError: CoreSegmentBuilderState = {
+        currentStation: mockStationA,
+        selectedLine: null,
+        nextStation: null,
+        step: 'select-station',
+        error: 'Some error',
+      }
+
+      const state = transitionClearError(stateWithError)
+
+      expect(state.error).toBeNull()
+      expect(state.currentStation).toBe(mockStationA)
+      expect(state.step).toBe('select-station')
+    })
+
+    it('should preserve all fields except error', () => {
+      const stateWithError = transitionWithError(
+        transitionToChooseAction(mockStationA, mockLineNorthern, mockStationB),
+        'Error'
+      )
+
+      const state = transitionClearError(stateWithError)
+
+      expect(state.error).toBeNull()
+      expect(state.currentStation).toBe(mockStationA)
+      expect(state.selectedLine).toBe(mockLineNorthern)
+      expect(state.nextStation).toBe(mockStationB)
+      expect(state.step).toBe('choose-action')
+    })
+
+    it('should work when error is already null', () => {
+      const stateWithoutError = transitionToSelectStation()
+      const state = transitionClearError(stateWithoutError)
+
+      expect(state.error).toBeNull()
+    })
+  })
+
+  describe('isValidTransition', () => {
+    it('should allow valid transitions from select-station', () => {
+      expect(isValidTransition('select-station', 'select-line')).toBe(true)
+      expect(isValidTransition('select-station', 'select-next-station')).toBe(true)
+    })
+
+    it('should allow valid transition from select-line', () => {
+      expect(isValidTransition('select-line', 'select-next-station')).toBe(true)
+    })
+
+    it('should allow valid transition from select-next-station', () => {
+      expect(isValidTransition('select-next-station', 'choose-action')).toBe(true)
+    })
+
+    it('should allow valid transitions from choose-action', () => {
+      expect(isValidTransition('choose-action', 'select-next-station')).toBe(true)
+      expect(isValidTransition('choose-action', 'select-station')).toBe(true)
+    })
+
+    it('should reject invalid transition from select-line to select-station', () => {
+      expect(isValidTransition('select-line', 'select-station')).toBe(false)
+    })
+
+    it('should reject invalid transition from select-next-station to select-line', () => {
+      expect(isValidTransition('select-next-station', 'select-line')).toBe(false)
+    })
+
+    it('should reject invalid transition from select-line to choose-action', () => {
+      expect(isValidTransition('select-line', 'choose-action')).toBe(false)
+    })
+
+    it('should reject invalid transition from select-next-station to select-station', () => {
+      expect(isValidTransition('select-next-station', 'select-station')).toBe(false)
+    })
+
+    it('should reject invalid transition from choose-action to select-line', () => {
+      expect(isValidTransition('choose-action', 'select-line')).toBe(false)
+    })
+  })
+
+  describe('logTransition', () => {
+    it('should not throw when called with valid states', () => {
+      const from = transitionToSelectStation()
+      const to = transitionToSelectLine(mockStationA)
+
+      expect(() => logTransition(from, to, 'test action')).not.toThrow()
+    })
+
+    it('should handle states with all fields populated', () => {
+      const from = transitionToChooseAction(mockStationA, mockLineNorthern, mockStationB)
+      const to = transitionToSelectNextStation(mockStationB, mockLineNorthern)
+
+      expect(() => logTransition(from, to, 'continue journey')).not.toThrow()
+    })
+
+    it('should handle states with errors', () => {
+      const from = transitionWithError(transitionToSelectStation(), 'Test error')
+      const to = transitionClearError(from)
+
+      expect(() => logTransition(from, to, 'clear error')).not.toThrow()
+    })
+  })
+})

--- a/frontend/src/components/routes/SegmentBuilder/transitions.ts
+++ b/frontend/src/components/routes/SegmentBuilder/transitions.ts
@@ -1,0 +1,457 @@
+/**
+ * Pure state transition functions for SegmentBuilder state machine
+ *
+ * This module provides pure functions that define all valid state transitions
+ * in the segment building workflow. Each function returns a complete new state
+ * object, making transitions explicit, testable, and easy to reason about.
+ *
+ * **Design principles:**
+ * - Pure functions: same input → same output, no side effects
+ * - Complete state: each function returns all 5 core state fields
+ * - Explicit transitions: no hidden state dependencies
+ * - Separation of concerns: core state machine logic only (no UI state like isSaving)
+ *
+ * **State machine flow:**
+ * ```
+ * select-station ←→ select-line → select-next-station → choose-action
+ *      ↑                                                        ↓
+ *      └────────────────────────────────────────────────────────
+ * ```
+ *
+ * @see ADR 11: Frontend State Management Pattern - Pure Function Architecture
+ * @see Issue #97: Extract State Machine Logic from SegmentBuilder
+ */
+
+import type { StationResponse, LineResponse } from '@/lib/api'
+import type { CoreSegmentBuilderState, Step } from './types'
+
+/**
+ * Transitions to initial state (select station)
+ *
+ * **Use when:**
+ * - Starting a new route
+ * - Canceling current operation
+ * - Resetting after completing destination
+ *
+ * @returns Complete initial state with all fields reset
+ *
+ * @example
+ * ```typescript
+ * const handleCancel = () => {
+ *   const newState = transitionToSelectStation()
+ *   applyTransition(newState)
+ * }
+ * ```
+ */
+export function transitionToSelectStation(): CoreSegmentBuilderState {
+  return {
+    currentStation: null,
+    selectedLine: null,
+    nextStation: null,
+    step: 'select-station',
+    error: null,
+  }
+}
+
+/**
+ * Transitions to select line step
+ *
+ * **Use when:**
+ * - Station selected that has multiple lines
+ * - User needs to choose which line to travel on
+ *
+ * @param currentStation - Station that was selected
+ * @returns State ready for line selection
+ *
+ * @example
+ * ```typescript
+ * if (availableLines.length > 1) {
+ *   const newState = transitionToSelectLine(selectedStation)
+ *   applyTransition(newState)
+ * }
+ * ```
+ */
+export function transitionToSelectLine(currentStation: StationResponse): CoreSegmentBuilderState {
+  return {
+    currentStation,
+    selectedLine: null,
+    nextStation: null,
+    step: 'select-line',
+    error: null,
+  }
+}
+
+/**
+ * Transitions to select next station step
+ *
+ * **Use when:**
+ * - Line selected (or auto-selected if only one line)
+ * - Ready to pick the next station on this line
+ *
+ * @param currentStation - Current station user is at
+ * @param selectedLine - Line to travel on
+ * @returns State ready for next station selection
+ *
+ * @example
+ * ```typescript
+ * const handleLineClick = (line: LineResponse) => {
+ *   const newState = transitionToSelectNextStation(currentStation, line)
+ *   applyTransition(newState)
+ * }
+ * ```
+ */
+export function transitionToSelectNextStation(
+  currentStation: StationResponse,
+  selectedLine: LineResponse
+): CoreSegmentBuilderState {
+  return {
+    currentStation,
+    selectedLine,
+    nextStation: null,
+    step: 'select-next-station',
+    error: null,
+  }
+}
+
+/**
+ * Transitions to choose action step
+ *
+ * **Use when:**
+ * - Next station selected
+ * - User needs to choose: continue journey or mark as destination
+ *
+ * @param currentStation - Current station
+ * @param selectedLine - Current line
+ * @param nextStation - Next station selected
+ * @returns State ready for action choice
+ *
+ * @example
+ * ```typescript
+ * const handleNextStationSelect = (station: StationResponse) => {
+ *   const newState = transitionToChooseAction(currentStation, selectedLine, station)
+ *   applyTransition(newState)
+ * }
+ * ```
+ */
+export function transitionToChooseAction(
+  currentStation: StationResponse,
+  selectedLine: LineResponse,
+  nextStation: StationResponse
+): CoreSegmentBuilderState {
+  return {
+    currentStation,
+    selectedLine,
+    nextStation,
+    step: 'choose-action',
+    error: null,
+  }
+}
+
+/**
+ * Transitions back from choose-action to select-next-station
+ *
+ * **Use when:**
+ * - User clicks "Back" button from choose-action step
+ * - Allows user to select a different next station
+ *
+ * @param currentStation - Current station to keep
+ * @param selectedLine - Current line to keep
+ * @returns State ready to select a different next station
+ *
+ * @example
+ * ```typescript
+ * const handleBackFromChooseAction = () => {
+ *   const newState = transitionBackFromChooseAction(currentStation, selectedLine)
+ *   applyTransition(newState)
+ * }
+ * ```
+ */
+export function transitionBackFromChooseAction(
+  currentStation: StationResponse,
+  selectedLine: LineResponse
+): CoreSegmentBuilderState {
+  return {
+    currentStation,
+    selectedLine,
+    nextStation: null,
+    step: 'select-next-station',
+    error: null,
+  }
+}
+
+/**
+ * Transitions to resume building from existing segments
+ *
+ * **Use when:**
+ * - Editing an existing route
+ * - After deleting a segment (resume from truncation point)
+ * - Resuming after clearing destination marker
+ *
+ * If resume context is null (empty route), resets to initial state.
+ *
+ * @param resumeStation - Station to resume from (from computeResumeState or DeletionResult)
+ * @param resumeLine - Line to resume on (from computeResumeState or DeletionResult)
+ * @returns State ready to continue building from resume point
+ *
+ * @example
+ * ```typescript
+ * const handleDeleteSegment = (index: number) => {
+ *   const result = deleteSegmentAndResequence(index, segments, stations, lines)
+ *   setLocalSegments(result.segments)
+ *
+ *   const newState = transitionToResumeFromSegments(
+ *     result.resumeFrom.station,
+ *     result.resumeFrom.line
+ *   )
+ *   applyTransition(newState)
+ * }
+ * ```
+ */
+export function transitionToResumeFromSegments(
+  resumeStation: StationResponse | null,
+  resumeLine: LineResponse | null
+): CoreSegmentBuilderState {
+  if (!resumeStation || !resumeLine) {
+    return transitionToSelectStation()
+  }
+
+  return transitionToSelectNextStation(resumeStation, resumeLine)
+}
+
+/**
+ * Computes next state after station selection based on available lines
+ *
+ * **Use when:**
+ * - Station selected, need to determine next step automatically
+ * - Implements auto-advance logic based on line count
+ *
+ * **Logic:**
+ * - 0 lines: Error state (station has no lines)
+ * - 1 line: Auto-select line and advance to select-next-station
+ * - 2+ lines: Advance to select-line (user must choose)
+ *
+ * @param station - Station that was selected
+ * @param availableLines - Lines available at this station
+ * @returns Next state based on line count
+ *
+ * @example
+ * ```typescript
+ * const handleStationSelect = (station: StationResponse) => {
+ *   const linesAtStation = lines.filter(l => station.lines.includes(l.tfl_id))
+ *   const newState = computeStateAfterStationSelect(station, linesAtStation)
+ *   applyTransition(newState)
+ * }
+ * ```
+ */
+export function computeStateAfterStationSelect(
+  station: StationResponse,
+  availableLines: LineResponse[]
+): CoreSegmentBuilderState {
+  if (availableLines.length === 0) {
+    return transitionWithError(
+      transitionToSelectLine(station),
+      'Selected station has no lines available'
+    )
+  }
+
+  if (availableLines.length === 1) {
+    // Auto-select the only line
+    return transitionToSelectNextStation(station, availableLines[0])
+  }
+
+  // Multiple lines - user must choose
+  return transitionToSelectLine(station)
+}
+
+/**
+ * Computes next state after segments are updated
+ *
+ * **Use when:**
+ * - Segments change (continue, destination, delete)
+ * - Need to determine appropriate next state
+ *
+ * **Logic:**
+ * - At choose-action with segments: Stay at choose-action
+ * - Has segments + current/selected set: Transition to select-next-station
+ * - No segments: Reset to initial state
+ *
+ * This implements the "auto-advance" logic after segment operations.
+ *
+ * @param currentState - Current state before segment update
+ * @param hasSegments - Whether route has any segments after update
+ * @returns Next state based on segment presence
+ *
+ * @example
+ * ```typescript
+ * useEffect(() => {
+ *   const newState = computeStateAfterSegmentUpdate(
+ *     { currentStation, selectedLine, nextStation, step, error },
+ *     localSegments.length > 0
+ *   )
+ *   applyTransition(newState)
+ * }, [localSegments.length])
+ * ```
+ */
+export function computeStateAfterSegmentUpdate(
+  currentState: CoreSegmentBuilderState,
+  hasSegments: boolean
+): CoreSegmentBuilderState {
+  // If we're at choose-action and have segments, stay there
+  if (currentState.step === 'choose-action' && hasSegments) {
+    return currentState
+  }
+
+  // If we have segments and current/selected are set, transition to next station
+  if (hasSegments && currentState.currentStation && currentState.selectedLine) {
+    return transitionToSelectNextStation(currentState.currentStation, currentState.selectedLine)
+  }
+
+  // Otherwise, reset to initial state
+  return transitionToSelectStation()
+}
+
+/**
+ * Transitions to error state (preserves current state, adds error)
+ *
+ * **Use when:**
+ * - Validation fails
+ * - API error occurs during state transition
+ * - Need to show error without changing current step
+ *
+ * @param currentState - Current state to preserve
+ * @param error - Error message to display
+ * @returns State with error message added
+ *
+ * @example
+ * ```typescript
+ * const validation = validateNotDuplicate(station, segments)
+ * if (!validation.valid) {
+ *   const newState = transitionWithError(currentState, validation.error)
+ *   applyTransition(newState)
+ *   return
+ * }
+ * ```
+ */
+export function transitionWithError(
+  currentState: CoreSegmentBuilderState,
+  error: string
+): CoreSegmentBuilderState {
+  return {
+    ...currentState,
+    error,
+  }
+}
+
+/**
+ * Clears error from current state
+ *
+ * **Use when:**
+ * - User takes action after error (retry, select different option)
+ * - Dismissing error message
+ *
+ * @param currentState - Current state with possible error
+ * @returns State with error cleared
+ *
+ * @example
+ * ```typescript
+ * const handleStationSelect = (station: StationResponse) => {
+ *   // Clear any previous errors
+ *   const stateWithoutError = transitionClearError(currentState)
+ *   // ... continue with validation and transition
+ * }
+ * ```
+ */
+export function transitionClearError(
+  currentState: CoreSegmentBuilderState
+): CoreSegmentBuilderState {
+  return {
+    ...currentState,
+    error: null,
+  }
+}
+
+/**
+ * Validates that a state transition is allowed
+ *
+ * **Use for:**
+ * - Debugging state machine issues
+ * - Runtime invariant checking in development
+ * - Testing state machine completeness
+ *
+ * @param from - Current step
+ * @param to - Target step
+ * @returns true if transition is valid, false otherwise
+ *
+ * @example
+ * ```typescript
+ * if (process.env.NODE_ENV === 'development') {
+ *   if (!isValidTransition(currentState.step, newState.step)) {
+ *     console.warn('Invalid transition detected', currentState.step, '->', newState.step)
+ *   }
+ * }
+ * ```
+ */
+export function isValidTransition(from: Step, to: Step): boolean {
+  const validTransitions: Record<Step, Step[]> = {
+    'select-station': ['select-line', 'select-next-station'],
+    'select-line': ['select-next-station'],
+    'select-next-station': ['choose-action'],
+    'choose-action': ['select-next-station', 'select-station'],
+  }
+
+  return validTransitions[from].includes(to)
+}
+
+/**
+ * Logs state transition (useful for debugging)
+ *
+ * **Use when:**
+ * - Debugging state machine behavior
+ * - Tracking down unexpected state changes
+ * - Understanding transition flow during development
+ *
+ * Only logs in development mode. No-op in production.
+ *
+ * @param from - Previous state
+ * @param to - New state
+ * @param action - Description of action that caused transition
+ *
+ * @example
+ * ```typescript
+ * const applyTransition = (newState: CoreSegmentBuilderState) => {
+ *   logTransition(
+ *     { currentStation, selectedLine, nextStation, step, error },
+ *     newState,
+ *     'handleStationSelect'
+ *   )
+ *   setCurrentStation(newState.currentStation)
+ *   setSelectedLine(newState.selectedLine)
+ *   // ...
+ * }
+ * ```
+ */
+export function logTransition(
+  from: CoreSegmentBuilderState,
+  to: CoreSegmentBuilderState,
+  action: string
+): void {
+  if (import.meta.env.DEV) {
+    console.log('[SegmentBuilder Transition]', {
+      action,
+      from: {
+        step: from.step,
+        currentStation: from.currentStation?.name,
+        selectedLine: from.selectedLine?.name,
+        nextStation: from.nextStation?.name,
+        hasError: !!from.error,
+      },
+      to: {
+        step: to.step,
+        currentStation: to.currentStation?.name,
+        selectedLine: to.selectedLine?.name,
+        nextStation: to.nextStation?.name,
+        hasError: !!to.error,
+      },
+    })
+  }
+}

--- a/frontend/src/components/routes/SegmentBuilder/types.ts
+++ b/frontend/src/components/routes/SegmentBuilder/types.ts
@@ -42,12 +42,45 @@ export type Step = 'select-station' | 'select-line' | 'select-next-station' | 'c
 export type ValidationResult = { valid: true } | { valid: false; error: string }
 
 /**
+ * Core state machine state (used by pure transition functions)
+ *
+ * This interface represents only the core state machine logic, excluding
+ * UI-specific state like `isSaving` and `saveSuccess`. Transition functions
+ * operate on this core state to maintain separation of concerns:
+ * - State machine logic is pure and synchronous
+ * - UI state is managed by component handlers around async operations
+ *
+ * This type is used by transition functions in transitions.ts to ensure
+ * they remain pure and testable.
+ *
+ * @see Issue #97: Extract State Machine Logic
+ * @see transitions.ts for state transition functions
+ */
+export interface CoreSegmentBuilderState {
+  /** Currently selected station (null when not selected) */
+  currentStation: StationResponse | null
+
+  /** Currently selected line for travel (null when not selected) */
+  selectedLine: LineResponse | null
+
+  /** Next station selected on the current line (null when not selected) */
+  nextStation: StationResponse | null
+
+  /** Current step in the segment building state machine */
+  step: Step
+
+  /** Error message to display to user (null when no error) */
+  error: string | null
+}
+
+/**
  * Complete state for the SegmentBuilder component
  *
- * This interface aggregates all state variables used in the SegmentBuilder.
- * Currently used for documentation purposes. In future refactoring phases
- * (issues #96-98), this will be used by state transition functions and
- * a custom hook to manage state centrally.
+ * This interface aggregates all state variables used in the SegmentBuilder,
+ * including both core state machine state and UI-specific state.
+ *
+ * The component uses individual useState hooks for each field. In future
+ * refactoring (issue #98), this will be consolidated into a custom hook.
  *
  * @see Issue #96: Extract Segment Building Logic
  * @see Issue #97: Extract State Machine Logic


### PR DESCRIPTION
## Summary
Extracts all state transition logic from SegmentBuilder component into pure, testable functions as part of Phase 3 refactoring (#91). This eliminates 62 scattered state setter calls and replaces them with 12 explicit transition functions.

## Changes

### Core State Machine (transitions.ts - NEW)
- **12 transition functions** returning complete `CoreSegmentBuilderState` objects
- **Pure functions**: same input → same output, no side effects
- **Complete state**: each function returns all 5 core state fields
- **Explicit transitions**: no hidden state dependencies

Key functions:
- `transitionToSelectStation()` - Reset to initial state
- `transitionToSelectLine()` - Advance to line selection
- `transitionToSelectNextStation()` - Advance to next station selection
- `transitionToChooseAction()` - Advance to action choice
- `transitionBackFromChooseAction()` - Navigate back one step
- `transitionToResumeFromSegments()` - Resume from deletion/edit
- `computeStateAfterStationSelect()` - Auto-advance logic based on line count
- `computeStateAfterSegmentUpdate()` - Handle segment changes
- `transitionWithError()` / `transitionClearError()` - Error handling
- `isValidTransition()` / `logTransition()` - Debugging utilities

### Test Coverage (transitions.test.ts - NEW)
- **42 tests** covering all transition functions
- **95.83% coverage** on new code
- Tests verify state shape, null handling, edge cases

### Component Refactoring (SegmentBuilder.tsx)
- **All 11 handlers** now use transition functions
- **Zero duplication** of reset patterns (was 3 occurrences)
- **Added `applyTransition()` helper** to update component state from transition results
- **Removed obsolete functions**: `resumeFromLastSegment`, `computeResumeState` calls

### Type System (types.ts)
- **Added `CoreSegmentBuilderState`** - 5-field interface for pure transitions
- **Separation of concerns**: Core state machine vs UI state (isSaving, saveSuccess)

### Scope Expansion - Truncation Context Fix (segments.ts)
**Problem**: When deleting segment B from route A→B→C→D, user should resume from station A, not reset to initial state

**Solution**: Enhanced `deleteSegmentAndResequence()` to return truncation context
- **Added `DeletionResult` interface** with segments + resumeFrom fields
- **Function signature updated** to accept stations and lines parameters
- **Returns both segments and resume context** (station/line from truncation point)

### Updated Tests (segments.test.ts)
- **Updated 22 existing tests** to expect DeletionResult
- **Added 5 new truncation tests** covering edge cases
- All 35 segment tests passing

## Test Results
```
✓ All 362 tests passing (no regressions)
✓ 42 new transition tests (95.83% coverage)
✓ 5 new truncation tests
✓ Pre-commit hooks passing (prettier, eslint, typescript)
```

## Architecture
Follows ADR 11: Frontend State Management Pattern - Pure Function Architecture

**State machine flow:**
```
select-station ←→ select-line → select-next-station → choose-action
     ↑                                                        ↓
     └────────────────────────────────────────────────────────
```

## Related Issues
- Closes #97
- Part of #91 (Phase 3: Pure Functions Architecture)
- Builds on #95 (Extract Validation & Types) - merged
- Builds on #96 (Extract Segment Building Logic) - merged

## Migration Path
No breaking changes - component API unchanged. Internal state management refactored to use pure functions.

## Summary by Sourcery

Extract and centralize SegmentBuilder state logic into pure, testable transition functions, enhance segment deletion to provide resume context, and refactor the component to use these transitions while updating types and tests accordingly.

New Features:
- Extract core state machine transitions into pure functions in transitions.ts
- Introduce DeletionResult with resumeFrom context in deleteSegmentAndResequence

Bug Fixes:
- Fix truncation context so deleting segments resumes from correct station and line instead of resetting state

Enhancements:
- Refactor SegmentBuilder component to use applyTransition helper and pure transition functions, removing inline state setters and obsolete helpers
- Separate core state machine type (CoreSegmentBuilderState) from UI-specific state

Tests:
- Add 42 unit tests covering all transition functions (95.83% coverage)
- Update 22 existing segment tests and add 5 truncation context tests for deleteSegmentAndResequence