### PR TITLE
refactor: update handleEditRoute to remove destination marker and adjust state for seamless route continuation

### DIFF
--- a/frontend/src/components/routes/SegmentBuilder/hooks/useSegmentBuilderState.ts
+++ b/frontend/src/components/routes/SegmentBuilder/hooks/useSegmentBuilderState.ts
@@ -424,7 +424,9 @@ export function useSegmentBuilderState({
 
   /**
    * Enter edit mode for a completed route
-   * Sets state to show the destination station with action buttons
+   * Removes the destination marker and positions the user as if they just selected
+   * the destination as the next station, allowing them to continue the route or
+   * mark it as destination again.
    */
   const handleEditRoute = useCallback(() => {
     // Find the destination segment (line_tfl_id === null) to get the destination station
@@ -440,8 +442,17 @@ export function useSegmentBuilderState({
     const arrivalLine = lines.find((l) => l.tfl_id === segmentBeforeDestination.line_tfl_id)
 
     if (prevStation && destinationStation && arrivalLine) {
+      // CRITICAL: Remove the destination marker BEFORE transitioning
+      // This makes prevStation the last segment, so handleContinueJourney's
+      // validateNotDuplicate(currentStation, segments, { allowLast: true })
+      // will pass (prevStation is now the last segment)
+      const segmentsWithoutDestination = localSegments.filter((seg) => seg.line_tfl_id !== null)
+      setLocalSegments(segmentsWithoutDestination)
+
       // Set up state as if we just selected the destination as the "next station"
       // This shows line buttons for interchanges + "Mark as Destination" button
+      // With the destination marker removed, prevStation is now the last segment,
+      // so it won't trigger duplicate errors when continuing
       const newState = transitionToChooseAction(prevStation, arrivalLine, destinationStation)
       applyTransition(newState)
     }

--- a/frontend/src/components/routes/SegmentBuilder/hooks/useSegmentBuilderState.ts
+++ b/frontend/src/components/routes/SegmentBuilder/hooks/useSegmentBuilderState.ts
@@ -28,6 +28,7 @@ import {
   buildSegmentsForContinue,
   buildSegmentsForDestination,
   deleteSegmentAndResequence,
+  removeDestinationMarker,
 } from '../segments'
 import {
   transitionToSelectStation,
@@ -429,6 +430,9 @@ export function useSegmentBuilderState({
    * mark it as destination again.
    */
   const handleEditRoute = useCallback(() => {
+    // Clear any stale errors from previous operations
+    setError(null)
+
     // Find the destination segment (line_tfl_id === null) to get the destination station
     const destinationSegment = localSegments.find((seg) => seg.line_tfl_id === null)
     if (!destinationSegment || localSegments.length < 2) {
@@ -446,7 +450,7 @@ export function useSegmentBuilderState({
       // This makes prevStation the last segment, so handleContinueJourney's
       // validateNotDuplicate(currentStation, segments, { allowLast: true })
       // will pass (prevStation is now the last segment)
-      const segmentsWithoutDestination = localSegments.filter((seg) => seg.line_tfl_id !== null)
+      const segmentsWithoutDestination = removeDestinationMarker(localSegments)
       setLocalSegments(segmentsWithoutDestination)
 
       // Set up state as if we just selected the destination as the "next station"

--- a/frontend/src/components/routes/SegmentBuilder/segments.ts
+++ b/frontend/src/components/routes/SegmentBuilder/segments.ts
@@ -238,6 +238,34 @@ export interface ResumeStateResult {
 }
 
 /**
+ * Removes destination marker segments from a route
+ *
+ * Destination markers are segments with line_tfl_id === null, which indicate
+ * the final destination of a route. This function filters them out and returns
+ * only the segments representing actual travel legs.
+ *
+ * This is commonly used when editing a route, where you want to:
+ * 1. Remove the destination marker
+ * 2. Continue building from the last actual travel segment
+ *
+ * @param segments - Route segments (may include destination markers)
+ * @returns New array with only non-destination segments (does not mutate input)
+ *
+ * @example
+ * ```typescript
+ * const segments = [
+ *   { sequence: 0, station_tfl_id: 'southgate', line_tfl_id: 'piccadilly' },
+ *   { sequence: 1, station_tfl_id: 'leicester-square', line_tfl_id: null }
+ * ]
+ * const result = removeDestinationMarker(segments)
+ * // Result: [{ sequence: 0, station_tfl_id: 'southgate', line_tfl_id: 'piccadilly' }]
+ * ```
+ */
+export function removeDestinationMarker(segments: SegmentRequest[]): SegmentRequest[] {
+  return segments.filter((seg) => seg.line_tfl_id !== null)
+}
+
+/**
  * Computes the station and line to resume from based on last segment
  *
  * This function is used when:


### PR DESCRIPTION
resolves #93

## Summary by Sourcery

Remove the destination segment when entering edit mode, update the state to mimic freshly selecting the destination, and adjust tests to ensure route continuation no longer triggers duplicate errors.

Bug Fixes:
- Allow continuing a route at a junction without a duplicate station error by removing the destination marker when editing.

Enhancements:
- Refactor handleEditRoute to strip out the destination segment and transition to the choose-action state as if the destination was just selected.

Tests:
- Unskip and extend regression tests to verify destination marker removal and seamless route continuation at junction stations.