### PR TITLE
Feature/issue 105 test railway network fixture

### DIFF
--- a/backend/tests/helpers/network_helpers.py
+++ b/backend/tests/helpers/network_helpers.py
@@ -1,0 +1,104 @@
+"""
+Helper functions for accessing test railway network entities.
+
+Provides convenient access methods for retrieving stations, lines, hubs, and
+connections from the test_railway_network fixture.
+"""
+
+from app.models.tfl import Line, Station, StationConnection
+
+from tests.conftest import RailwayNetworkFixture
+
+
+def get_station_by_tfl_id(network: RailwayNetworkFixture, tfl_id: str) -> Station:
+    """
+    Get a station from the network by its TfL ID.
+
+    Args:
+        network: Test railway network dictionary from fixture
+        tfl_id: TfL ID of the station (e.g., "parallel-north", "fork-junction")
+
+    Returns:
+        Station object
+
+    Raises:
+        KeyError: If station with given tfl_id doesn't exist in network
+    """
+    return network["stations"][tfl_id]
+
+
+def get_line_by_tfl_id(network: RailwayNetworkFixture, tfl_id: str) -> Line:
+    """
+    Get a line from the network by its TfL ID.
+
+    Args:
+        network: Test railway network dictionary from fixture
+        tfl_id: TfL ID of the line (e.g., "forkedline", "parallelline")
+
+    Returns:
+        Line object
+
+    Raises:
+        KeyError: If line with given tfl_id doesn't exist in network
+    """
+    return network["lines"][tfl_id]
+
+
+def get_hub_stations(network: RailwayNetworkFixture, hub_code: str) -> list[Station]:
+    """
+    Get all child stations of a hub.
+
+    Args:
+        network: Test railway network dictionary from fixture
+        hub_code: Hub NaPTAN code (e.g., "HUBNORTH", "HUBCENTRAL")
+
+    Returns:
+        List of Station objects belonging to the hub
+
+    Raises:
+        KeyError: If hub with given code doesn't exist in network
+    """
+    return network["hubs"][hub_code]
+
+
+def get_connections_for_line(network: RailwayNetworkFixture, line_tfl_id: str) -> list[StationConnection]:
+    """
+    Get all StationConnection records for a specific line.
+
+    Args:
+        network: Test railway network dictionary from fixture
+        line_tfl_id: TfL ID of the line
+
+    Returns:
+        List of StationConnection objects for the line
+
+    Raises:
+        KeyError: If line with given tfl_id doesn't exist in network
+    """
+    line = get_line_by_tfl_id(network, line_tfl_id)
+    return [conn for conn in network["connections"] if conn.line_id == line.id]
+
+
+def get_stations_on_line(network: RailwayNetworkFixture, line_tfl_id: str) -> list[Station]:
+    """
+    Get all stations served by a line.
+
+    Extracts unique station TfL IDs from the line's route sequences
+    and returns the corresponding Station objects.
+
+    Args:
+        network: Test railway network dictionary from fixture
+        line_tfl_id: TfL ID of the line
+
+    Returns:
+        List of unique Station objects served by the line
+    """
+    line = get_line_by_tfl_id(network, line_tfl_id)
+
+    # Extract unique station IDs from all routes
+    station_ids = set()
+    for route in line.routes["routes"]:
+        station_ids.update(route["stations"])
+
+    # Return corresponding Station objects
+    return [network["stations"][tfl_id] for tfl_id in station_ids]

--- a/backend/tests/helpers/types.py
+++ b/backend/tests/helpers/types.py
@@ -1,0 +1,32 @@
+"""
+Type definitions for test fixtures.
+
+Provides type-safe structures for test data, improving IDE support and
+maintaining clear contracts between fixtures and test functions.
+"""
+
+from dataclasses import dataclass
+
+from app.models.tfl import Line, Station, StationConnection
+
+
+@dataclass
+class RailwayNetworkFixture:
+    """
+    Complete test railway network with all components.
+
+    Provides attribute-style access to network entities with full IDE support.
+
+    Attributes:
+        stations: Dictionary mapping TfL station IDs to Station objects
+        lines: Dictionary mapping TfL line IDs to Line objects
+        hubs: Dictionary mapping hub codes to lists of child Station objects
+        connections: List of all StationConnection records (bidirectional)
+        stats: Dictionary with counts (stations_count, lines_count, hubs_count, connections_count)
+    """
+
+    stations: dict[str, Station]
+    lines: dict[str, Line]
+    hubs: dict[str, list[Station]]
+    connections: list[StationConnection]
+    stats: dict[str, int]

--- a/backend/tests/test_railway_network_fixture.py
+++ b/backend/tests/test_railway_network_fixture.py
@@ -1,0 +1,214 @@
+"""
+Integration tests for test_railway_network fixture.
+
+Verifies that the session-scoped fixture builds correctly with all stations,
+lines, hubs, and StationConnection graph as expected.
+"""
+
+import pytest
+
+from tests.conftest import RailwayNetworkFixture
+from tests.helpers.network_helpers import (
+    get_connections_for_line,
+    get_hub_stations,
+    get_line_by_tfl_id,
+    get_station_by_tfl_id,
+    get_stations_on_line,
+)
+from tests.helpers.railway_network import TestRailwayNetwork
+
+
+class TestRailwayNetworkFixture:
+    """Tests for test_railway_network fixture structure and integrity."""
+
+    def test_fixture_builds_successfully(self, test_railway_network: RailwayNetworkFixture):
+        """Verify fixture builds without errors."""
+        assert test_railway_network is not None
+        assert "stations" in test_railway_network
+        assert "lines" in test_railway_network
+        assert "hubs" in test_railway_network
+        assert "connections" in test_railway_network
+        assert "stats" in test_railway_network
+
+    def test_network_has_expected_counts(self, test_railway_network: RailwayNetworkFixture):
+        """Verify fixture contains expected number of entities."""
+        stats = test_railway_network["stats"]
+
+        # 49 stations (6 deprecated + 43 new network)
+        assert stats["stations_count"] == 49
+
+        # 8 lines across 4 modes
+        assert stats["lines_count"] == 8
+
+        # 2 hubs (HUBNORTH, HUBCENTRAL) + 2 deprecated hubs (HUB_ALPHA, HUB_BETA)
+        assert stats["hubs_count"] == 4
+
+        # ~72 bidirectional connections from route sequences
+        assert stats["connections_count"] > 50
+        assert stats["connections_count"] < 150
+
+    def test_network_has_all_expected_stations(self, test_railway_network: RailwayNetworkFixture):
+        """Verify all expected stations exist in network."""
+        stations = test_railway_network["stations"]
+
+        # Check new network stations (sample)
+        assert "parallel-north" in stations
+        assert "fork-junction" in stations
+        assert "shared-station" in stations
+        assert "hubnorth-overground" in stations
+        assert "hubcentral-dlr" in stations
+
+        # Check deprecated stations still present
+        assert TestRailwayNetwork.HUB_ALPHA_TUBE_ID in stations
+        assert TestRailwayNetwork.STANDALONE_CHARLIE_ID in stations
+
+    def test_network_has_all_lines(self, test_railway_network: RailwayNetworkFixture):
+        """Verify all 8 lines exist in network."""
+        lines = test_railway_network["lines"]
+
+        assert "forkedline" in lines
+        assert "parallelline" in lines
+        assert "asymmetricline" in lines
+        assert "2stopline" in lines
+        assert "sharedline-a" in lines
+        assert "sharedline-b" in lines
+        assert "sharedline-c" in lines
+        assert "elizabethline" in lines
+
+    def test_hub_north_structure(self, test_railway_network: RailwayNetworkFixture):
+        """Verify HUB_NORTH has correct child stations."""
+        hub_stations = test_railway_network["hubs"]["HUBNORTH"]
+
+        # HUB_NORTH should have 4 children (tube, overground, elizabeth, bus)
+        assert len(hub_stations) == 4
+
+        # Get station IDs
+        station_ids = {s.tfl_id for s in hub_stations}
+
+        assert "parallel-north" in station_ids  # tube
+        assert "hubnorth-overground" in station_ids  # overground
+        assert "hubnorth-elizabeth" in station_ids  # elizabeth-line
+        assert "hubnorth-bus" in station_ids  # bus
+
+        # All should have same hub code and common name
+        for station in hub_stations:
+            assert station.hub_naptan_code == "HUBNORTH"
+            assert station.hub_common_name == "North Interchange"
+
+    def test_hub_central_structure(self, test_railway_network: RailwayNetworkFixture):
+        """Verify HUB_CENTRAL has correct child stations."""
+        hub_stations = test_railway_network["hubs"]["HUBCENTRAL"]
+
+        # HUB_CENTRAL should have 2 children (tube, dlr)
+        assert len(hub_stations) == 2
+
+        station_ids = {s.tfl_id for s in hub_stations}
+
+        assert "fork-mid-1" in station_ids  # tube (forkedline)
+        assert "hubcentral-dlr" in station_ids  # dlr (2stopline)
+
+        for station in hub_stations:
+            assert station.hub_naptan_code == "HUBCENTRAL"
+            assert station.hub_common_name == "Central Hub"
+
+    def test_connections_are_bidirectional(self, test_railway_network: RailwayNetworkFixture):
+        """Verify connections exist in both directions (sample check)."""
+        connections = test_railway_network["connections"]
+
+        # Get station IDs for testing
+        parallel_north = test_railway_network["stations"]["parallel-north"]
+        parallel_split = test_railway_network["stations"]["parallel-split"]
+        parallelline = test_railway_network["lines"]["parallelline"]
+
+        # Find connections between parallel-north and parallel-split
+        forward_conn = None
+        reverse_conn = None
+
+        for conn in connections:
+            if (
+                conn.from_station_id == parallel_north.id
+                and conn.to_station_id == parallel_split.id
+                and conn.line_id == parallelline.id
+            ):
+                forward_conn = conn
+
+            if (
+                conn.from_station_id == parallel_split.id
+                and conn.to_station_id == parallel_north.id
+                and conn.line_id == parallelline.id
+            ):
+                reverse_conn = conn
+
+        # Both directions should exist
+        assert forward_conn is not None, "Forward connection should exist"
+        assert reverse_conn is not None, "Reverse connection should exist"
+
+    def test_shared_station_appears_on_multiple_lines(self, test_railway_network: RailwayNetworkFixture):
+        """Verify shared-station serves 3 lines (sharedline-a, b, c)."""
+        shared_station = test_railway_network["stations"]["shared-station"]
+
+        # Check station.lines contains all 3 line IDs
+        assert "sharedline-a" in shared_station.lines
+        assert "sharedline-b" in shared_station.lines
+        assert "sharedline-c" in shared_station.lines
+
+        # Station should not be a hub
+        assert shared_station.hub_naptan_code is None
+
+
+class TestNetworkHelpers:
+    """Tests for network helper functions."""
+
+    def test_get_station_by_tfl_id(self, test_railway_network: RailwayNetworkFixture):
+        """Test getting station by TfL ID."""
+        station = get_station_by_tfl_id(test_railway_network, "parallel-north")
+
+        assert station.tfl_id == "parallel-north"
+        assert station.hub_naptan_code == "HUBNORTH"
+
+    def test_get_line_by_tfl_id(self, test_railway_network: RailwayNetworkFixture):
+        """Test getting line by TfL ID."""
+        line = get_line_by_tfl_id(test_railway_network, "forkedline")
+
+        assert line.tfl_id == "forkedline"
+        assert line.mode == "tube"
+
+    def test_get_hub_stations(self, test_railway_network: RailwayNetworkFixture):
+        """Test getting hub child stations."""
+        hub_stations = get_hub_stations(test_railway_network, "HUBNORTH")
+
+        assert len(hub_stations) == 4
+        assert all(s.hub_naptan_code == "HUBNORTH" for s in hub_stations)
+
+    def test_get_connections_for_line(self, test_railway_network: RailwayNetworkFixture):
+        """Test getting connections for a specific line."""
+        connections = get_connections_for_line(test_railway_network, "2stopline")
+
+        # 2stopline has only 2 stations, so 2 bidirectional connections (A→B, B→A)
+        assert len(connections) == 2
+
+        # Verify line_id matches
+        line = get_line_by_tfl_id(test_railway_network, "2stopline")
+        assert all(conn.line_id == line.id for conn in connections)
+
+    def test_get_stations_on_line(self, test_railway_network: RailwayNetworkFixture):
+        """Test getting all stations on a line."""
+        stations = get_stations_on_line(test_railway_network, "2stopline")
+
+        # 2stopline has exactly 2 stations
+        assert len(stations) == 2
+
+        station_ids = {s.tfl_id for s in stations}
+        assert "twostop-west" in station_ids
+        assert "twostop-east" in station_ids
+
+    def test_helper_raises_on_invalid_id(self, test_railway_network: RailwayNetworkFixture):
+        """Test helpers raise KeyError for invalid IDs."""
+        with pytest.raises(KeyError):
+            get_station_by_tfl_id(test_railway_network, "nonexistent-station")
+
+        with pytest.raises(KeyError):
+            get_line_by_tfl_id(test_railway_network, "nonexistent-line")
+
+        with pytest.raises(KeyError):
+            get_hub_stations(test_railway_network, "NONEXISTENT_HUB")

--- a/backend/tests/test_routes_api.py
+++ b/backend/tests/test_routes_api.py
@@ -16,7 +16,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from tests.conftest import RailwayNetworkFixture
+from tests.helpers.types import RailwayNetworkFixture
 
 
 class TestRoutesAPI:

--- a/docs/test_network_diagram.md
+++ b/docs/test_network_diagram.md
@@ -13,6 +13,8 @@ The `TestRailwayNetwork` class in `/backend/tests/helpers/railway_network.py` pr
 **Why This Network?**
 This fictional network makes tests self-documenting and easier to understand. Instead of memorizing real TfL station names and relationships, tests use descriptive station names like `fork-junction` and `parallel-split` that clearly indicate their purpose.
 
+Note: a "hub" is defined (in NaTPAN) as a multi-mode interchange (stations serving different transport modes), while "shared stations" serve multiple lines of the same mode. A station on multiple lines of the same mode is NOT a hub.
+
 ---
 
 ## Network Diagram


### PR DESCRIPTION
closes #105

## Summary by Sourcery

Introduce a comprehensive test railway network fixture, migrate existing route tests to use it, and add supporting integration tests and helpers

New Features:
- Add `test_railway_network` fixture constructing a full-scale mock network of stations, lines, hubs, and connections
- Provide integration tests and helper functions (`network_helpers.py`) to verify and query the network fixture

Enhancements:
- Replace legacy `hub_test_data` in route API tests with the new fixture and update tests to use updated station IDs and hub codes
- Extend test network documentation with definitions for hubs versus shared stations