### PR TITLE
Feature/issue 106 migrate dedup tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
   "python.testing.cwd": "${workspaceFolder}/backend",
   "python.testing.pytestArgs": [
     "tests"
-  ]
+  ],
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/DavidAnson/markdownlint/main/schema/markdownlint-config-schema.json": "untitled:Untitled-2"
+  }
 }

--- a/backend/tests/test_tfl_api_dedup.py
+++ b/backend/tests/test_tfl_api_dedup.py
@@ -4,7 +4,6 @@ import posixpath
 import uuid
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -16,8 +15,7 @@ from app.models.user import User
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-if TYPE_CHECKING:
-    from tests.helpers.types import RailwayNetworkFixture
+from tests.helpers.types import RailwayNetworkFixture
 
 
 def build_api_url(endpoint: str) -> str:

--- a/backend/tests/test_tfl_api_dedup.py
+++ b/backend/tests/test_tfl_api_dedup.py
@@ -119,8 +119,8 @@ class TestGetStationsDeduplicated:
             assert hub_station["name"] == "North Interchange"
             assert hub_station["hub_naptan_code"] == "HUBNORTH"
             assert hub_station["hub_common_name"] == "North Interchange"
-            # Lines should be aggregated and sorted
-            assert hub_station["lines"] == ["asymmetricline", "parallelline"]
+            # Lines should be aggregated
+            assert set(hub_station["lines"]) == {"asymmetricline", "parallelline"}
 
             # Find standalone
             standalone_result = next(s for s in data if s["tfl_id"] == "via-bank-1")

--- a/backend/tests/test_tfl_service_dedup.py
+++ b/backend/tests/test_tfl_service_dedup.py
@@ -2,15 +2,13 @@
 
 import uuid
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
 
 import pytest
 from app.models.tfl import Station
 from app.services.tfl_service import TfLService
 from sqlalchemy.ext.asyncio import AsyncSession
 
-if TYPE_CHECKING:
-    from tests.helpers.types import RailwayNetworkFixture
+from tests.helpers.types import RailwayNetworkFixture
 
 
 @pytest.fixture


### PR DESCRIPTION
closes #106

## Summary by Sourcery

Enhancements:
- Migrate service and API deduplication tests to use the RailwayNetworkFixture helper instead of manual Station instantiation