### PR TITLE
refactor: replace real TfL station IDs with factory pattern in route API tests (Issue #107)

### DIFF
--- a/backend/tests/test_routes_api.py
+++ b/backend/tests/test_routes_api.py
@@ -16,6 +16,7 @@ from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from tests.helpers.railway_network import create_test_station
 from tests.helpers.types import RailwayNetworkFixture
 
 
@@ -36,13 +37,10 @@ class TestRoutesAPI:
     @pytest.fixture
     async def test_station1(self, db_session: AsyncSession) -> Station:
         """Create a test station."""
-        station = Station(
-            tfl_id="940GZZLUOXC",
-            name="Oxford Circus",
-            latitude=51.515,
-            longitude=-0.141,
-            lines=["central", "victoria"],
-            last_updated=datetime.now(UTC),
+        station = create_test_station(
+            tfl_id="test-station-1",
+            name="Test Station 1",
+            lines=["test-line-1", "test-line-2"],
         )
         db_session.add(station)
         await db_session.commit()
@@ -52,13 +50,10 @@ class TestRoutesAPI:
     @pytest.fixture
     async def test_station2(self, db_session: AsyncSession) -> Station:
         """Create a second test station."""
-        station = Station(
-            tfl_id="940GZZLUBND",
-            name="Bond Street",
-            latitude=51.514,
-            longitude=-0.149,
-            lines=["central", "jubilee"],
-            last_updated=datetime.now(UTC),
+        station = create_test_station(
+            tfl_id="test-station-2",
+            name="Test Station 2",
+            lines=["test-line-1", "test-line-3"],
         )
         db_session.add(station)
         await db_session.commit()
@@ -68,13 +63,10 @@ class TestRoutesAPI:
     @pytest.fixture
     async def test_station3(self, db_session: AsyncSession) -> Station:
         """Create a third test station."""
-        station = Station(
-            tfl_id="940GZZLUTCR",
-            name="Tottenham Court Road",
-            latitude=51.516,
-            longitude=-0.130,
-            lines=["central", "northern"],
-            last_updated=datetime.now(UTC),
+        station = create_test_station(
+            tfl_id="test-station-3",
+            name="Test Station 3",
+            lines=["test-line-1", "test-line-4"],
         )
         db_session.add(station)
         await db_session.commit()


### PR DESCRIPTION
Replace inline Station() constructors with create_test_station() factory in test_station1/2/3 fixtures. This improves maintainability by:
- Single point of change when Station model evolves
- Easy to find impacted tests (grep for create_test_station)
- Consistent defaults across all test stations

Changes:
- Add import for create_test_station from tests.helpers.railway_network
- Refactor test_station1: 940GZZLUOXC → test-station-1
- Refactor test_station2: 940GZZLUBND → test-station-2
- Refactor test_station3: 940GZZLUTCR → test-station-3
- Abstract line names: central/victoria/jubilee → test-line-1/2/3/4

Test results:
- All 54 tests passing (100% pass rate)
- route_service.py coverage maintained at 96.62%
- All pre-commit hooks passing (ruff, mypy, prettier)

Issue #107 completion note:
The issue description was outdated - hub_test_data fixture was already removed and hub validation tests were already migrated in previous PRs (#104, #105, #106). This PR completes the final remaining work: refactoring the 3 basic CRUD test fixtures to use the factory pattern.

Resolves #107
closes #70 (parent issue)

## Summary by Sourcery

Refactor route API tests to centralize station fixture creation using a factory, replacing hard-coded TfL IDs and line names with consistent test values for improved maintainability.

Enhancements:
- Replace inline Station constructors with create_test_station factory in route API tests

Tests:
- Refactor test_station1/2/3 fixtures to use create_test_station with generic IDs, names, and test-line values