### PR TITLE
Feature/issue 126 capture tfl disruption data

### DIFF
--- a/backend/app/schemas/tfl.py
+++ b/backend/app/schemas/tfl.py
@@ -53,6 +53,18 @@ class StationResponse(BaseModel):
     hub_common_name: str | None  # Hub common name (e.g., 'Seven Sisters')
 
 
+class AffectedRouteInfo(BaseModel):
+    """Route segment affected by disruption.
+
+    Contains affected stations for matching against user routes.
+    Does NOT include route variant IDs (not available in Line.routes data).
+    """
+
+    name: str  # e.g., "Cockfosters → Heathrow Terminal 5"
+    direction: str  # "inbound" or "outbound"
+    affected_stations: list[str]  # NaPTAN codes in sequence
+
+
 class DisruptionResponse(BaseModel):
     """Response schema for TfL disruption data."""
 
@@ -62,6 +74,7 @@ class DisruptionResponse(BaseModel):
     status_severity_description: str  # e.g., "Good Service", "Severe Delays"
     reason: str | None = None  # Description of disruption
     created_at: datetime | None = None  # When disruption started (if available)
+    affected_routes: list[AffectedRouteInfo] | None = None  # Affected route segments with station sequences
 
 
 class StationDisruptionResponse(BaseModel):

--- a/backend/tfl_responses/Line_DisruptionByModeByPathModes.txt
+++ b/backend/tfl_responses/Line_DisruptionByModeByPathModes.txt
@@ -1,0 +1,42 @@
+HTTP/1.1 200 OK
+
+age: 0
+api-entity-payload: Disruption
+cache-control: public, must-revalidate, max-age=30, s-maxage=60
+content-encoding: gzip
+content-length: 350
+content-type: application/json; charset=utf-8
+date: Thu, 13 Nov 2025 07:49:24 GMT
+server: cloudflare
+via: 1.1 varnish
+x-api: Line
+x-aspnet-version: 4.0.30319
+x-backend: api
+x-cache: MISS
+x-cacheable: Yes. Cacheable
+x-frame-options: deny
+x-operation: Line_DisruptionByModeByPathModes
+x-proxy-connection: unset
+x-ttl: 60.000
+x-ttl-rule: 0
+x-varnish: 665010810
+
+[{
+    "$type": "Tfl.Api.Presentation.Entities.Disruption, Tfl.Api.Presentation.Entities",
+    "category": "RealTime",
+    "type": "routeInfo",
+    "categoryDescription": "RealTime",
+    "description": "Central Line: Minor delays between North Acton and West Ruislip due to train cancellations. GOOD SERVICE on the rest of the line.  ",
+    "affectedRoutes": [],
+    "affectedStops": [],
+    "closureText": "minorDelays"
+}, {
+    "$type": "Tfl.Api.Presentation.Entities.Disruption, Tfl.Api.Presentation.Entities",
+    "category": "RealTime",
+    "type": "routeBlocking",
+    "categoryDescription": "RealTime",
+    "description": "Piccadilly Line: No service between Cockfosters and Arnos Grove while we fix a track fault. Tickets are valid on London Buses. GOOD SERVICE on the rest of the line.  ",
+    "affectedRoutes": [],
+    "affectedStops": [],
+    "closureText": "partSuspended"
+}]

--- a/backend/tfl_responses/Line_RouteSequenceByPathIdPathDirectionQueryServiceTypesQueryExcludeCrowding.txt
+++ b/backend/tfl_responses/Line_RouteSequenceByPathIdPathDirectionQueryServiceTypesQueryExcludeCrowding.txt
@@ -1,0 +1,4962 @@
+HTTP/1.1 200 OK
+
+age: 0
+api-entity-payload: Line,RouteSection
+cache-control: public, must-revalidate, max-age=43200, s-maxage=86400
+content-encoding: gzip
+content-length: 7690
+content-type: application/json; charset=utf-8
+date: Thu, 13 Nov 2025 08:11:18 GMT
+server: cloudflare
+via: 1.1 varnish
+x-api: Line
+x-aspnet-version: 4.0.30319
+x-backend: api
+x-cache: MISS
+x-cacheable: Yes. Cacheable
+x-frame-options: deny
+x-operation: Line_RouteSequenceByPathIdPathDirectionQueryServiceTypesQueryExcludeCrowding
+x-proxy-connection: unset
+x-ttl: 3600.000
+x-ttl-rule: 359
+x-varnish: 1133872768
+
+{
+    "$type": "Tfl.Api.Presentation.Entities.RouteSequence, Tfl.Api.Presentation.Entities",
+    "lineId": "northern",
+    "lineName": "Northern",
+    "direction": "inbound",
+    "isOutboundOnly": false,
+    "mode": "tube",
+    "lineStrings": ["[[[-0.194298,51.650541],[-0.17921,51.630597],[-0.18542,51.618014],[-0.188362,51.609426],[-0.192527,51.600921],[-0.165012,51.587131],[-0.145857,51.577532],[-0.134819,51.565478],[-0.138433,51.556822],[-0.140733,51.550312],[-0.14274,51.539292],[-0.138789,51.534679],[-0.132182,51.528055],[-0.138321,51.524951],[-0.134361,51.520599],[-0.13041,51.516426],[-0.128426,51.511386],[-0.127277,51.50741],[-0.122666,51.507058],[-0.11478,51.503299],[-0.105963,51.488337],[-0.112439,51.48185],[-0.122644,51.472184],[-0.130016,51.465135],[-0.138317,51.461742],[-0.147582,51.452654],[-0.152997,51.443288],[-0.159736,51.435678],[-0.168374,51.42763],[-0.178086,51.41816],[-0.192005,51.415309],[-0.194839,51.402142]]]", "[[[-0.194298,51.650541],[-0.17921,51.630597],[-0.18542,51.618014],[-0.188362,51.609426],[-0.192527,51.600921],[-0.165012,51.587131],[-0.145857,51.577532],[-0.134819,51.565478],[-0.138433,51.556822],[-0.140733,51.550312],[-0.14274,51.539292],[-0.132182,51.528055],[-0.123194,51.530663],[-0.105898,51.532624],[-0.08777,51.525864],[-0.088322,51.518176],[-0.090047,51.513132],[-0.088873,51.505721],[-0.09337,51.501199],[-0.100606,51.494536],[-0.105963,51.488337],[-0.112439,51.48185],[-0.122644,51.472184],[-0.130016,51.465135],[-0.138317,51.461742],[-0.147582,51.452654],[-0.152997,51.443288],[-0.159736,51.435678],[-0.168374,51.42763],[-0.178086,51.41816],[-0.192005,51.415309],[-0.194839,51.402142]]]", "[[[-0.274928,51.613653],[-0.264048,51.602774],[-0.249919,51.595424],[-0.226424,51.583301],[-0.213622,51.57665],[-0.194039,51.572259],[-0.177464,51.556239],[-0.164783,51.550529],[-0.153388,51.544118],[-0.14274,51.539292],[-0.138789,51.534679],[-0.132182,51.528055],[-0.138321,51.524951],[-0.134361,51.520599],[-0.13041,51.516426],[-0.128426,51.511386],[-0.127277,51.50741],[-0.122666,51.507058],[-0.11478,51.503299],[-0.105963,51.488337],[-0.112439,51.48185],[-0.122644,51.472184],[-0.130016,51.465135],[-0.138317,51.461742],[-0.147582,51.452654],[-0.152997,51.443288],[-0.159736,51.435678],[-0.168374,51.42763],[-0.178086,51.41816],[-0.192005,51.415309],[-0.194839,51.402142]]]", "[[[-0.274928,51.613653],[-0.264048,51.602774],[-0.249919,51.595424],[-0.226424,51.583301],[-0.213622,51.57665],[-0.194039,51.572259],[-0.177464,51.556239],[-0.164783,51.550529],[-0.153388,51.544118],[-0.14274,51.539292],[-0.132182,51.528055],[-0.123194,51.530663],[-0.105898,51.532624],[-0.08777,51.525864],[-0.088322,51.518176],[-0.090047,51.513132],[-0.088873,51.505721],[-0.09337,51.501199],[-0.100606,51.494536],[-0.105963,51.488337],[-0.112439,51.48185],[-0.122644,51.472184],[-0.130016,51.465135],[-0.138317,51.461742],[-0.147582,51.452654],[-0.152997,51.443288],[-0.159736,51.435678],[-0.168374,51.42763],[-0.178086,51.41816],[-0.192005,51.415309],[-0.194839,51.402142]]]", "[[[-0.209986,51.608229],[-0.192527,51.600921],[-0.165012,51.587131],[-0.145857,51.577532],[-0.134819,51.565478],[-0.138433,51.556822],[-0.140733,51.550312],[-0.14274,51.539292],[-0.138789,51.534679],[-0.132182,51.528055],[-0.138321,51.524951],[-0.134361,51.520599],[-0.13041,51.516426],[-0.128426,51.511386],[-0.127277,51.50741],[-0.122666,51.507058],[-0.11478,51.503299],[-0.105963,51.488337],[-0.112439,51.48185],[-0.122644,51.472184],[-0.130016,51.465135],[-0.138317,51.461742],[-0.147582,51.452654],[-0.152997,51.443288],[-0.159736,51.435678],[-0.168374,51.42763],[-0.178086,51.41816],[-0.192005,51.415309],[-0.194839,51.402142]]]", "[[[-0.209986,51.608229],[-0.192527,51.600921],[-0.165012,51.587131],[-0.145857,51.577532],[-0.134819,51.565478],[-0.138433,51.556822],[-0.140733,51.550312],[-0.14274,51.539292],[-0.132182,51.528055],[-0.123194,51.530663],[-0.105898,51.532624],[-0.08777,51.525864],[-0.088322,51.518176],[-0.090047,51.513132],[-0.088873,51.505721],[-0.09337,51.501199],[-0.100606,51.494536],[-0.105963,51.488337],[-0.112439,51.48185],[-0.122644,51.472184],[-0.130016,51.465135],[-0.138317,51.461742],[-0.147582,51.452654],[-0.152997,51.443288],[-0.159736,51.435678],[-0.168374,51.42763],[-0.178086,51.41816],[-0.192005,51.415309],[-0.194839,51.402142]]]", "[[[-0.194298,51.650541],[-0.17921,51.630597],[-0.18542,51.618014],[-0.188362,51.609426],[-0.192527,51.600921],[-0.165012,51.587131],[-0.145857,51.577532],[-0.134819,51.565478],[-0.138433,51.556822],[-0.140733,51.550312],[-0.14274,51.539292],[-0.138789,51.534679],[-0.132182,51.528055],[-0.138321,51.524951],[-0.134361,51.520599],[-0.13041,51.516426],[-0.128426,51.511386],[-0.127277,51.50741],[-0.122666,51.507058],[-0.11478,51.503299],[-0.105963,51.488337],[-0.128476,51.479912],[-0.142142,51.479932]]]", "[[[-0.274928,51.613653],[-0.264048,51.602774],[-0.249919,51.595424],[-0.226424,51.583301],[-0.213622,51.57665],[-0.194039,51.572259],[-0.177464,51.556239],[-0.164783,51.550529],[-0.153388,51.544118],[-0.14274,51.539292],[-0.138789,51.534679],[-0.132182,51.528055],[-0.138321,51.524951],[-0.134361,51.520599],[-0.13041,51.516426],[-0.128426,51.511386],[-0.127277,51.50741],[-0.122666,51.507058],[-0.11478,51.503299],[-0.105963,51.488337],[-0.128476,51.479912],[-0.142142,51.479932]]]"],
+    "stations": [{
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZBPSUST",
+        "icsId": "1002195",
+        "topMostParentId": "940GZZBPSUST",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZBPSUST",
+        "name": "Battersea Power Station Underground Station",
+        "lat": 51.479932,
+        "lon": -0.142142
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUACY",
+        "icsId": "1000008",
+        "topMostParentId": "940GZZLUACY",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "2+3",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUACY",
+        "name": "Archway Underground Station",
+        "lat": 51.565478,
+        "lon": -0.134819
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUAGL",
+        "icsId": "1000007",
+        "topMostParentId": "940GZZLUAGL",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUAGL",
+        "name": "Angel Underground Station",
+        "lat": 51.532624,
+        "lon": -0.105898
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUBOR",
+        "icsId": "1000026",
+        "topMostParentId": "940GZZLUBOR",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUBOR",
+        "name": "Borough Underground Station",
+        "lat": 51.501199,
+        "lon": -0.09337
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUBTK",
+        "icsId": "1000034",
+        "topMostParentId": "940GZZLUBTK",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "4",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUBTK",
+        "name": "Burnt Oak Underground Station",
+        "lat": 51.602774,
+        "lon": -0.264048
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUBTX",
+        "icsId": "1000030",
+        "topMostParentId": "940GZZLUBTX",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "3",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUBTX",
+        "name": "Brent Cross Underground Station",
+        "lat": 51.57665,
+        "lon": -0.213622
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUBZP",
+        "icsId": "1000020",
+        "topMostParentId": "940GZZLUBZP",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "2",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUBZP",
+        "name": "Belsize Park Underground Station",
+        "lat": 51.550529,
+        "lon": -0.164783
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUCFM",
+        "icsId": "1000043",
+        "topMostParentId": "940GZZLUCFM",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "2",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUCFM",
+        "name": "Chalk Farm Underground Station",
+        "lat": 51.544118,
+        "lon": -0.153388
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUCND",
+        "icsId": "1000054",
+        "topMostParentId": "940GZZLUCND",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "4",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUCND",
+        "name": "Colindale Underground Station",
+        "lat": 51.595424,
+        "lon": -0.249919
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUCPC",
+        "icsId": "1000050",
+        "topMostParentId": "940GZZLUCPC",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "2",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUCPC",
+        "name": "Clapham Common Underground Station",
+        "lat": 51.461742,
+        "lon": -0.138317
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUCPN",
+        "icsId": "1000051",
+        "topMostParentId": "940GZZLUCPN",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "2",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUCPN",
+        "name": "Clapham North Underground Station",
+        "lat": 51.465135,
+        "lon": -0.130016
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUCPS",
+        "icsId": "1000052",
+        "topMostParentId": "940GZZLUCPS",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "2+3",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUCPS",
+        "name": "Clapham South Underground Station",
+        "lat": 51.452654,
+        "lon": -0.147582
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUCSD",
+        "icsId": "1000055",
+        "topMostParentId": "940GZZLUCSD",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "3",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUCSD",
+        "name": "Colliers Wood Underground Station",
+        "lat": 51.41816,
+        "lon": -0.178086
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUCTN",
+        "icsId": "1000036",
+        "topMostParentId": "940GZZLUCTN",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "2",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUCTN",
+        "name": "Camden Town Underground Station",
+        "lat": 51.539292,
+        "lon": -0.14274
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUEFY",
+        "icsId": "1000067",
+        "topMostParentId": "940GZZLUEFY",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "3",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUEFY",
+        "name": "East Finchley Underground Station",
+        "lat": 51.587131,
+        "lon": -0.165012
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUEGW",
+        "icsId": "1000070",
+        "topMostParentId": "940GZZLUEGW",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "5",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUEGW",
+        "name": "Edgware Underground Station",
+        "lat": 51.613653,
+        "lon": -0.274928
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUEMB",
+        "icsId": "1000075",
+        "topMostParentId": "940GZZLUEMB",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "bakerloo",
+            "name": "Bakerloo",
+            "uri": "/Line/bakerloo",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "circle",
+            "name": "Circle",
+            "uri": "/Line/circle",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "district",
+            "name": "District",
+            "uri": "/Line/district",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUEMB",
+        "name": "Embankment Underground Station",
+        "lat": 51.507058,
+        "lon": -0.122666
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUFYC",
+        "icsId": "1000081",
+        "topMostParentId": "940GZZLUFYC",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "4",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUFYC",
+        "name": "Finchley Central Underground Station",
+        "lat": 51.600921,
+        "lon": -0.192527
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUGDG",
+        "icsId": "1000089",
+        "topMostParentId": "940GZZLUGDG",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUGDG",
+        "name": "Goodge Street Underground Station",
+        "lat": 51.520599,
+        "lon": -0.134361
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUGGN",
+        "icsId": "1000087",
+        "topMostParentId": "940GZZLUGGN",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "3",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUGGN",
+        "name": "Golders Green Underground Station",
+        "lat": 51.572259,
+        "lon": -0.194039
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUHBT",
+        "icsId": "1000107",
+        "topMostParentId": "940GZZLUHBT",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "5",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUHBT",
+        "name": "High Barnet Underground Station",
+        "lat": 51.650541,
+        "lon": -0.194298
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUHCL",
+        "icsId": "1000106",
+        "topMostParentId": "940GZZLUHCL",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "3+4",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUHCL",
+        "name": "Hendon Central Underground Station",
+        "lat": 51.583301,
+        "lon": -0.226424
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUHGT",
+        "icsId": "1000109",
+        "topMostParentId": "940GZZLUHGT",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "3",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUHGT",
+        "name": "Highgate Underground Station",
+        "lat": 51.577532,
+        "lon": -0.145857
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUHTD",
+        "icsId": "1000098",
+        "topMostParentId": "940GZZLUHTD",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "2+3",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUHTD",
+        "name": "Hampstead Underground Station",
+        "lat": 51.556239,
+        "lon": -0.177464
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUKNG",
+        "icsId": "1000121",
+        "topMostParentId": "940GZZLUKNG",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "1+2",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUKNG",
+        "name": "Kennington Underground Station",
+        "lat": 51.488337,
+        "lon": -0.105963
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLULSQ",
+        "icsId": "1000135",
+        "topMostParentId": "940GZZLULSQ",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "piccadilly",
+            "name": "Piccadilly",
+            "uri": "/Line/piccadilly",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLULSQ",
+        "name": "Leicester Square Underground Station",
+        "lat": 51.511386,
+        "lon": -0.128426
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUMDN",
+        "icsId": "1000151",
+        "topMostParentId": "940GZZLUMDN",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "4",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUMDN",
+        "name": "Morden Underground Station",
+        "lat": 51.402142,
+        "lon": -0.194839
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUMHL",
+        "icsId": "1000147",
+        "topMostParentId": "940GZZLUMHL",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "4",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUMHL",
+        "name": "Mill Hill East Underground Station",
+        "lat": 51.608229,
+        "lon": -0.209986
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUMTC",
+        "icsId": "1000152",
+        "topMostParentId": "940GZZLUMTC",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "2",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUMTC",
+        "name": "Mornington Crescent Underground Station",
+        "lat": 51.534679,
+        "lon": -0.138789
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUOVL",
+        "icsId": "1000172",
+        "topMostParentId": "940GZZLUOVL",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "2",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUOVL",
+        "name": "Oval Underground Station",
+        "lat": 51.48185,
+        "lon": -0.112439
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUSKW",
+        "icsId": "1000223",
+        "topMostParentId": "940GZZLUSKW",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "2",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "victoria",
+            "name": "Victoria",
+            "uri": "/Line/victoria",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUSKW",
+        "name": "Stockwell Underground Station",
+        "lat": 51.472184,
+        "lon": -0.122644
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUSWN",
+        "icsId": "1000216",
+        "topMostParentId": "940GZZLUSWN",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "3+4",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUSWN",
+        "name": "South Wimbledon Underground Station",
+        "lat": 51.415309,
+        "lon": -0.192005
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUTAW",
+        "icsId": "1000237",
+        "topMostParentId": "940GZZLUTAW",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "4",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUTAW",
+        "name": "Totteridge & Whetstone Underground Station",
+        "lat": 51.630597,
+        "lon": -0.17921
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUTBC",
+        "icsId": "1000233",
+        "topMostParentId": "940GZZLUTBC",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "3",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUTBC",
+        "name": "Tooting Bec Underground Station",
+        "lat": 51.435678,
+        "lon": -0.159736
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUTBY",
+        "icsId": "1000234",
+        "topMostParentId": "940GZZLUTBY",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "3",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUTBY",
+        "name": "Tooting Broadway Underground Station",
+        "lat": 51.42763,
+        "lon": -0.168374
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUTFP",
+        "icsId": "1000239",
+        "topMostParentId": "940GZZLUTFP",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "2",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUTFP",
+        "name": "Tufnell Park Underground Station",
+        "lat": 51.556822,
+        "lon": -0.138433
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUWFN",
+        "icsId": "1000261",
+        "topMostParentId": "940GZZLUWFN",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "4",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUWFN",
+        "name": "West Finchley Underground Station",
+        "lat": 51.609426,
+        "lon": -0.188362
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUWOP",
+        "icsId": "1000276",
+        "topMostParentId": "940GZZLUWOP",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "4",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUWOP",
+        "name": "Woodside Park Underground Station",
+        "lat": 51.618014,
+        "lon": -0.18542
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZLUWRR",
+        "icsId": "1000252",
+        "topMostParentId": "940GZZLUWRR",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "victoria",
+            "name": "Victoria",
+            "uri": "/Line/victoria",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZLUWRR",
+        "name": "Warren Street Underground Station",
+        "lat": 51.524951,
+        "lon": -0.138321
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "stationId": "940GZZNEUGST",
+        "icsId": "1002196",
+        "topMostParentId": "940GZZNEUGST",
+        "modes": ["tube"],
+        "stopType": "NaptanMetroStation",
+        "zone": "6",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "940GZZNEUGST",
+        "name": "Nine Elms Underground Station",
+        "lat": 51.479912,
+        "lon": -0.128476
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "icsId": "1000012",
+        "modes": ["bus", "national-rail", "tube"],
+        "stopType": "TransportInterchange",
+        "zone": "3",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "southern",
+            "name": "Southern",
+            "uri": "/Line/southern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "HUBBAL",
+        "name": "Balham",
+        "lat": 51.443259,
+        "lon": -0.152707
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "icsId": "1000013",
+        "modes": ["bus", "dlr", "tube"],
+        "stopType": "TransportInterchange",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "133",
+            "name": "133",
+            "uri": "/Line/133",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "141",
+            "name": "141",
+            "uri": "/Line/141",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "21",
+            "name": "21",
+            "uri": "/Line/21",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "25",
+            "name": "25",
+            "uri": "/Line/25",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "26",
+            "name": "26",
+            "uri": "/Line/26",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "43",
+            "name": "43",
+            "uri": "/Line/43",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "8",
+            "name": "8",
+            "uri": "/Line/8",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "central",
+            "name": "Central",
+            "uri": "/Line/central",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "dlr",
+            "name": "DLR",
+            "uri": "/Line/dlr",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n21",
+            "name": "N21",
+            "uri": "/Line/n21",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n242",
+            "name": "N242",
+            "uri": "/Line/n242",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n25",
+            "name": "N25",
+            "uri": "/Line/n25",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n26",
+            "name": "N26",
+            "uri": "/Line/n26",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n550",
+            "name": "N550",
+            "uri": "/Line/n550",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n551",
+            "name": "N551",
+            "uri": "/Line/n551",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n8",
+            "name": "N8",
+            "uri": "/Line/n8",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "waterloo-city",
+            "name": "Waterloo & City",
+            "uri": "/Line/waterloo-city",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "HUBBAN",
+        "name": "Bank",
+        "lat": 51.513395,
+        "lon": -0.089095
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "icsId": "1000045",
+        "modes": ["bus", "national-rail", "tube"],
+        "stopType": "TransportInterchange",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "139",
+            "name": "139",
+            "uri": "/Line/139",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "176",
+            "name": "176",
+            "uri": "/Line/176",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "26",
+            "name": "26",
+            "uri": "/Line/26",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "87",
+            "name": "87",
+            "uri": "/Line/87",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "91",
+            "name": "91",
+            "uri": "/Line/91",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "bakerloo",
+            "name": "Bakerloo",
+            "uri": "/Line/bakerloo",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n155",
+            "name": "N155",
+            "uri": "/Line/n155",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n199",
+            "name": "N199",
+            "uri": "/Line/n199",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n21",
+            "name": "N21",
+            "uri": "/Line/n21",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n26",
+            "name": "N26",
+            "uri": "/Line/n26",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n343",
+            "name": "N343",
+            "uri": "/Line/n343",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n44",
+            "name": "N44",
+            "uri": "/Line/n44",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n87",
+            "name": "N87",
+            "uri": "/Line/n87",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n89",
+            "name": "N89",
+            "uri": "/Line/n89",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n91",
+            "name": "N91",
+            "uri": "/Line/n91",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "southeastern",
+            "name": "Southeastern",
+            "uri": "/Line/southeastern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "HUBCHX",
+        "name": "Charing Cross",
+        "lat": 51.507819,
+        "lon": -0.126137
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "icsId": "1000073",
+        "modes": ["bus", "national-rail", "tube"],
+        "stopType": "TransportInterchange",
+        "zone": "1+2",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "1",
+            "name": "1",
+            "uri": "/Line/1",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "172",
+            "name": "172",
+            "uri": "/Line/172",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "188",
+            "name": "188",
+            "uri": "/Line/188",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "363",
+            "name": "363",
+            "uri": "/Line/363",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "415",
+            "name": "415",
+            "uri": "/Line/415",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "453",
+            "name": "453",
+            "uri": "/Line/453",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "53",
+            "name": "53",
+            "uri": "/Line/53",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "63",
+            "name": "63",
+            "uri": "/Line/63",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "bakerloo",
+            "name": "Bakerloo",
+            "uri": "/Line/bakerloo",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "bl1",
+            "name": "BL1",
+            "uri": "/Line/bl1",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n1",
+            "name": "N1",
+            "uri": "/Line/n1",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n53",
+            "name": "N53",
+            "uri": "/Line/n53",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n63",
+            "name": "N63",
+            "uri": "/Line/n63",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "southeastern",
+            "name": "Southeastern",
+            "uri": "/Line/southeastern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "thameslink",
+            "name": "Thameslink",
+            "uri": "/Line/thameslink",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "HUBEPH",
+        "name": "Elephant & Castle",
+        "lat": 51.494505,
+        "lon": -0.099185
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "icsId": "1000077",
+        "modes": ["bus", "national-rail", "overground", "tube"],
+        "stopType": "TransportInterchange",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "1",
+            "name": "1",
+            "uri": "/Line/1",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "253",
+            "name": "253",
+            "uri": "/Line/253",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "30",
+            "name": "30",
+            "uri": "/Line/30",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "68",
+            "name": "68",
+            "uri": "/Line/68",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "91",
+            "name": "91",
+            "uri": "/Line/91",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "avanti-west-coast",
+            "name": "Avanti West Coast",
+            "uri": "/Line/avanti-west-coast",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "lioness",
+            "name": "Lioness",
+            "uri": "/Line/lioness",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n20",
+            "name": "N20",
+            "uri": "/Line/n20",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n253",
+            "name": "N253",
+            "uri": "/Line/n253",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n5",
+            "name": "N5",
+            "uri": "/Line/n5",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n91",
+            "name": "N91",
+            "uri": "/Line/n91",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "victoria",
+            "name": "Victoria",
+            "uri": "/Line/victoria",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "west-midlands-trains",
+            "name": "West Midlands Trains",
+            "uri": "/Line/west-midlands-trains",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "HUBEUS",
+        "name": "Euston",
+        "lat": 51.527365,
+        "lon": -0.132754
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "icsId": "1000129",
+        "modes": ["bus", "international-rail", "national-rail", "tube"],
+        "stopType": "TransportInterchange",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "17",
+            "name": "17",
+            "uri": "/Line/17",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "205",
+            "name": "205",
+            "uri": "/Line/205",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "214",
+            "name": "214",
+            "uri": "/Line/214",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "259",
+            "name": "259",
+            "uri": "/Line/259",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "30",
+            "name": "30",
+            "uri": "/Line/30",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "390",
+            "name": "390",
+            "uri": "/Line/390",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "46",
+            "name": "46",
+            "uri": "/Line/46",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "476",
+            "name": "476",
+            "uri": "/Line/476",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "63",
+            "name": "63",
+            "uri": "/Line/63",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "73",
+            "name": "73",
+            "uri": "/Line/73",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "91",
+            "name": "91",
+            "uri": "/Line/91",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "circle",
+            "name": "Circle",
+            "uri": "/Line/circle",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "east-midlands-railway",
+            "name": "East Midlands Railway",
+            "uri": "/Line/east-midlands-railway",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "grand-central",
+            "name": "Grand Central",
+            "uri": "/Line/grand-central",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "great-northern",
+            "name": "Great Northern",
+            "uri": "/Line/great-northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "hammersmith-city",
+            "name": "Hammersmith & City",
+            "uri": "/Line/hammersmith-city",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "hull-trains",
+            "name": "Hull Trains",
+            "uri": "/Line/hull-trains",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "london-north-eastern-railway",
+            "name": "London North Eastern Railway",
+            "uri": "/Line/london-north-eastern-railway",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "lumo",
+            "name": "Lumo",
+            "uri": "/Line/lumo",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "metropolitan",
+            "name": "Metropolitan",
+            "uri": "/Line/metropolitan",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n205",
+            "name": "N205",
+            "uri": "/Line/n205",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n63",
+            "name": "N63",
+            "uri": "/Line/n63",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n73",
+            "name": "N73",
+            "uri": "/Line/n73",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n91",
+            "name": "N91",
+            "uri": "/Line/n91",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "piccadilly",
+            "name": "Piccadilly",
+            "uri": "/Line/piccadilly",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "southeastern",
+            "name": "Southeastern",
+            "uri": "/Line/southeastern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "thameslink",
+            "name": "Thameslink",
+            "uri": "/Line/thameslink",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "victoria",
+            "name": "Victoria",
+            "uri": "/Line/victoria",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "HUBKGX",
+        "name": "King's Cross & St Pancras International",
+        "lat": 51.531683,
+        "lon": -0.123538
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "icsId": "1000123",
+        "modes": ["bus", "national-rail", "tube"],
+        "stopType": "TransportInterchange",
+        "zone": "2",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "east-midlands-railway",
+            "name": "East Midlands Railway",
+            "uri": "/Line/east-midlands-railway",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "thameslink",
+            "name": "Thameslink",
+            "uri": "/Line/thameslink",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "HUBKTN",
+        "name": "Kentish Town",
+        "lat": 51.550409,
+        "lon": -0.140545
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "icsId": "1000139",
+        "modes": ["bus", "national-rail", "tube"],
+        "stopType": "TransportInterchange",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "133",
+            "name": "133",
+            "uri": "/Line/133",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "141",
+            "name": "141",
+            "uri": "/Line/141",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "149",
+            "name": "149",
+            "uri": "/Line/149",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "17",
+            "name": "17",
+            "uri": "/Line/17",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "21",
+            "name": "21",
+            "uri": "/Line/21",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "344",
+            "name": "344",
+            "uri": "/Line/344",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "35",
+            "name": "35",
+            "uri": "/Line/35",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "388",
+            "name": "388",
+            "uri": "/Line/388",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "43",
+            "name": "43",
+            "uri": "/Line/43",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "47",
+            "name": "47",
+            "uri": "/Line/47",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "jubilee",
+            "name": "Jubilee",
+            "uri": "/Line/jubilee",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n133",
+            "name": "N133",
+            "uri": "/Line/n133",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n199",
+            "name": "N199",
+            "uri": "/Line/n199",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n21",
+            "name": "N21",
+            "uri": "/Line/n21",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n343",
+            "name": "N343",
+            "uri": "/Line/n343",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "southeastern",
+            "name": "Southeastern",
+            "uri": "/Line/southeastern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "southern",
+            "name": "Southern",
+            "uri": "/Line/southern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "thameslink",
+            "name": "Thameslink",
+            "uri": "/Line/thameslink",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "HUBLBG",
+        "name": "London Bridge",
+        "lat": 51.505881,
+        "lon": -0.086807
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "icsId": "1000169",
+        "modes": ["bus", "national-rail", "tube"],
+        "stopType": "TransportInterchange",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "great-northern",
+            "name": "Great Northern",
+            "uri": "/Line/great-northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "HUBOLD",
+        "name": "Old Street",
+        "lat": 51.526065,
+        "lon": -0.088193
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "icsId": "1000235",
+        "modes": ["elizabeth-line", "tube"],
+        "stopType": "TransportInterchange",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "central",
+            "name": "Central",
+            "uri": "/Line/central",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "elizabeth",
+            "name": "Elizabeth line",
+            "uri": "/Line/elizabeth",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "HUBTCR",
+        "name": "Tottenham Court Road",
+        "lat": 51.516018,
+        "lon": -0.130888
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "icsId": "1000254",
+        "modes": ["bus", "national-rail", "tube"],
+        "stopType": "TransportInterchange",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "1",
+            "name": "1",
+            "uri": "/Line/1",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "11",
+            "name": "11",
+            "uri": "/Line/11",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "139",
+            "name": "139",
+            "uri": "/Line/139",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "172",
+            "name": "172",
+            "uri": "/Line/172",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "176",
+            "name": "176",
+            "uri": "/Line/176",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "188",
+            "name": "188",
+            "uri": "/Line/188",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "243",
+            "name": "243",
+            "uri": "/Line/243",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "341",
+            "name": "341",
+            "uri": "/Line/341",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "381",
+            "name": "381",
+            "uri": "/Line/381",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "59",
+            "name": "59",
+            "uri": "/Line/59",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "68",
+            "name": "68",
+            "uri": "/Line/68",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "76",
+            "name": "76",
+            "uri": "/Line/76",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "77",
+            "name": "77",
+            "uri": "/Line/77",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "bakerloo",
+            "name": "Bakerloo",
+            "uri": "/Line/bakerloo",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "bl1",
+            "name": "BL1",
+            "uri": "/Line/bl1",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "c10",
+            "name": "C10",
+            "uri": "/Line/c10",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "jubilee",
+            "name": "Jubilee",
+            "uri": "/Line/jubilee",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n1",
+            "name": "N1",
+            "uri": "/Line/n1",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n171",
+            "name": "N171",
+            "uri": "/Line/n171",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n381",
+            "name": "N381",
+            "uri": "/Line/n381",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "n68",
+            "name": "N68",
+            "uri": "/Line/n68",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "sl6",
+            "name": "SL6",
+            "uri": "/Line/sl6",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "south-western-railway",
+            "name": "South Western Railway",
+            "uri": "/Line/south-western-railway",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "waterloo-city",
+            "name": "Waterloo & City",
+            "uri": "/Line/waterloo-city",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "HUBWAT",
+        "name": "Waterloo",
+        "lat": 51.504269,
+        "lon": -0.113356
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+        "icsId": "1000149",
+        "modes": ["bus", "national-rail", "tube"],
+        "stopType": "TransportInterchange",
+        "zone": "1",
+        "lines": [{
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "circle",
+            "name": "Circle",
+            "uri": "/Line/circle",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "great-northern",
+            "name": "Great Northern",
+            "uri": "/Line/great-northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "hammersmith-city",
+            "name": "Hammersmith & City",
+            "uri": "/Line/hammersmith-city",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "metropolitan",
+            "name": "Metropolitan",
+            "uri": "/Line/metropolitan",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+            "id": "northern",
+            "name": "Northern",
+            "uri": "/Line/northern",
+            "type": "Line",
+            "crowding": {
+                "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+            },
+            "routeType": "Unknown",
+            "status": "Unknown"
+        }],
+        "status": true,
+        "id": "HUBZMG",
+        "name": "Moorgate",
+        "lat": 51.518338,
+        "lon": -0.088627
+    }],
+    "stopPointSequences": [{
+        "$type": "Tfl.Api.Presentation.Entities.StopPointSequence, Tfl.Api.Presentation.Entities",
+        "lineId": "northern",
+        "lineName": "Northern",
+        "direction": "inbound",
+        "branchId": 1,
+        "nextBranchIds": [9],
+        "prevBranchIds": [],
+        "stopPoint": [{
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUHBT",
+            "icsId": "1000107",
+            "topMostParentId": "940GZZLUHBT",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "5",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUHBT",
+            "name": "High Barnet Underground Station",
+            "lat": 51.650541,
+            "lon": -0.194298
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUTAW",
+            "icsId": "1000237",
+            "topMostParentId": "940GZZLUTAW",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "4",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUTAW",
+            "name": "Totteridge & Whetstone Underground Station",
+            "lat": 51.630597,
+            "lon": -0.17921
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUWOP",
+            "icsId": "1000276",
+            "topMostParentId": "940GZZLUWOP",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "4",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUWOP",
+            "name": "Woodside Park Underground Station",
+            "lat": 51.618014,
+            "lon": -0.18542
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUWFN",
+            "icsId": "1000261",
+            "topMostParentId": "940GZZLUWFN",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "4",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUWFN",
+            "name": "West Finchley Underground Station",
+            "lat": 51.609426,
+            "lon": -0.188362
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUFYC",
+            "icsId": "1000081",
+            "topMostParentId": "940GZZLUFYC",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "4",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUFYC",
+            "name": "Finchley Central Underground Station",
+            "lat": 51.600921,
+            "lon": -0.192527
+        }],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.StopPointSequence, Tfl.Api.Presentation.Entities",
+        "lineId": "northern",
+        "lineName": "Northern",
+        "direction": "inbound",
+        "branchId": 9,
+        "nextBranchIds": [3, 4],
+        "prevBranchIds": [1, 2],
+        "stopPoint": [{
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUFYC",
+            "icsId": "1000081",
+            "topMostParentId": "940GZZLUFYC",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "4",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUFYC",
+            "name": "Finchley Central Underground Station",
+            "lat": 51.600921,
+            "lon": -0.192527
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUEFY",
+            "icsId": "1000067",
+            "topMostParentId": "940GZZLUEFY",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "3",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUEFY",
+            "name": "East Finchley Underground Station",
+            "lat": 51.587131,
+            "lon": -0.165012
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUHGT",
+            "icsId": "1000109",
+            "topMostParentId": "940GZZLUHGT",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "3",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUHGT",
+            "name": "Highgate Underground Station",
+            "lat": 51.577532,
+            "lon": -0.145857
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUACY",
+            "icsId": "1000008",
+            "topMostParentId": "940GZZLUACY",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2+3",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUACY",
+            "name": "Archway Underground Station",
+            "lat": 51.565478,
+            "lon": -0.134819
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUTFP",
+            "icsId": "1000239",
+            "topMostParentId": "940GZZLUTFP",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUTFP",
+            "name": "Tufnell Park Underground Station",
+            "lat": 51.556822,
+            "lon": -0.138433
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "parentId": "HUBKTN",
+            "stationId": "940GZZLUKSH",
+            "icsId": "1000123",
+            "topMostParentId": "HUBKTN",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUKSH",
+            "name": "Kentish Town Underground Station",
+            "lat": 51.550312,
+            "lon": -0.140733
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUCTN",
+            "icsId": "1000036",
+            "topMostParentId": "940GZZLUCTN",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUCTN",
+            "name": "Camden Town Underground Station",
+            "lat": 51.539292,
+            "lon": -0.14274
+        }],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.StopPointSequence, Tfl.Api.Presentation.Entities",
+        "lineId": "northern",
+        "lineName": "Northern",
+        "direction": "inbound",
+        "branchId": 3,
+        "nextBranchIds": [5],
+        "prevBranchIds": [9, 0],
+        "stopPoint": [{
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUCTN",
+            "icsId": "1000036",
+            "topMostParentId": "940GZZLUCTN",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUCTN",
+            "name": "Camden Town Underground Station",
+            "lat": 51.539292,
+            "lon": -0.14274
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUMTC",
+            "icsId": "1000152",
+            "topMostParentId": "940GZZLUMTC",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUMTC",
+            "name": "Mornington Crescent Underground Station",
+            "lat": 51.534679,
+            "lon": -0.138789
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "parentId": "HUBEUS",
+            "stationId": "940GZZLUEUS",
+            "icsId": "1000077",
+            "topMostParentId": "HUBEUS",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "hasDisruption": true,
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "victoria",
+                "name": "Victoria",
+                "uri": "/Line/victoria",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUEUS",
+            "name": "Euston Underground Station",
+            "lat": 51.528055,
+            "lon": -0.132182
+        }],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.StopPointSequence, Tfl.Api.Presentation.Entities",
+        "lineId": "northern",
+        "lineName": "Northern",
+        "direction": "inbound",
+        "branchId": 5,
+        "nextBranchIds": [7, 8],
+        "prevBranchIds": [3],
+        "stopPoint": [{
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "parentId": "HUBEUS",
+            "stationId": "940GZZLUEUS",
+            "icsId": "1000077",
+            "topMostParentId": "HUBEUS",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "hasDisruption": true,
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "victoria",
+                "name": "Victoria",
+                "uri": "/Line/victoria",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUEUS",
+            "name": "Euston Underground Station",
+            "lat": 51.528055,
+            "lon": -0.132182
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUWRR",
+            "icsId": "1000252",
+            "topMostParentId": "940GZZLUWRR",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "victoria",
+                "name": "Victoria",
+                "uri": "/Line/victoria",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUWRR",
+            "name": "Warren Street Underground Station",
+            "lat": 51.524951,
+            "lon": -0.138321
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUGDG",
+            "icsId": "1000089",
+            "topMostParentId": "940GZZLUGDG",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUGDG",
+            "name": "Goodge Street Underground Station",
+            "lat": 51.520599,
+            "lon": -0.134361
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "parentId": "HUBTCR",
+            "stationId": "940GZZLUTCR",
+            "icsId": "1000235",
+            "topMostParentId": "HUBTCR",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "central",
+                "name": "Central",
+                "uri": "/Line/central",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUTCR",
+            "name": "Tottenham Court Road Underground Station",
+            "lat": 51.516426,
+            "lon": -0.13041
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLULSQ",
+            "icsId": "1000135",
+            "topMostParentId": "940GZZLULSQ",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "piccadilly",
+                "name": "Piccadilly",
+                "uri": "/Line/piccadilly",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLULSQ",
+            "name": "Leicester Square Underground Station",
+            "lat": 51.511386,
+            "lon": -0.128426
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "parentId": "HUBCHX",
+            "stationId": "940GZZLUCHX",
+            "icsId": "1000045",
+            "topMostParentId": "HUBCHX",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "hasDisruption": true,
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "bakerloo",
+                "name": "Bakerloo",
+                "uri": "/Line/bakerloo",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUCHX",
+            "name": "Charing Cross Underground Station",
+            "lat": 51.50741,
+            "lon": -0.127277
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUEMB",
+            "icsId": "1000075",
+            "topMostParentId": "940GZZLUEMB",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "bakerloo",
+                "name": "Bakerloo",
+                "uri": "/Line/bakerloo",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "circle",
+                "name": "Circle",
+                "uri": "/Line/circle",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "district",
+                "name": "District",
+                "uri": "/Line/district",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUEMB",
+            "name": "Embankment Underground Station",
+            "lat": 51.507058,
+            "lon": -0.122666
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "parentId": "HUBWAT",
+            "stationId": "940GZZLUWLO",
+            "icsId": "1000254",
+            "topMostParentId": "HUBWAT",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "bakerloo",
+                "name": "Bakerloo",
+                "uri": "/Line/bakerloo",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "jubilee",
+                "name": "Jubilee",
+                "uri": "/Line/jubilee",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "waterloo-city",
+                "name": "Waterloo & City",
+                "uri": "/Line/waterloo-city",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUWLO",
+            "name": "Waterloo Underground Station",
+            "lat": 51.503299,
+            "lon": -0.11478
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUKNG",
+            "icsId": "1000121",
+            "topMostParentId": "940GZZLUKNG",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1+2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUKNG",
+            "name": "Kennington Underground Station",
+            "lat": 51.488337,
+            "lon": -0.105963
+        }],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.StopPointSequence, Tfl.Api.Presentation.Entities",
+        "lineId": "northern",
+        "lineName": "Northern",
+        "direction": "inbound",
+        "branchId": 8,
+        "nextBranchIds": [],
+        "prevBranchIds": [5, 6],
+        "stopPoint": [{
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUKNG",
+            "icsId": "1000121",
+            "topMostParentId": "940GZZLUKNG",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1+2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUKNG",
+            "name": "Kennington Underground Station",
+            "lat": 51.488337,
+            "lon": -0.105963
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUOVL",
+            "icsId": "1000172",
+            "topMostParentId": "940GZZLUOVL",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUOVL",
+            "name": "Oval Underground Station",
+            "lat": 51.48185,
+            "lon": -0.112439
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUSKW",
+            "icsId": "1000223",
+            "topMostParentId": "940GZZLUSKW",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "victoria",
+                "name": "Victoria",
+                "uri": "/Line/victoria",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUSKW",
+            "name": "Stockwell Underground Station",
+            "lat": 51.472184,
+            "lon": -0.122644
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUCPN",
+            "icsId": "1000051",
+            "topMostParentId": "940GZZLUCPN",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUCPN",
+            "name": "Clapham North Underground Station",
+            "lat": 51.465135,
+            "lon": -0.130016
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUCPC",
+            "icsId": "1000050",
+            "topMostParentId": "940GZZLUCPC",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUCPC",
+            "name": "Clapham Common Underground Station",
+            "lat": 51.461742,
+            "lon": -0.138317
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUCPS",
+            "icsId": "1000052",
+            "topMostParentId": "940GZZLUCPS",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2+3",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUCPS",
+            "name": "Clapham South Underground Station",
+            "lat": 51.452654,
+            "lon": -0.147582
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "parentId": "HUBBAL",
+            "stationId": "940GZZLUBLM",
+            "icsId": "1000012",
+            "topMostParentId": "HUBBAL",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "3",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUBLM",
+            "name": "Balham Underground Station",
+            "lat": 51.443288,
+            "lon": -0.152997
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUTBC",
+            "icsId": "1000233",
+            "topMostParentId": "940GZZLUTBC",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "3",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUTBC",
+            "name": "Tooting Bec Underground Station",
+            "lat": 51.435678,
+            "lon": -0.159736
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUTBY",
+            "icsId": "1000234",
+            "topMostParentId": "940GZZLUTBY",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "3",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUTBY",
+            "name": "Tooting Broadway Underground Station",
+            "lat": 51.42763,
+            "lon": -0.168374
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUCSD",
+            "icsId": "1000055",
+            "topMostParentId": "940GZZLUCSD",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "3",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUCSD",
+            "name": "Colliers Wood Underground Station",
+            "lat": 51.41816,
+            "lon": -0.178086
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUSWN",
+            "icsId": "1000216",
+            "topMostParentId": "940GZZLUSWN",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "3+4",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUSWN",
+            "name": "South Wimbledon Underground Station",
+            "lat": 51.415309,
+            "lon": -0.192005
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUMDN",
+            "icsId": "1000151",
+            "topMostParentId": "940GZZLUMDN",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "4",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUMDN",
+            "name": "Morden Underground Station",
+            "lat": 51.402142,
+            "lon": -0.194839
+        }],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.StopPointSequence, Tfl.Api.Presentation.Entities",
+        "lineId": "northern",
+        "lineName": "Northern",
+        "direction": "inbound",
+        "branchId": 4,
+        "nextBranchIds": [6],
+        "prevBranchIds": [9, 0],
+        "stopPoint": [{
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUCTN",
+            "icsId": "1000036",
+            "topMostParentId": "940GZZLUCTN",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUCTN",
+            "name": "Camden Town Underground Station",
+            "lat": 51.539292,
+            "lon": -0.14274
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "parentId": "HUBEUS",
+            "stationId": "940GZZLUEUS",
+            "icsId": "1000077",
+            "topMostParentId": "HUBEUS",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "hasDisruption": true,
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "victoria",
+                "name": "Victoria",
+                "uri": "/Line/victoria",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUEUS",
+            "name": "Euston Underground Station",
+            "lat": 51.528055,
+            "lon": -0.132182
+        }],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.StopPointSequence, Tfl.Api.Presentation.Entities",
+        "lineId": "northern",
+        "lineName": "Northern",
+        "direction": "inbound",
+        "branchId": 6,
+        "nextBranchIds": [8],
+        "prevBranchIds": [4],
+        "stopPoint": [{
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "parentId": "HUBEUS",
+            "stationId": "940GZZLUEUS",
+            "icsId": "1000077",
+            "topMostParentId": "HUBEUS",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "hasDisruption": true,
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "victoria",
+                "name": "Victoria",
+                "uri": "/Line/victoria",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUEUS",
+            "name": "Euston Underground Station",
+            "lat": 51.528055,
+            "lon": -0.132182
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "parentId": "HUBKGX",
+            "stationId": "940GZZLUKSX",
+            "icsId": "1000129",
+            "topMostParentId": "HUBKGX",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "circle",
+                "name": "Circle",
+                "uri": "/Line/circle",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "hammersmith-city",
+                "name": "Hammersmith & City",
+                "uri": "/Line/hammersmith-city",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "metropolitan",
+                "name": "Metropolitan",
+                "uri": "/Line/metropolitan",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "piccadilly",
+                "name": "Piccadilly",
+                "uri": "/Line/piccadilly",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "victoria",
+                "name": "Victoria",
+                "uri": "/Line/victoria",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUKSX",
+            "name": "King's Cross St. Pancras Underground Station",
+            "lat": 51.530663,
+            "lon": -0.123194
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUAGL",
+            "icsId": "1000007",
+            "topMostParentId": "940GZZLUAGL",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUAGL",
+            "name": "Angel Underground Station",
+            "lat": 51.532624,
+            "lon": -0.105898
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "parentId": "HUBOLD",
+            "stationId": "940GZZLUODS",
+            "icsId": "1000169",
+            "topMostParentId": "HUBOLD",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUODS",
+            "name": "Old Street Underground Station",
+            "lat": 51.525864,
+            "lon": -0.08777
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "parentId": "HUBZMG",
+            "stationId": "940GZZLUMGT",
+            "icsId": "1000149",
+            "topMostParentId": "HUBZMG",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "circle",
+                "name": "Circle",
+                "uri": "/Line/circle",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "hammersmith-city",
+                "name": "Hammersmith & City",
+                "uri": "/Line/hammersmith-city",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "metropolitan",
+                "name": "Metropolitan",
+                "uri": "/Line/metropolitan",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUMGT",
+            "name": "Moorgate Underground Station",
+            "lat": 51.518176,
+            "lon": -0.088322
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "parentId": "HUBBAN",
+            "stationId": "940GZZLUBNK",
+            "icsId": "1000013",
+            "topMostParentId": "HUBBAN",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "hasDisruption": true,
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "central",
+                "name": "Central",
+                "uri": "/Line/central",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "waterloo-city",
+                "name": "Waterloo & City",
+                "uri": "/Line/waterloo-city",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUBNK",
+            "name": "Bank Underground Station",
+            "lat": 51.513132,
+            "lon": -0.090047
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "parentId": "HUBLBG",
+            "stationId": "940GZZLULNB",
+            "icsId": "1000139",
+            "topMostParentId": "HUBLBG",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "hasDisruption": true,
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "jubilee",
+                "name": "Jubilee",
+                "uri": "/Line/jubilee",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLULNB",
+            "name": "London Bridge Underground Station",
+            "lat": 51.505721,
+            "lon": -0.088873
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUBOR",
+            "icsId": "1000026",
+            "topMostParentId": "940GZZLUBOR",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUBOR",
+            "name": "Borough Underground Station",
+            "lat": 51.501199,
+            "lon": -0.09337
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "parentId": "HUBEPH",
+            "stationId": "940GZZLUEAC",
+            "icsId": "1000073",
+            "topMostParentId": "HUBEPH",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1+2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "bakerloo",
+                "name": "Bakerloo",
+                "uri": "/Line/bakerloo",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUEAC",
+            "name": "Elephant & Castle Underground Station",
+            "lat": 51.494536,
+            "lon": -0.100606
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUKNG",
+            "icsId": "1000121",
+            "topMostParentId": "940GZZLUKNG",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1+2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUKNG",
+            "name": "Kennington Underground Station",
+            "lat": 51.488337,
+            "lon": -0.105963
+        }],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.StopPointSequence, Tfl.Api.Presentation.Entities",
+        "lineId": "northern",
+        "lineName": "Northern",
+        "direction": "inbound",
+        "branchId": 0,
+        "nextBranchIds": [3, 4],
+        "prevBranchIds": [],
+        "stopPoint": [{
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUEGW",
+            "icsId": "1000070",
+            "topMostParentId": "940GZZLUEGW",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "5",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUEGW",
+            "name": "Edgware Underground Station",
+            "lat": 51.613653,
+            "lon": -0.274928
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUBTK",
+            "icsId": "1000034",
+            "topMostParentId": "940GZZLUBTK",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "4",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUBTK",
+            "name": "Burnt Oak Underground Station",
+            "lat": 51.602774,
+            "lon": -0.264048
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUCND",
+            "icsId": "1000054",
+            "topMostParentId": "940GZZLUCND",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "4",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUCND",
+            "name": "Colindale Underground Station",
+            "lat": 51.595424,
+            "lon": -0.249919
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUHCL",
+            "icsId": "1000106",
+            "topMostParentId": "940GZZLUHCL",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "3+4",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUHCL",
+            "name": "Hendon Central Underground Station",
+            "lat": 51.583301,
+            "lon": -0.226424
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUBTX",
+            "icsId": "1000030",
+            "topMostParentId": "940GZZLUBTX",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "3",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUBTX",
+            "name": "Brent Cross Underground Station",
+            "lat": 51.57665,
+            "lon": -0.213622
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUGGN",
+            "icsId": "1000087",
+            "topMostParentId": "940GZZLUGGN",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "3",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUGGN",
+            "name": "Golders Green Underground Station",
+            "lat": 51.572259,
+            "lon": -0.194039
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUHTD",
+            "icsId": "1000098",
+            "topMostParentId": "940GZZLUHTD",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2+3",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUHTD",
+            "name": "Hampstead Underground Station",
+            "lat": 51.556239,
+            "lon": -0.177464
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUBZP",
+            "icsId": "1000020",
+            "topMostParentId": "940GZZLUBZP",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUBZP",
+            "name": "Belsize Park Underground Station",
+            "lat": 51.550529,
+            "lon": -0.164783
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUCFM",
+            "icsId": "1000043",
+            "topMostParentId": "940GZZLUCFM",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUCFM",
+            "name": "Chalk Farm Underground Station",
+            "lat": 51.544118,
+            "lon": -0.153388
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUCTN",
+            "icsId": "1000036",
+            "topMostParentId": "940GZZLUCTN",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUCTN",
+            "name": "Camden Town Underground Station",
+            "lat": 51.539292,
+            "lon": -0.14274
+        }],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.StopPointSequence, Tfl.Api.Presentation.Entities",
+        "lineId": "northern",
+        "lineName": "Northern",
+        "direction": "inbound",
+        "branchId": 2,
+        "nextBranchIds": [9],
+        "prevBranchIds": [],
+        "stopPoint": [{
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUMHL",
+            "icsId": "1000147",
+            "topMostParentId": "940GZZLUMHL",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "4",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUMHL",
+            "name": "Mill Hill East Underground Station",
+            "lat": 51.608229,
+            "lon": -0.209986
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUFYC",
+            "icsId": "1000081",
+            "topMostParentId": "940GZZLUFYC",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "4",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUFYC",
+            "name": "Finchley Central Underground Station",
+            "lat": 51.600921,
+            "lon": -0.192527
+        }],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.StopPointSequence, Tfl.Api.Presentation.Entities",
+        "lineId": "northern",
+        "lineName": "Northern",
+        "direction": "inbound",
+        "branchId": 7,
+        "nextBranchIds": [],
+        "prevBranchIds": [5],
+        "stopPoint": [{
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZLUKNG",
+            "icsId": "1000121",
+            "topMostParentId": "940GZZLUKNG",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1+2",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZLUKNG",
+            "name": "Kennington Underground Station",
+            "lat": 51.488337,
+            "lon": -0.105963
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZNEUGST",
+            "icsId": "1002196",
+            "topMostParentId": "940GZZNEUGST",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "6",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZNEUGST",
+            "name": "Nine Elms Underground Station",
+            "lat": 51.479912,
+            "lon": -0.128476
+        }, {
+            "$type": "Tfl.Api.Presentation.Entities.MatchedStop, Tfl.Api.Presentation.Entities",
+            "stationId": "940GZZBPSUST",
+            "icsId": "1002195",
+            "topMostParentId": "940GZZBPSUST",
+            "modes": ["tube"],
+            "stopType": "NaptanMetroStation",
+            "zone": "1",
+            "lines": [{
+                "$type": "Tfl.Api.Presentation.Entities.Identifier, Tfl.Api.Presentation.Entities",
+                "id": "northern",
+                "name": "Northern",
+                "uri": "/Line/northern",
+                "type": "Line",
+                "crowding": {
+                    "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+                },
+                "routeType": "Unknown",
+                "status": "Unknown"
+            }],
+            "status": true,
+            "id": "940GZZBPSUST",
+            "name": "Battersea Power Station Underground Station",
+            "lat": 51.479932,
+            "lon": -0.142142
+        }],
+        "serviceType": "Regular"
+    }],
+    "orderedLineRoutes": [{
+        "$type": "Tfl.Api.Presentation.Entities.OrderedRoute, Tfl.Api.Presentation.Entities",
+        "name": "Edgware  &harr;  Morden  via Bank",
+        "naptanIds": ["940GZZLUEGW", "940GZZLUBTK", "940GZZLUCND", "940GZZLUHCL", "940GZZLUBTX", "940GZZLUGGN", "940GZZLUHTD", "940GZZLUBZP", "940GZZLUCFM", "940GZZLUCTN", "940GZZLUEUS", "940GZZLUKSX", "940GZZLUAGL", "940GZZLUODS", "940GZZLUMGT", "940GZZLUBNK", "940GZZLULNB", "940GZZLUBOR", "940GZZLUEAC", "940GZZLUKNG", "940GZZLUOVL", "940GZZLUSKW", "940GZZLUCPN", "940GZZLUCPC", "940GZZLUCPS", "940GZZLUBLM", "940GZZLUTBC", "940GZZLUTBY", "940GZZLUCSD", "940GZZLUSWN", "940GZZLUMDN"],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.OrderedRoute, Tfl.Api.Presentation.Entities",
+        "name": "Edgware  &harr;  Battersea Power Station ",
+        "naptanIds": ["940GZZLUEGW", "940GZZLUBTK", "940GZZLUCND", "940GZZLUHCL", "940GZZLUBTX", "940GZZLUGGN", "940GZZLUHTD", "940GZZLUBZP", "940GZZLUCFM", "940GZZLUCTN", "940GZZLUMTC", "940GZZLUEUS", "940GZZLUWRR", "940GZZLUGDG", "940GZZLUTCR", "940GZZLULSQ", "940GZZLUCHX", "940GZZLUEMB", "940GZZLUWLO", "940GZZLUKNG", "940GZZNEUGST", "940GZZBPSUST"],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.OrderedRoute, Tfl.Api.Presentation.Entities",
+        "name": "Edgware  &harr;  Morden  via Charing Cross",
+        "naptanIds": ["940GZZLUEGW", "940GZZLUBTK", "940GZZLUCND", "940GZZLUHCL", "940GZZLUBTX", "940GZZLUGGN", "940GZZLUHTD", "940GZZLUBZP", "940GZZLUCFM", "940GZZLUCTN", "940GZZLUMTC", "940GZZLUEUS", "940GZZLUWRR", "940GZZLUGDG", "940GZZLUTCR", "940GZZLULSQ", "940GZZLUCHX", "940GZZLUEMB", "940GZZLUWLO", "940GZZLUKNG", "940GZZLUOVL", "940GZZLUSKW", "940GZZLUCPN", "940GZZLUCPC", "940GZZLUCPS", "940GZZLUBLM", "940GZZLUTBC", "940GZZLUTBY", "940GZZLUCSD", "940GZZLUSWN", "940GZZLUMDN"],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.OrderedRoute, Tfl.Api.Presentation.Entities",
+        "name": "High Barnet  &harr;  Morden  via Bank",
+        "naptanIds": ["940GZZLUHBT", "940GZZLUTAW", "940GZZLUWOP", "940GZZLUWFN", "940GZZLUFYC", "940GZZLUEFY", "940GZZLUHGT", "940GZZLUACY", "940GZZLUTFP", "940GZZLUKSH", "940GZZLUCTN", "940GZZLUEUS", "940GZZLUKSX", "940GZZLUAGL", "940GZZLUODS", "940GZZLUMGT", "940GZZLUBNK", "940GZZLULNB", "940GZZLUBOR", "940GZZLUEAC", "940GZZLUKNG", "940GZZLUOVL", "940GZZLUSKW", "940GZZLUCPN", "940GZZLUCPC", "940GZZLUCPS", "940GZZLUBLM", "940GZZLUTBC", "940GZZLUTBY", "940GZZLUCSD", "940GZZLUSWN", "940GZZLUMDN"],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.OrderedRoute, Tfl.Api.Presentation.Entities",
+        "name": "High Barnet  &harr;  Battersea Power Station ",
+        "naptanIds": ["940GZZLUHBT", "940GZZLUTAW", "940GZZLUWOP", "940GZZLUWFN", "940GZZLUFYC", "940GZZLUEFY", "940GZZLUHGT", "940GZZLUACY", "940GZZLUTFP", "940GZZLUKSH", "940GZZLUCTN", "940GZZLUMTC", "940GZZLUEUS", "940GZZLUWRR", "940GZZLUGDG", "940GZZLUTCR", "940GZZLULSQ", "940GZZLUCHX", "940GZZLUEMB", "940GZZLUWLO", "940GZZLUKNG", "940GZZNEUGST", "940GZZBPSUST"],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.OrderedRoute, Tfl.Api.Presentation.Entities",
+        "name": "High Barnet  &harr;  Morden  via Charing Cross",
+        "naptanIds": ["940GZZLUHBT", "940GZZLUTAW", "940GZZLUWOP", "940GZZLUWFN", "940GZZLUFYC", "940GZZLUEFY", "940GZZLUHGT", "940GZZLUACY", "940GZZLUTFP", "940GZZLUKSH", "940GZZLUCTN", "940GZZLUMTC", "940GZZLUEUS", "940GZZLUWRR", "940GZZLUGDG", "940GZZLUTCR", "940GZZLULSQ", "940GZZLUCHX", "940GZZLUEMB", "940GZZLUWLO", "940GZZLUKNG", "940GZZLUOVL", "940GZZLUSKW", "940GZZLUCPN", "940GZZLUCPC", "940GZZLUCPS", "940GZZLUBLM", "940GZZLUTBC", "940GZZLUTBY", "940GZZLUCSD", "940GZZLUSWN", "940GZZLUMDN"],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.OrderedRoute, Tfl.Api.Presentation.Entities",
+        "name": "Mill Hill East  &harr;  Morden  via Bank",
+        "naptanIds": ["940GZZLUMHL", "940GZZLUFYC", "940GZZLUEFY", "940GZZLUHGT", "940GZZLUACY", "940GZZLUTFP", "940GZZLUKSH", "940GZZLUCTN", "940GZZLUEUS", "940GZZLUKSX", "940GZZLUAGL", "940GZZLUODS", "940GZZLUMGT", "940GZZLUBNK", "940GZZLULNB", "940GZZLUBOR", "940GZZLUEAC", "940GZZLUKNG", "940GZZLUOVL", "940GZZLUSKW", "940GZZLUCPN", "940GZZLUCPC", "940GZZLUCPS", "940GZZLUBLM", "940GZZLUTBC", "940GZZLUTBY", "940GZZLUCSD", "940GZZLUSWN", "940GZZLUMDN"],
+        "serviceType": "Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.OrderedRoute, Tfl.Api.Presentation.Entities",
+        "name": "Mill Hill East  &harr;  Morden  via Charing Cross",
+        "naptanIds": ["940GZZLUMHL", "940GZZLUFYC", "940GZZLUEFY", "940GZZLUHGT", "940GZZLUACY", "940GZZLUTFP", "940GZZLUKSH", "940GZZLUCTN", "940GZZLUMTC", "940GZZLUEUS", "940GZZLUWRR", "940GZZLUGDG", "940GZZLUTCR", "940GZZLULSQ", "940GZZLUCHX", "940GZZLUEMB", "940GZZLUWLO", "940GZZLUKNG", "940GZZLUOVL", "940GZZLUSKW", "940GZZLUCPN", "940GZZLUCPC", "940GZZLUCPS", "940GZZLUBLM", "940GZZLUTBC", "940GZZLUTBY", "940GZZLUCSD", "940GZZLUSWN", "940GZZLUMDN"],
+        "serviceType": "Regular"
+    }]
+}

--- a/backend/tfl_responses/Line_StatusByIdsByPathIdsQueryDetail.txt
+++ b/backend/tfl_responses/Line_StatusByIdsByPathIdsQueryDetail.txt
@@ -1,0 +1,729 @@
+HTTP/1.1 200 OK
+
+age: 0
+api-entity-payload: Line,LineStatus
+cache-control: public, must-revalidate, max-age=30, s-maxage=60
+content-encoding: gzip
+content-length: 1351
+content-type: application/json; charset=utf-8
+date: Thu, 13 Nov 2025 07:49:32 GMT
+server: cloudflare
+via: 1.1 varnish
+x-api: Line
+x-aspnet-version: 4.0.30319
+x-backend: api
+x-cache: MISS
+x-cacheable: Yes. Cacheable
+x-frame-options: deny
+x-operation: Line_StatusByIdsByPathIdsQueryDetail
+x-proxy-connection: unset
+x-ttl: 60.000
+x-ttl-rule: 0
+x-varnish: 665012965
+
+[{
+    "$type": "Tfl.Api.Presentation.Entities.Line, Tfl.Api.Presentation.Entities",
+    "id": "piccadilly",
+    "name": "Piccadilly",
+    "modeName": "tube",
+    "disruptions": [],
+    "created": "2025-11-05T16:17:11.813Z",
+    "modified": "2025-11-05T16:17:11.813Z",
+    "lineStatuses": [{
+        "$type": "Tfl.Api.Presentation.Entities.LineStatus, Tfl.Api.Presentation.Entities",
+        "id": 0,
+        "lineId": "piccadilly",
+        "statusSeverity": 3,
+        "statusSeverityDescription": "Part Suspended",
+        "reason": "Piccadilly Line: No service between Cockfosters and Arnos Grove while we fix a track fault. Tickets are valid on London Buses. GOOD SERVICE on the rest of the line.  ",
+        "created": "0001-01-01T00:00:00",
+        "validityPeriods": [{
+            "$type": "Tfl.Api.Presentation.Entities.ValidityPeriod, Tfl.Api.Presentation.Entities",
+            "fromDate": "2025-11-13T07:41:56Z",
+            "toDate": "2025-11-13T10:48:55Z",
+            "isNow": true
+        }],
+        "disruption": {
+            "$type": "Tfl.Api.Presentation.Entities.Disruption, Tfl.Api.Presentation.Entities",
+            "category": "RealTime",
+            "categoryDescription": "RealTime",
+            "description": "Piccadilly Line: No service between Cockfosters and Arnos Grove while we fix a track fault. Tickets are valid on London Buses. GOOD SERVICE on the rest of the line.  ",
+            "affectedRoutes": [{
+                "$type": "Tfl.Api.Presentation.Entities.DisruptedRoute, Tfl.Api.Presentation.Entities",
+                "id": "1817",
+                "name": "Cockfosters Underground Station - Uxbridge Underground Station",
+                "direction": "inbound",
+                "originationName": "Cockfosters Underground Station",
+                "destinationName": "Uxbridge Underground Station",
+                "isEntireRouteSection": false,
+                "routeSectionNaptanEntrySequence": [{
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 0,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUCKS",
+                        "modes": [],
+                        "icsCode": "1000053",
+                        "stationNaptan": "940GZZLUCKS",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUCKS",
+                        "commonName": "Cockfosters Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 1,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUOAK",
+                        "modes": [],
+                        "icsCode": "1000168",
+                        "stationNaptan": "940GZZLUOAK",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUOAK",
+                        "commonName": "Oakwood Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 2,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUSGT",
+                        "modes": [],
+                        "icsCode": "1000210",
+                        "stationNaptan": "940GZZLUSGT",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUSGT",
+                        "commonName": "Southgate Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 3,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUASG",
+                        "modes": [],
+                        "icsCode": "1000009",
+                        "stationNaptan": "940GZZLUASG",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUASG",
+                        "commonName": "Arnos Grove Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }]
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.DisruptedRoute, Tfl.Api.Presentation.Entities",
+                "id": "1818",
+                "name": "Uxbridge Underground Station - Cockfosters Underground Station",
+                "direction": "outbound",
+                "originationName": "Uxbridge Underground Station",
+                "destinationName": "Cockfosters Underground Station",
+                "isEntireRouteSection": false,
+                "routeSectionNaptanEntrySequence": [{
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 38,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUASG",
+                        "modes": [],
+                        "icsCode": "1000009",
+                        "stationNaptan": "940GZZLUASG",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUASG",
+                        "commonName": "Arnos Grove Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 39,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUSGT",
+                        "modes": [],
+                        "icsCode": "1000210",
+                        "stationNaptan": "940GZZLUSGT",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUSGT",
+                        "commonName": "Southgate Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 40,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUOAK",
+                        "modes": [],
+                        "icsCode": "1000168",
+                        "stationNaptan": "940GZZLUOAK",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUOAK",
+                        "commonName": "Oakwood Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 41,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUCKS",
+                        "modes": [],
+                        "icsCode": "1000053",
+                        "stationNaptan": "940GZZLUCKS",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUCKS",
+                        "commonName": "Cockfosters Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }]
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.DisruptedRoute, Tfl.Api.Presentation.Entities",
+                "id": "1819",
+                "name": "Cockfosters Underground Station - Heathrow Terminal 5 Underground Station",
+                "direction": "inbound",
+                "originationName": "Cockfosters Underground Station",
+                "destinationName": "Heathrow Terminal 5 Underground Station",
+                "isEntireRouteSection": false,
+                "routeSectionNaptanEntrySequence": [{
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 0,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUCKS",
+                        "modes": [],
+                        "icsCode": "1000053",
+                        "stationNaptan": "940GZZLUCKS",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUCKS",
+                        "commonName": "Cockfosters Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 1,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUOAK",
+                        "modes": [],
+                        "icsCode": "1000168",
+                        "stationNaptan": "940GZZLUOAK",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUOAK",
+                        "commonName": "Oakwood Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 2,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUSGT",
+                        "modes": [],
+                        "icsCode": "1000210",
+                        "stationNaptan": "940GZZLUSGT",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUSGT",
+                        "commonName": "Southgate Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 3,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUASG",
+                        "modes": [],
+                        "icsCode": "1000009",
+                        "stationNaptan": "940GZZLUASG",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUASG",
+                        "commonName": "Arnos Grove Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }]
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.DisruptedRoute, Tfl.Api.Presentation.Entities",
+                "id": "1820",
+                "name": "Heathrow Terminal 4 Underground Station - Cockfosters Underground Station",
+                "direction": "outbound",
+                "originationName": "Heathrow Terminal 4 Underground Station",
+                "destinationName": "Cockfosters Underground Station",
+                "isEntireRouteSection": false,
+                "routeSectionNaptanEntrySequence": [{
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 34,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUASG",
+                        "modes": [],
+                        "icsCode": "1000009",
+                        "stationNaptan": "940GZZLUASG",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUASG",
+                        "commonName": "Arnos Grove Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 35,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUSGT",
+                        "modes": [],
+                        "icsCode": "1000210",
+                        "stationNaptan": "940GZZLUSGT",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUSGT",
+                        "commonName": "Southgate Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 36,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUOAK",
+                        "modes": [],
+                        "icsCode": "1000168",
+                        "stationNaptan": "940GZZLUOAK",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUOAK",
+                        "commonName": "Oakwood Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 37,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUCKS",
+                        "modes": [],
+                        "icsCode": "1000053",
+                        "stationNaptan": "940GZZLUCKS",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUCKS",
+                        "commonName": "Cockfosters Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }]
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.DisruptedRoute, Tfl.Api.Presentation.Entities",
+                "id": "1821",
+                "name": "Heathrow Terminal 5 Underground Station - Cockfosters Underground Station",
+                "direction": "outbound",
+                "originationName": "Heathrow Terminal 5 Underground Station",
+                "destinationName": "Cockfosters Underground Station",
+                "isEntireRouteSection": false,
+                "routeSectionNaptanEntrySequence": [{
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 34,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUASG",
+                        "modes": [],
+                        "icsCode": "1000009",
+                        "stationNaptan": "940GZZLUASG",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUASG",
+                        "commonName": "Arnos Grove Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 35,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUSGT",
+                        "modes": [],
+                        "icsCode": "1000210",
+                        "stationNaptan": "940GZZLUSGT",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUSGT",
+                        "commonName": "Southgate Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 36,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUOAK",
+                        "modes": [],
+                        "icsCode": "1000168",
+                        "stationNaptan": "940GZZLUOAK",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUOAK",
+                        "commonName": "Oakwood Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 37,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUCKS",
+                        "modes": [],
+                        "icsCode": "1000053",
+                        "stationNaptan": "940GZZLUCKS",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUCKS",
+                        "commonName": "Cockfosters Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }]
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.DisruptedRoute, Tfl.Api.Presentation.Entities",
+                "id": "1822",
+                "name": "Cockfosters Underground Station - Heathrow Terminal 4 Underground Station",
+                "direction": "inbound",
+                "originationName": "Cockfosters Underground Station",
+                "destinationName": "Heathrow Terminal 4 Underground Station",
+                "isEntireRouteSection": false,
+                "routeSectionNaptanEntrySequence": [{
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 0,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUCKS",
+                        "modes": [],
+                        "icsCode": "1000053",
+                        "stationNaptan": "940GZZLUCKS",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUCKS",
+                        "commonName": "Cockfosters Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 1,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUOAK",
+                        "modes": [],
+                        "icsCode": "1000168",
+                        "stationNaptan": "940GZZLUOAK",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUOAK",
+                        "commonName": "Oakwood Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 2,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUSGT",
+                        "modes": [],
+                        "icsCode": "1000210",
+                        "stationNaptan": "940GZZLUSGT",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUSGT",
+                        "commonName": "Southgate Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }, {
+                    "$type": "Tfl.Api.Presentation.Entities.RouteSectionNaptanEntrySequence, Tfl.Api.Presentation.Entities",
+                    "ordinal": 3,
+                    "stopPoint": {
+                        "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                        "naptanId": "940GZZLUASG",
+                        "modes": [],
+                        "icsCode": "1000009",
+                        "stationNaptan": "940GZZLUASG",
+                        "lines": [],
+                        "lineGroup": [],
+                        "lineModeGroups": [],
+                        "status": true,
+                        "id": "940GZZLUASG",
+                        "commonName": "Arnos Grove Underground Station",
+                        "placeType": "StopPoint",
+                        "additionalProperties": [],
+                        "children": [],
+                        "lat": 0.0,
+                        "lon": 0.0
+                    }
+                }]
+            }],
+            "affectedStops": [{
+                "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                "naptanId": "940GZZLUASG",
+                "stationNaptan": "940GZZLUASG",
+                "status": true,
+                "id": "940GZZLUASG",
+                "commonName": "Arnos Grove Underground Station",
+                "lat": 0.0,
+                "lon": 0.0
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                "naptanId": "940GZZLUCKS",
+                "stationNaptan": "940GZZLUCKS",
+                "status": true,
+                "id": "940GZZLUCKS",
+                "commonName": "Cockfosters Underground Station",
+                "lat": 0.0,
+                "lon": 0.0
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                "naptanId": "940GZZLUOAK",
+                "stationNaptan": "940GZZLUOAK",
+                "status": true,
+                "id": "940GZZLUOAK",
+                "commonName": "Oakwood Underground Station",
+                "lat": 0.0,
+                "lon": 0.0
+            }, {
+                "$type": "Tfl.Api.Presentation.Entities.StopPoint, Tfl.Api.Presentation.Entities",
+                "naptanId": "940GZZLUSGT",
+                "stationNaptan": "940GZZLUSGT",
+                "status": true,
+                "id": "940GZZLUSGT",
+                "commonName": "Southgate Underground Station",
+                "lat": 0.0,
+                "lon": 0.0
+            }],
+            "closureText": "partSuspended"
+        }
+    }],
+    "routeSections": [{
+        "$type": "Tfl.Api.Presentation.Entities.MatchedRoute, Tfl.Api.Presentation.Entities",
+        "name": "Cockfosters Underground Station - Uxbridge Underground Station",
+        "direction": "inbound",
+        "originationName": "Cockfosters Underground Station",
+        "destinationName": "Uxbridge Underground Station",
+        "originator": "940GZZLUCKS",
+        "destination": "940GZZLUUXB",
+        "serviceType": "Regular",
+        "validTo": "2025-12-23T00:00:00Z",
+        "validFrom": "2025-11-01T00:00:00Z"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedRoute, Tfl.Api.Presentation.Entities",
+        "name": "Uxbridge Underground Station - Cockfosters Underground Station",
+        "direction": "outbound",
+        "originationName": "Uxbridge Underground Station",
+        "destinationName": "Cockfosters Underground Station",
+        "originator": "940GZZLUUXB",
+        "destination": "940GZZLUCKS",
+        "serviceType": "Regular",
+        "validTo": "2025-12-23T00:00:00Z",
+        "validFrom": "2025-11-01T00:00:00Z"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedRoute, Tfl.Api.Presentation.Entities",
+        "name": "Cockfosters Underground Station - Heathrow Terminal 5 Underground Station",
+        "direction": "inbound",
+        "originationName": "Cockfosters Underground Station",
+        "destinationName": "Heathrow Terminal 5 Underground Station",
+        "originator": "940GZZLUCKS",
+        "destination": "940GZZLUHR5",
+        "serviceType": "Regular",
+        "validTo": "2025-12-23T00:00:00Z",
+        "validFrom": "2025-11-01T00:00:00Z"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedRoute, Tfl.Api.Presentation.Entities",
+        "name": "Heathrow Terminal 4 Underground Station - Cockfosters Underground Station",
+        "direction": "outbound",
+        "originationName": "Heathrow Terminal 4 Underground Station",
+        "destinationName": "Cockfosters Underground Station",
+        "originator": "940GZZLUHR4",
+        "destination": "940GZZLUCKS",
+        "serviceType": "Regular",
+        "validTo": "2025-12-23T00:00:00Z",
+        "validFrom": "2025-11-01T00:00:00Z"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedRoute, Tfl.Api.Presentation.Entities",
+        "name": "Heathrow Terminal 5 Underground Station - Cockfosters Underground Station",
+        "direction": "outbound",
+        "originationName": "Heathrow Terminal 5 Underground Station",
+        "destinationName": "Cockfosters Underground Station",
+        "originator": "940GZZLUHR5",
+        "destination": "940GZZLUCKS",
+        "serviceType": "Regular",
+        "validTo": "2025-12-23T00:00:00Z",
+        "validFrom": "2025-11-01T00:00:00Z"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.MatchedRoute, Tfl.Api.Presentation.Entities",
+        "name": "Cockfosters Underground Station - Heathrow Terminal 4 Underground Station",
+        "direction": "inbound",
+        "originationName": "Cockfosters Underground Station",
+        "destinationName": "Heathrow Terminal 4 Underground Station",
+        "originator": "940GZZLUCKS",
+        "destination": "940GZZLUHR4",
+        "serviceType": "Regular",
+        "validTo": "2025-12-23T00:00:00Z",
+        "validFrom": "2025-11-01T00:00:00Z"
+    }],
+    "serviceTypes": [{
+        "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+        "name": "Regular",
+        "uri": "/Line/Route?ids=Piccadilly&serviceTypes=Regular"
+    }, {
+        "$type": "Tfl.Api.Presentation.Entities.LineServiceTypeInfo, Tfl.Api.Presentation.Entities",
+        "name": "Night",
+        "uri": "/Line/Route?ids=Piccadilly&serviceTypes=Night"
+    }],
+    "crowding": {
+        "$type": "Tfl.Api.Presentation.Entities.Crowding, Tfl.Api.Presentation.Entities"
+    }
+}]

--- a/docs/adr/07-external-apis.md
+++ b/docs/adr/07-external-apis.md
@@ -172,6 +172,29 @@ Use `/Line/{ids}/Status` endpoint (`StatusByIdsByPathIdsQueryDetail`) instead of
 - Test mocks more complex (mock Line with nested LineStatus and ValidityPeriod)
 - Different response shape requires updated test fixtures
 
+---
+
+## Capture Affected Routes Data from TfL API
+
+### Status
+Active (Issue #126, implemented 2025-11-13)
+
+### Context
+TfL API provides `affectedRoutes` with station sequences in disruption responses. Initial implementation discarded this data. Future inverted index (Issue #125) needs station-level data for accurate matching.
+
+### Decision
+Capture `affected_routes` field in `DisruptionResponse` containing route name, direction, and affected station NaPTAN codes. No route variant IDs (don't exist in Line.routes data).
+
+### Consequences
+**Easier:**
+- Station-level disruption matching vs whole-line alerts
+- Future inverted index implementation without schema migration
+
+**More Difficult:**
+- Larger response payloads with station lists
+
+---
+
 ## Route Sequence Validation for Branch-Aware Paths
 
 ### Status


### PR DESCRIPTION
resolves #126

## Summary by Sourcery

Include detailed affected route information (route segments and station lists) in disruption responses by introducing helper functions, updating the extraction logic, extending the schema, and adding comprehensive tests and documentation.

New Features:
- Capture affected routes with station sequences from TfL disruption responses

Enhancements:
- Add pure helper functions for parsing timestamps, extracting NaPTAN codes, and building affected route info
- Update disruption extraction to include affected routes, reason, and created timestamp using helper methods

Documentation:
- Add AffectedRouteInfo schema and update DisruptionResponse to include affected_routes
- Document the decision to capture affected routes in the ADR for external APIs

Tests:
- Add unit tests for all new helper functions and integration tests covering various affected routes scenarios