### PR TITLE
feat: add RouteStationIndex model and migration for efficient disruption lookups

### DIFF
--- a/backend/alembic/versions/6675f5ef1429_add_route_station_index.py
+++ b/backend/alembic/versions/6675f5ef1429_add_route_station_index.py
@@ -1,0 +1,102 @@
+"""add_route_station_index
+
+Revision ID: 6675f5ef1429
+Revises: 595219043932
+Create Date: 2025-11-13 16:57:37.107767
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "6675f5ef1429"
+down_revision: str | Sequence[str] | None = "595219043932"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Create route_station_index table for fast disruption lookups
+    op.create_table(
+        "route_station_index",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column(
+            "route_id",
+            sa.UUID(),
+            nullable=False,
+            comment="User's route ID",
+        ),
+        sa.Column(
+            "line_tfl_id",
+            sa.String(length=50),
+            nullable=False,
+            comment="TfL line ID (e.g., 'piccadilly', 'northern')",
+        ),
+        sa.Column(
+            "station_naptan",
+            sa.String(length=50),
+            nullable=False,
+            comment="Station NaPTAN code (e.g., '940GZZLUKSX')",
+        ),
+        sa.Column(
+            "line_data_version",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            comment="Copy of Line.last_updated for staleness detection",
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["route_id"],
+            ["routes.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Create indexes for efficient lookups
+    # Primary lookup: "Which routes pass through station X on line Y?"
+    op.create_index(
+        op.f("ix_route_station_index_line_station"),
+        "route_station_index",
+        ["line_tfl_id", "station_naptan"],
+        unique=False,
+    )
+
+    # Cleanup lookup: "Delete all index entries for route Z"
+    op.create_index(
+        op.f("ix_route_station_index_route"),
+        "route_station_index",
+        ["route_id"],
+        unique=False,
+    )
+
+    # Staleness lookup: "Find routes with outdated index data"
+    op.create_index(
+        op.f("ix_route_station_index_line_data_version"),
+        "route_station_index",
+        ["line_data_version"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Drop indexes in reverse order
+    op.drop_index(
+        op.f("ix_route_station_index_line_data_version"),
+        table_name="route_station_index",
+    )
+    op.drop_index(op.f("ix_route_station_index_route"), table_name="route_station_index")
+    op.drop_index(
+        op.f("ix_route_station_index_line_station"),
+        table_name="route_station_index",
+    )
+
+    # Drop table
+    op.drop_table("route_station_index")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -12,6 +12,7 @@ from app.models.notification import (
 )
 from app.models.rate_limit import RateLimitAction, RateLimitLog
 from app.models.route import Route, RouteSchedule, RouteSegment
+from app.models.route_index import RouteStationIndex
 from app.models.tfl import Line, Station, StationConnection
 from app.models.user import (
     EmailAddress,
@@ -42,6 +43,7 @@ __all__ = [
     "Route",
     "RouteSegment",
     "RouteSchedule",
+    "RouteStationIndex",
     # Notification models
     "NotificationPreference",
     "NotificationLog",

--- a/backend/app/models/route.py
+++ b/backend/app/models/route.py
@@ -26,6 +26,7 @@ from app.models.user import User
 
 if TYPE_CHECKING:
     from app.models.notification import NotificationPreference
+    from app.models.route_index import RouteStationIndex
 
 
 class Route(BaseModel):
@@ -71,6 +72,10 @@ class Route(BaseModel):
         cascade="all, delete-orphan",
     )
     notification_preferences: Mapped[list["NotificationPreference"]] = relationship(
+        back_populates="route",
+        cascade="all, delete-orphan",
+    )
+    station_indexes: Mapped[list["RouteStationIndex"]] = relationship(
         back_populates="route",
         cascade="all, delete-orphan",
     )

--- a/backend/app/models/route_index.py
+++ b/backend/app/models/route_index.py
@@ -1,0 +1,74 @@
+"""Route station index model for fast disruption matching."""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import BaseModel
+from app.models.route import Route
+
+
+class RouteStationIndex(BaseModel):
+    """
+    Inverted index mapping (line_tfl_id, station_naptan) → route_id.
+
+    Enables O(log n) lookup of routes affected by station-level disruptions.
+    One row per station in each user's journey (expanded from sparse route_segments).
+
+    Example:
+        User creates route: King's Cross → Leicester Square (Piccadilly)
+        Index entries created for ALL intermediate stations:
+        - route_id=123, line_tfl_id="piccadilly", station_naptan="940GZZLUKSX"  (King's Cross)
+        - route_id=123, line_tfl_id="piccadilly", station_naptan="940GZZLURSQ"  (Russell Square)
+        - route_id=123, line_tfl_id="piccadilly", station_naptan="940GZZLUHBN"  (Holborn)
+        - route_id=123, line_tfl_id="piccadilly", station_naptan="940GZZLUCGN"  (Covent Garden)
+        - route_id=123, line_tfl_id="piccadilly", station_naptan="940GZZLULSQ"  (Leicester Square)
+
+    Updated when:
+        - User creates/updates route (Phase 2)
+        - Line.routes data changes (detected via line_data_version staleness check)
+    """
+
+    __tablename__ = "route_station_index"
+
+    route_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("routes.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="User's route ID",
+    )
+    line_tfl_id: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+        comment="TfL line ID (e.g., 'piccadilly', 'northern')",
+    )
+    station_naptan: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+        comment="Station NaPTAN code (e.g., '940GZZLUKSX')",
+    )
+    line_data_version: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        comment="Copy of Line.last_updated for staleness detection",
+    )
+
+    # Relationships
+    route: Mapped[Route] = relationship()
+
+    __table_args__ = (
+        # Primary lookup: "Which routes pass through station X on line Y?"
+        Index("ix_route_station_index_line_station", "line_tfl_id", "station_naptan"),
+        # Cleanup lookup: "Delete all index entries for route Z"
+        Index("ix_route_station_index_route", "route_id"),
+        # Staleness lookup: "Find routes with outdated index data"
+        Index("ix_route_station_index_line_data_version", "line_data_version"),
+    )
+
+    def __repr__(self) -> str:
+        """String representation of the route station index entry."""
+        return f"<RouteStationIndex(route_id={self.route_id}, line={self.line_tfl_id}, station={self.station_naptan})>"

--- a/backend/app/models/route_index.py
+++ b/backend/app/models/route_index.py
@@ -38,7 +38,6 @@ class RouteStationIndex(BaseModel):
         UUID(as_uuid=True),
         ForeignKey("routes.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,
         comment="User's route ID",
     )
     line_tfl_id: Mapped[str] = mapped_column(
@@ -58,7 +57,7 @@ class RouteStationIndex(BaseModel):
     )
 
     # Relationships
-    route: Mapped[Route] = relationship()
+    route: Mapped[Route] = relationship(back_populates="station_indexes")
 
     __table_args__ = (
         # Primary lookup: "Which routes pass through station X on line Y?"


### PR DESCRIPTION
closes #127

## Summary by Sourcery

Implement an inverted index for efficient disruption lookups by adding the RouteStationIndex model, migration, documentation, and tests

New Features:
- Add RouteStationIndex model to map routes to line and station combinations for fast lookups

Enhancements:
- Add station_indexes relationship to Route model

Build:
- Add Alembic migration to create route_station_index table with composite and cascade indexes

Documentation:
- Document the inverted index design and usage in the database ADR

Tests:
- Add comprehensive tests for RouteStationIndex covering creation, querying, cascade deletion, relationships, and staleness detection