### PR TITLE
feat: Implement route index management and rebuilding functionality

### DIFF
--- a/backend/app/celery/tasks.py
+++ b/backend/app/celery/tasks.py
@@ -5,23 +5,74 @@ periodic task that checks for TfL disruptions and sends alerts to users.
 """
 
 import asyncio
-from typing import Any
+from typing import Protocol, TypedDict
+from uuid import UUID
 
 import structlog
+from sqlalchemy import select
 
 from app.celery.app import celery_app
 from app.celery.database import worker_session_factory
+from app.models.route import Route
 from app.services.alert_service import AlertService, get_redis_client
+from app.services.route_index_service import RouteIndexService
 
 logger = structlog.get_logger(__name__)
 
 
-@celery_app.task(
+# Protocol for Celery task request
+class TaskRequest(Protocol):
+    """Protocol for Celery task request object."""
+
+    @property
+    def retries(self) -> int:
+        """Number of times task has been retried."""
+        ...
+
+
+# Protocol for Celery bound task
+class BoundTask(Protocol):
+    """Protocol for Celery bound task self parameter."""
+
+    @property
+    def request(self) -> TaskRequest:
+        """Task request object."""
+        ...
+
+    def retry(self, exc: Exception | None = None, countdown: int | None = None) -> Exception:
+        """
+        Retry the task.
+
+        This method raises an exception to signal task retry.
+        """
+        ...
+
+
+# Type definitions for task return values
+class DisruptionCheckResult(TypedDict):
+    """Result from check_disruptions_and_alert task."""
+
+    status: str
+    routes_checked: int
+    alerts_sent: int
+    errors: int
+
+
+class RebuildIndexesResult(TypedDict):
+    """Result from rebuild_route_indexes task."""
+
+    status: str
+    rebuilt_count: int
+    failed_count: int
+    errors: list[str]
+
+
+@celery_app.task(  # type: ignore[arg-type]
     bind=True,
     max_retries=3,
     name="app.celery.tasks.check_disruptions_and_alert",
 )
-def check_disruptions_and_alert(self: Any) -> dict[str, Any]:  # noqa: ANN401
+def check_disruptions_and_alert(self: BoundTask) -> DisruptionCheckResult:
     """
     Check for TfL disruptions and send alerts to users with matching preferences.
 
@@ -38,7 +89,7 @@ def check_disruptions_and_alert(self: Any) -> dict[str, Any]:  # noqa: ANN401
         self: Celery task instance (bound via bind=True)
 
     Returns:
-        dict: Task execution result with status and statistics
+        DisruptionCheckResult: Task execution result with status and statistics
 
     Raises:
         Retry: If the task should be retried due to transient failure
@@ -63,7 +114,7 @@ def check_disruptions_and_alert(self: Any) -> dict[str, Any]:  # noqa: ANN401
         raise self.retry(exc=exc, countdown=60) from exc
 
 
-async def _check_disruptions_async() -> dict[str, Any]:
+async def _check_disruptions_async() -> DisruptionCheckResult:
     """
     Async implementation of disruption checking logic.
 
@@ -72,7 +123,7 @@ async def _check_disruptions_async() -> dict[str, Any]:
     session lifecycle and Redis connection.
 
     Returns:
-        dict: Execution statistics including routes_checked, alerts_sent, and errors
+        DisruptionCheckResult: Execution statistics including routes_checked, alerts_sent, and errors
     """
     session = None
     redis_client = None
@@ -85,14 +136,119 @@ async def _check_disruptions_async() -> dict[str, Any]:
         alert_service = AlertService(db=session, redis_client=redis_client)
         result = await alert_service.process_all_routes()
 
-        return {
-            "status": "success",
-            **result,
-        }
+        return DisruptionCheckResult(
+            status="success",
+            routes_checked=result["routes_checked"],
+            alerts_sent=result["alerts_sent"],
+            errors=result["errors"],
+        )
 
     finally:
         # Ensure resources are properly closed
         if redis_client is not None:
             await redis_client.aclose()
+        if session is not None:
+            await session.close()
+
+
+@celery_app.task(  # type: ignore[arg-type]
+    bind=True,
+    max_retries=3,
+    name="app.celery.tasks.rebuild_route_indexes",
+)
+def rebuild_route_indexes_task(
+    self: BoundTask,
+    route_id: str | None = None,
+) -> RebuildIndexesResult:
+    """
+    Rebuild route station indexes for single route or all routes.
+
+    This task can be triggered manually via admin API or scheduled for maintenance.
+    It rebuilds the inverted index that maps (line_tfl_id, station_naptan) → route_id.
+
+    Args:
+        self: Celery task instance (bound via bind=True)
+        route_id: Optional route UUID string. If provided, rebuilds only that route.
+                  If None, rebuilds all routes.
+
+    Returns:
+        RebuildIndexesResult: Task execution result with rebuilt_count, failed_count, and errors
+
+    Raises:
+        Retry: If the task should be retried due to transient failure
+    """
+    try:
+        # Run async logic in the event loop
+        result = asyncio.run(_rebuild_indexes_async(route_id))
+        logger.info(
+            "rebuild_indexes_task_completed",
+            route_id=route_id,
+            result=result,
+        )
+        return result
+
+    except Exception as exc:
+        logger.error(
+            "rebuild_indexes_task_failed",
+            route_id=route_id,
+            error=str(exc),
+            error_type=type(exc).__name__,
+            retry_count=self.request.retries,
+        )
+        # Retry with exponential backoff (60s countdown)
+        raise self.retry(exc=exc, countdown=60) from exc
+
+
+async def _rebuild_indexes_async(route_id_str: str | None = None) -> RebuildIndexesResult:
+    """
+    Async implementation of route index rebuilding logic.
+
+    Args:
+        route_id_str: Optional route UUID as string
+
+    Returns:
+        RebuildIndexesResult: Execution statistics including rebuilt_count, failed_count, and errors
+    """
+    session = None
+    try:
+        # Create database session for this task
+        session = worker_session_factory()
+        index_service = RouteIndexService(session)
+
+        rebuilt_count = 0
+        failed_count = 0
+        errors: list[str] = []
+
+        if route_id_str:
+            # Rebuild single route
+            route_id = UUID(route_id_str)
+            try:
+                await index_service.build_route_station_index(route_id, auto_commit=True)
+                rebuilt_count = 1
+            except Exception as exc:
+                failed_count = 1
+                errors.append(f"Route {route_id}: {exc!s}")
+        else:
+            # Rebuild all routes
+            result = await session.execute(select(Route))
+            routes = result.scalars().all()
+
+            for route in routes:
+                try:
+                    await index_service.build_route_station_index(route.id, auto_commit=True)
+                    rebuilt_count += 1
+                except Exception as exc:
+                    failed_count += 1
+                    errors.append(f"Route {route.id}: {exc!s}")
+
+        return RebuildIndexesResult(
+            status="success" if failed_count == 0 else "partial_failure",
+            rebuilt_count=rebuilt_count,
+            failed_count=failed_count,
+            errors=errors,
+        )
+
+    finally:
+        # Ensure resources are properly closed
         if session is not None:
             await session.close()

--- a/backend/app/celery/tasks.py
+++ b/backend/app/celery/tasks.py
@@ -93,7 +93,9 @@ def check_disruptions_and_alert(self: BoundTask) -> DisruptionCheckResult:
         Retry: If the task should be retried due to transient failure
     """
     try:
-        # Run async logic in the event loop
+        # asyncio.run() creates a new event loop for this worker thread.
+        # This is the standard pattern for Celery tasks calling async code.
+        # Not blocking since each task runs in its own worker thread.
         result = asyncio.run(_check_disruptions_async())
         logger.info(
             "check_disruptions_task_completed",
@@ -176,7 +178,9 @@ def rebuild_route_indexes_task(
         Retry: If the task should be retried due to transient failure
     """
     try:
-        # Run async logic in the event loop
+        # asyncio.run() creates a new event loop for this worker thread.
+        # This is the standard pattern for Celery tasks calling async code.
+        # Not blocking since each task runs in its own worker thread.
         result = asyncio.run(_rebuild_indexes_async(route_id))
         logger.info(
             "rebuild_indexes_task_completed",

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -6,6 +6,18 @@ from uuid import UUID
 from app.models.notification import NotificationMethod, NotificationStatus
 from pydantic import BaseModel, ConfigDict, Field
 
+# ==================== Route Index Management Schemas ====================
+
+
+class RebuildIndexesResponse(BaseModel):
+    """Response from rebuilding route station indexes."""
+
+    success: bool = Field(..., description="Whether the rebuild completed successfully")
+    rebuilt_count: int = Field(..., description="Number of routes rebuilt")
+    failed_count: int = Field(..., description="Number of routes that failed to rebuild")
+    errors: list[str] = Field(default_factory=list, description="Error messages for failed routes")
+
+
 # ==================== Alert Management Schemas ====================
 
 

--- a/backend/app/services/route_index_service.py
+++ b/backend/app/services/route_index_service.py
@@ -1,0 +1,376 @@
+"""Service for building and maintaining route station indexes."""
+
+from uuid import UUID
+
+import structlog
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.route import Route, RouteSegment
+from app.models.route_index import RouteStationIndex
+from app.models.tfl import Line
+
+logger = structlog.get_logger(__name__)
+
+
+class RouteIndexService:
+    """
+    Service for building inverted indexes mapping (line, station) → routes.
+
+    Enables O(log n) disruption lookup by expanding sparse route segments
+    into complete station lists using Line.routes data.
+    """
+
+    def __init__(self, db: AsyncSession) -> None:
+        """
+        Initialize service with database session.
+
+        Args:
+            db: Async database session
+        """
+        self.db = db
+
+    async def build_route_station_index(
+        self,
+        route_id: UUID,
+        *,
+        auto_commit: bool = True,
+    ) -> dict[str, int]:
+        """
+        Build inverted index for a route by expanding segments to all intermediate stations.
+
+        Algorithm:
+        1. Delete existing index entries for this route (in transaction)
+        2. Load route with segments (ordered by sequence)
+        3. For each segment pair (current → next):
+           - Get Line.routes JSON for current.line_id
+           - Find ALL route variants containing BOTH stations
+           - For EACH matching variant:
+             - Extract all stations between current and next (inclusive)
+             - Create index entry for each (line_tfl_id, station_naptan)
+        4. Optionally commit transaction (if auto_commit=True)
+
+        Note: If multiple route variants exist (e.g., Northern Line Bank/Charing Cross branches),
+        we store ALL stations from ALL variants. This means alerts trigger if ANY branch is disrupted.
+
+        Args:
+            route_id: UUID of route to index
+            auto_commit: If True, commits the transaction. If False, caller must commit.
+
+        Returns:
+            Dictionary with statistics:
+                - entries_created: Number of index entries created
+                - segments_processed: Number of segment pairs processed
+
+        Raises:
+            ValueError: If route not found or has invalid segments
+        """
+        logger.info("build_route_station_index_started", route_id=str(route_id))
+
+        try:
+            # Load route with segments and related data
+            route = await self._load_route_with_segments(route_id)
+            if not route:
+                msg = f"Route {route_id} not found"
+                logger.error("route_not_found", route_id=str(route_id))
+                raise ValueError(msg)
+
+            # Delete existing index entries for this route
+            await self._delete_existing_index(route_id)
+
+            # Process segments and build index
+            entries_created = await self._process_segments(route)
+
+            # Commit transaction if requested
+            if auto_commit:
+                await self.db.commit()
+
+            logger.info(
+                "build_route_station_index_completed",
+                route_id=str(route_id),
+                entries_created=entries_created,
+                segments_count=len(route.segments),
+                auto_commit=auto_commit,
+            )
+
+            return {
+                "entries_created": entries_created,
+                "segments_processed": len(route.segments) - 1,  # Pairs count
+            }
+
+        except Exception as exc:
+            if auto_commit:
+                await self.db.rollback()
+            logger.error(
+                "build_route_station_index_failed",
+                route_id=str(route_id),
+                error=str(exc),
+            )
+            raise
+
+    async def _load_route_with_segments(self, route_id: UUID) -> Route | None:
+        """
+        Load route with segments, stations, and lines eagerly loaded.
+
+        Args:
+            route_id: UUID of route to load
+
+        Returns:
+            Route instance or None if not found
+        """
+        result = await self.db.execute(
+            select(Route)
+            .where(Route.id == route_id)
+            .options(
+                selectinload(Route.segments).selectinload(RouteSegment.station),
+                selectinload(Route.segments).selectinload(RouteSegment.line),
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def _delete_existing_index(self, route_id: UUID) -> None:
+        """
+        Delete all existing index entries for a route.
+
+        Args:
+            route_id: UUID of route
+        """
+        await self.db.execute(delete(RouteStationIndex).where(RouteStationIndex.route_id == route_id))
+        logger.debug("deleted_existing_index", route_id=str(route_id))
+
+    async def _process_segments(self, route: Route) -> int:
+        """
+        Process route segments and create index entries.
+
+        Iterates through segment pairs, expands to intermediate stations,
+        and creates index entries for each station.
+
+        Args:
+            route: Route instance with segments loaded
+
+        Returns:
+            Number of index entries created
+        """
+        segments = route.segments
+        if len(segments) < 2:  # noqa: PLR2004
+            logger.warning(
+                "route_has_insufficient_segments",
+                route_id=str(route.id),
+                segment_count=len(segments),
+            )
+            return 0
+
+        entries_created = 0
+
+        # Process each consecutive segment pair
+        for i in range(len(segments) - 1):
+            current_segment = segments[i]
+            next_segment = segments[i + 1]
+
+            # Skip if current segment has no line (destination-only segment)
+            if not current_segment.line:
+                logger.debug(
+                    "skipping_segment_no_line",
+                    route_id=str(route.id),
+                    sequence=current_segment.sequence,
+                )
+                continue
+
+            # Get station IDs for searching Line.routes (use actual tfl_id, not hub code)
+            # Line.routes contains actual station TfL IDs, not hub codes
+            from_station_search_id = current_segment.station.tfl_id
+            to_station_search_id = next_segment.station.tfl_id
+
+            # Expand segment pair to intermediate stations
+            try:
+                station_naptans = await self._expand_segment_to_stations(
+                    from_station_search_id,
+                    to_station_search_id,
+                    current_segment.line,
+                )
+
+                # Create index entries for all intermediate stations
+                for station_naptan in station_naptans:
+                    self.db.add(
+                        RouteStationIndex(
+                            route_id=route.id,
+                            line_tfl_id=current_segment.line.tfl_id,
+                            station_naptan=station_naptan,
+                            line_data_version=current_segment.line.last_updated,
+                        )
+                    )
+                    entries_created += 1
+
+                logger.debug(
+                    "expanded_segment",
+                    route_id=str(route.id),
+                    from_station=from_station_search_id,
+                    to_station=to_station_search_id,
+                    line=current_segment.line.tfl_id,
+                    stations_found=len(station_naptans),
+                )
+
+            except ValueError as exc:
+                logger.warning(
+                    "segment_expansion_failed",
+                    route_id=str(route.id),
+                    from_station=from_station_search_id,
+                    to_station=to_station_search_id,
+                    line=current_segment.line.tfl_id if current_segment.line else None,
+                    error=str(exc),
+                )
+                # Continue processing other segments rather than failing entire index build
+                continue
+
+        return entries_created
+
+    async def _expand_segment_to_stations(
+        self,
+        from_station_naptan: str,
+        to_station_naptan: str,
+        line: Line,
+    ) -> list[str]:
+        """
+        Expand segment to all intermediate stations using Line.routes data.
+
+        Searches through all route variants in Line.routes and extracts
+        stations between from_station and to_station (inclusive).
+        If multiple variants contain the segment, returns stations from ALL variants.
+
+        Args:
+            from_station_naptan: Starting station NaPTAN code (may be hub code)
+            to_station_naptan: Ending station NaPTAN code (may be hub code)
+            line: Line instance with routes JSON
+
+        Returns:
+            List of station NaPTAN codes (deduplicated, order preserved)
+
+        Raises:
+            ValueError: If Line.routes is None/empty or no variant contains both stations
+        """
+        if not line.routes or "routes" not in line.routes:
+            msg = f"Line {line.tfl_id} has no routes data"
+            raise ValueError(msg)
+
+        all_stations: list[str] = []
+        variants_found = 0
+
+        # Search through all route variants
+        for variant in line.routes["routes"]:
+            stations = variant.get("stations", [])
+            if not stations:
+                continue
+
+            # Find positions of from and to stations in this variant
+            try:
+                from_idx = stations.index(from_station_naptan)
+                to_idx = stations.index(to_station_naptan)
+            except ValueError:
+                # This variant doesn't contain both stations, try next variant
+                continue
+
+            # Extract all stations between from and to (inclusive)
+            start_idx = min(from_idx, to_idx)
+            end_idx = max(from_idx, to_idx)
+            variant_stations = stations[start_idx : end_idx + 1]
+
+            # Add stations from this variant (preserving order, deduplicating)
+            for station in variant_stations:
+                if station not in all_stations:
+                    all_stations.append(station)
+
+            variants_found += 1
+            logger.debug(
+                "found_matching_variant",
+                line=line.tfl_id,
+                variant_name=variant.get("name", "unknown"),
+                from_station=from_station_naptan,
+                to_station=to_station_naptan,
+                stations_in_variant=len(variant_stations),
+            )
+
+        if variants_found == 0:
+            msg = f"No route variant on line {line.tfl_id} contains both {from_station_naptan} and {to_station_naptan}"
+            raise ValueError(msg)
+
+        logger.debug(
+            "expanded_segment_summary",
+            line=line.tfl_id,
+            from_station=from_station_naptan,
+            to_station=to_station_naptan,
+            variants_matched=variants_found,
+            total_unique_stations=len(all_stations),
+        )
+
+        return all_stations
+
+
+# =============================================================================
+# Pure Function Helpers
+# =============================================================================
+
+
+def find_stations_between(
+    stations: list[str],
+    from_station: str,
+    to_station: str,
+) -> list[str] | None:
+    """
+    Find all stations between from_station and to_station in an ordered list.
+
+    Pure function with no side effects.
+
+    Args:
+        stations: Ordered list of station NaPTAN codes
+        from_station: Starting station NaPTAN code
+        to_station: Ending station NaPTAN code
+
+    Returns:
+        List of stations between from and to (inclusive), or None if both stations not found
+
+    Examples:
+        >>> stations = ["A", "B", "C", "D", "E"]
+        >>> find_stations_between(stations, "B", "D")
+        ['B', 'C', 'D']
+        >>> find_stations_between(stations, "D", "B")  # Reversed order
+        ['B', 'C', 'D']
+        >>> find_stations_between(stations, "A", "Z")  # Not found
+        None
+    """
+    try:
+        from_idx = stations.index(from_station)
+        to_idx = stations.index(to_station)
+    except ValueError:
+        return None
+
+    start_idx = min(from_idx, to_idx)
+    end_idx = max(from_idx, to_idx)
+    return stations[start_idx : end_idx + 1]
+
+
+def deduplicate_preserving_order(items: list[str]) -> list[str]:
+    """
+    Remove duplicates from list while preserving first occurrence order.
+
+    Pure function with no side effects.
+
+    Args:
+        items: List of strings (may contain duplicates)
+
+    Returns:
+        List with duplicates removed, order preserved
+
+    Examples:
+        >>> deduplicate_preserving_order(["A", "B", "A", "C", "B"])
+        ['A', 'B', 'C']
+        >>> deduplicate_preserving_order([])
+        []
+    """
+    seen: set[str] = set()
+    result: list[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result

--- a/backend/app/services/route_index_service.py
+++ b/backend/app/services/route_index_service.py
@@ -271,6 +271,18 @@ class RouteIndexService:
                 )
                 continue
 
+            # Skip if either segment is missing station data
+            if not current_segment.station or not next_segment.station:
+                logger.warning(
+                    "skipping_segment_missing_station",
+                    route_id=str(route.id),
+                    current_sequence=current_segment.sequence,
+                    next_sequence=next_segment.sequence,
+                    current_station_missing=current_segment.station is None,
+                    next_station_missing=next_segment.station is None,
+                )
+                continue
+
             # Track that we're processing this pair
             pairs_processed += 1
 

--- a/backend/tests/test_admin_route_index.py
+++ b/backend/tests/test_admin_route_index.py
@@ -1,0 +1,179 @@
+"""Tests for admin route index management endpoint."""
+
+from collections.abc import AsyncGenerator
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+from app.core.config import settings
+from app.core.database import get_db
+from app.main import app
+from app.models.user import User
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def build_api_url(endpoint: str) -> str:
+    """
+    Build full API URL with version prefix.
+
+    Args:
+        endpoint: API endpoint path (e.g., '/admin/routes/rebuild-indexes')
+
+    Returns:
+        Full API URL (e.g., '/api/v1/admin/routes/rebuild-indexes')
+    """
+    prefix = settings.API_V1_PREFIX.rstrip("/")
+    path = endpoint if endpoint.startswith("/") else f"/{endpoint}"
+    return f"{prefix}{path}"
+
+
+@pytest.fixture
+async def async_client_with_db(db_session: AsyncSession) -> AsyncGenerator[AsyncClient]:
+    """Async HTTP client with database dependency override."""
+
+    async def override_get_db() -> AsyncGenerator[AsyncSession]:
+        yield db_session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            yield client
+    finally:
+        app.dependency_overrides.clear()
+
+
+class TestAdminRebuildIndexesEndpoint:
+    """Tests for POST /admin/routes/rebuild-indexes endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_rebuild_indexes_success_single_route(
+        self,
+        async_client_with_db: AsyncClient,
+        admin_user: User,
+        admin_auth_headers: dict[str, str],
+    ) -> None:
+        """Test rebuilding indexes for a single route successfully."""
+        route_id = uuid4()
+
+        # Mock the service method to avoid needing full database setup
+        mock_result = {"rebuilt_count": 1, "failed_count": 0, "errors": []}
+
+        with patch("app.api.admin.RouteIndexService") as mock_service_class:
+            mock_service = AsyncMock()
+            mock_service.rebuild_routes = AsyncMock(return_value=mock_result)
+            mock_service_class.return_value = mock_service
+
+            response = await async_client_with_db.post(
+                build_api_url(f"/admin/routes/rebuild-indexes?route_id={route_id}"),
+                headers=admin_auth_headers,
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert data["rebuilt_count"] == 1
+            assert data["failed_count"] == 0
+            assert data["errors"] == []
+
+            # Verify service was called correctly
+            mock_service.rebuild_routes.assert_called_once_with(route_id, auto_commit=True)
+
+    @pytest.mark.asyncio
+    async def test_rebuild_indexes_success_all_routes(
+        self,
+        async_client_with_db: AsyncClient,
+        admin_user: User,
+        admin_auth_headers: dict[str, str],
+    ) -> None:
+        """Test rebuilding indexes for all routes successfully."""
+        mock_result = {"rebuilt_count": 5, "failed_count": 0, "errors": []}
+
+        with patch("app.api.admin.RouteIndexService") as mock_service_class:
+            mock_service = AsyncMock()
+            mock_service.rebuild_routes = AsyncMock(return_value=mock_result)
+            mock_service_class.return_value = mock_service
+
+            response = await async_client_with_db.post(
+                build_api_url("/admin/routes/rebuild-indexes"),
+                headers=admin_auth_headers,
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert data["rebuilt_count"] == 5
+            assert data["failed_count"] == 0
+            assert data["errors"] == []
+
+            # Verify service was called with None (all routes)
+            mock_service.rebuild_routes.assert_called_once_with(None, auto_commit=True)
+
+    @pytest.mark.asyncio
+    async def test_rebuild_indexes_partial_failure(
+        self,
+        async_client_with_db: AsyncClient,
+        admin_user: User,
+        admin_auth_headers: dict[str, str],
+    ) -> None:
+        """Test rebuilding indexes with some failures."""
+        route_id = uuid4()
+        mock_result = {
+            "rebuilt_count": 0,
+            "failed_count": 1,
+            "errors": [f"Route {route_id}: Route not found"],
+        }
+
+        with patch("app.api.admin.RouteIndexService") as mock_service_class:
+            mock_service = AsyncMock()
+            mock_service.rebuild_routes = AsyncMock(return_value=mock_result)
+            mock_service_class.return_value = mock_service
+
+            response = await async_client_with_db.post(
+                build_api_url(f"/admin/routes/rebuild-indexes?route_id={route_id}"),
+                headers=admin_auth_headers,
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is False
+            assert data["rebuilt_count"] == 0
+            assert data["failed_count"] == 1
+            assert len(data["errors"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_rebuild_indexes_requires_admin(
+        self,
+        async_client_with_db: AsyncClient,
+        test_user: User,
+        test_auth_headers: dict[str, str],
+    ) -> None:
+        """Test that non-admin users cannot rebuild indexes."""
+        response = await async_client_with_db.post(
+            build_api_url("/admin/routes/rebuild-indexes"),
+            headers=test_auth_headers,
+        )
+
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_rebuild_indexes_exception_handling(
+        self,
+        async_client_with_db: AsyncClient,
+        admin_user: User,
+        admin_auth_headers: dict[str, str],
+    ) -> None:
+        """Test that service exceptions are properly converted to HTTP errors."""
+        with patch("app.api.admin.RouteIndexService") as mock_service_class:
+            mock_service = AsyncMock()
+            mock_service.rebuild_routes = AsyncMock(side_effect=Exception("Database error"))
+            mock_service_class.return_value = mock_service
+
+            response = await async_client_with_db.post(
+                build_api_url("/admin/routes/rebuild-indexes"),
+                headers=admin_auth_headers,
+            )
+
+            assert response.status_code == 500
+            assert "Failed to rebuild indexes" in response.json()["detail"]

--- a/backend/tests/test_admin_route_index.py
+++ b/backend/tests/test_admin_route_index.py
@@ -52,7 +52,7 @@ class TestAdminRebuildIndexesEndpoint:
         self,
         async_client_with_db: AsyncClient,
         admin_user: User,
-        admin_auth_headers: dict[str, str],
+        admin_headers: dict[str, str],
     ) -> None:
         """Test rebuilding indexes for a single route successfully."""
         route_id = uuid4()
@@ -67,7 +67,7 @@ class TestAdminRebuildIndexesEndpoint:
 
             response = await async_client_with_db.post(
                 build_api_url(f"/admin/routes/rebuild-indexes?route_id={route_id}"),
-                headers=admin_auth_headers,
+                headers=admin_headers,
             )
 
             assert response.status_code == 200
@@ -85,7 +85,7 @@ class TestAdminRebuildIndexesEndpoint:
         self,
         async_client_with_db: AsyncClient,
         admin_user: User,
-        admin_auth_headers: dict[str, str],
+        admin_headers: dict[str, str],
     ) -> None:
         """Test rebuilding indexes for all routes successfully."""
         mock_result = {"rebuilt_count": 5, "failed_count": 0, "errors": []}
@@ -97,7 +97,7 @@ class TestAdminRebuildIndexesEndpoint:
 
             response = await async_client_with_db.post(
                 build_api_url("/admin/routes/rebuild-indexes"),
-                headers=admin_auth_headers,
+                headers=admin_headers,
             )
 
             assert response.status_code == 200
@@ -115,7 +115,7 @@ class TestAdminRebuildIndexesEndpoint:
         self,
         async_client_with_db: AsyncClient,
         admin_user: User,
-        admin_auth_headers: dict[str, str],
+        admin_headers: dict[str, str],
     ) -> None:
         """Test rebuilding indexes with some failures."""
         route_id = uuid4()
@@ -132,7 +132,7 @@ class TestAdminRebuildIndexesEndpoint:
 
             response = await async_client_with_db.post(
                 build_api_url(f"/admin/routes/rebuild-indexes?route_id={route_id}"),
-                headers=admin_auth_headers,
+                headers=admin_headers,
             )
 
             assert response.status_code == 200
@@ -147,12 +147,12 @@ class TestAdminRebuildIndexesEndpoint:
         self,
         async_client_with_db: AsyncClient,
         test_user: User,
-        test_auth_headers: dict[str, str],
+        auth_headers_for_user: dict[str, str],
     ) -> None:
         """Test that non-admin users cannot rebuild indexes."""
         response = await async_client_with_db.post(
             build_api_url("/admin/routes/rebuild-indexes"),
-            headers=test_auth_headers,
+            headers=auth_headers_for_user,
         )
 
         assert response.status_code == 403
@@ -162,7 +162,7 @@ class TestAdminRebuildIndexesEndpoint:
         self,
         async_client_with_db: AsyncClient,
         admin_user: User,
-        admin_auth_headers: dict[str, str],
+        admin_headers: dict[str, str],
     ) -> None:
         """Test that service exceptions are properly converted to HTTP errors."""
         with patch("app.api.admin.RouteIndexService") as mock_service_class:
@@ -172,7 +172,7 @@ class TestAdminRebuildIndexesEndpoint:
 
             response = await async_client_with_db.post(
                 build_api_url("/admin/routes/rebuild-indexes"),
-                headers=admin_auth_headers,
+                headers=admin_headers,
             )
 
             assert response.status_code == 500

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -1,9 +1,15 @@
 """Tests for Celery tasks."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
 
 import pytest
-from app.celery.tasks import _check_disruptions_async, check_disruptions_and_alert
+from app.celery.tasks import (
+    _check_disruptions_async,
+    _rebuild_indexes_async,
+    check_disruptions_and_alert,
+    rebuild_route_indexes_task,
+)
 
 # ==================== check_disruptions_and_alert Tests ====================
 
@@ -380,3 +386,298 @@ def test_check_disruptions_task_logs_on_error(mock_asyncio_run: MagicMock) -> No
         mock_logger.error.assert_called_once()
         call_args = mock_logger.error.call_args
         assert call_args[0][0] == "check_disruptions_task_failed"
+
+
+# ==================== rebuild_route_indexes_task Tests ====================
+
+
+def test_rebuild_indexes_task_registered() -> None:
+    """Test that rebuild_route_indexes_task function exists."""
+    # This is a simple test to ensure the task exists
+    assert rebuild_route_indexes_task is not None
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.RouteIndexService")
+@patch("app.celery.tasks.worker_session_factory")
+async def test_rebuild_indexes_async_success_single_route(
+    mock_session_factory: MagicMock,
+    mock_service_class: MagicMock,
+) -> None:
+    """Test successful execution for a single route."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock RouteIndexService
+    mock_service_instance = AsyncMock()
+    mock_service_instance.rebuild_routes = AsyncMock(
+        return_value={
+            "rebuilt_count": 1,
+            "failed_count": 0,
+            "errors": [],
+        }
+    )
+    mock_service_class.return_value = mock_service_instance
+
+    # Execute async function with single route
+    test_route_id = "550e8400-e29b-41d4-a716-446655440000"
+    result = await _rebuild_indexes_async(test_route_id)
+
+    # Verify result
+    assert result["status"] == "success"
+    assert result["rebuilt_count"] == 1
+    assert result["failed_count"] == 0
+    assert result["errors"] == []
+
+    # Verify RouteIndexService was instantiated correctly
+    mock_service_class.assert_called_once_with(mock_session)
+
+    # Verify rebuild_routes was called with correct UUID
+    mock_service_instance.rebuild_routes.assert_called_once()
+    call_args = mock_service_instance.rebuild_routes.call_args
+    assert call_args[0][0] == UUID(test_route_id)
+    assert call_args[1]["auto_commit"] is True
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.RouteIndexService")
+@patch("app.celery.tasks.worker_session_factory")
+async def test_rebuild_indexes_async_success_all_routes(
+    mock_session_factory: MagicMock,
+    mock_service_class: MagicMock,
+) -> None:
+    """Test successful execution for all routes."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock RouteIndexService
+    mock_service_instance = AsyncMock()
+    mock_service_instance.rebuild_routes = AsyncMock(
+        return_value={
+            "rebuilt_count": 10,
+            "failed_count": 0,
+            "errors": [],
+        }
+    )
+    mock_service_class.return_value = mock_service_instance
+
+    # Execute async function with no route_id (rebuild all)
+    result = await _rebuild_indexes_async(None)
+
+    # Verify result
+    assert result["status"] == "success"
+    assert result["rebuilt_count"] == 10
+    assert result["failed_count"] == 0
+    assert result["errors"] == []
+
+    # Verify rebuild_routes was called with None
+    mock_service_instance.rebuild_routes.assert_called_once()
+    call_args = mock_service_instance.rebuild_routes.call_args
+    assert call_args[0][0] is None
+    assert call_args[1]["auto_commit"] is True
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.RouteIndexService")
+@patch("app.celery.tasks.worker_session_factory")
+async def test_rebuild_indexes_async_partial_failure(
+    mock_session_factory: MagicMock,
+    mock_service_class: MagicMock,
+) -> None:
+    """Test async function when some routes fail."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock RouteIndexService with partial failure
+    mock_service_instance = AsyncMock()
+    mock_service_instance.rebuild_routes = AsyncMock(
+        return_value={
+            "rebuilt_count": 8,
+            "failed_count": 2,
+            "errors": ["Route 1 failed", "Route 2 failed"],
+        }
+    )
+    mock_service_class.return_value = mock_service_instance
+
+    # Execute async function
+    result = await _rebuild_indexes_async(None)
+
+    # Verify result shows partial_failure
+    assert result["status"] == "partial_failure"
+    assert result["rebuilt_count"] == 8
+    assert result["failed_count"] == 2
+    assert len(result["errors"]) == 2
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.worker_session_factory")
+async def test_rebuild_indexes_async_invalid_uuid(
+    mock_session_factory: MagicMock,
+) -> None:
+    """Test that invalid UUID string raises ValueError."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Execute with invalid UUID string
+    with pytest.raises(ValueError, match="badly formed hexadecimal UUID string"):
+        await _rebuild_indexes_async("not-a-valid-uuid")
+
+    # Verify session was still closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.RouteIndexService")
+@patch("app.celery.tasks.worker_session_factory")
+async def test_rebuild_indexes_async_closes_session_on_success(
+    mock_session_factory: MagicMock,
+    mock_service_class: MagicMock,
+) -> None:
+    """Test that async function properly closes database connection."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock RouteIndexService
+    mock_service_instance = AsyncMock()
+    mock_service_instance.rebuild_routes = AsyncMock(
+        return_value={
+            "rebuilt_count": 5,
+            "failed_count": 0,
+            "errors": [],
+        }
+    )
+    mock_service_class.return_value = mock_service_instance
+
+    # Execute async function
+    await _rebuild_indexes_async(None)
+
+    # Verify session was closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.RouteIndexService")
+@patch("app.celery.tasks.worker_session_factory")
+async def test_rebuild_indexes_async_closes_session_on_error(
+    mock_session_factory: MagicMock,
+    mock_service_class: MagicMock,
+) -> None:
+    """Test that async function closes session even when error occurs."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock RouteIndexService to raise error
+    mock_service_instance = AsyncMock()
+    mock_service_instance.rebuild_routes = AsyncMock(side_effect=RuntimeError("Database error"))
+    mock_service_class.return_value = mock_service_instance
+
+    # Execute async function and catch exception
+    with pytest.raises(RuntimeError, match="Database error"):
+        await _rebuild_indexes_async(None)
+
+    # Verify session was still closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.RouteIndexService")
+@patch("app.celery.tasks.worker_session_factory")
+async def test_rebuild_indexes_async_closes_session_when_service_fails(
+    mock_session_factory: MagicMock,
+    mock_service_class: MagicMock,
+) -> None:
+    """Test that session is closed even when RouteIndexService instantiation fails."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock RouteIndexService to raise error on instantiation
+    mock_service_class.side_effect = RuntimeError("Service init failed")
+
+    # Execute async function and catch exception
+    with pytest.raises(RuntimeError, match="Service init failed"):
+        await _rebuild_indexes_async(None)
+
+    # Verify session was still closed
+    mock_session.close.assert_called_once()
+
+
+@patch("app.celery.tasks.asyncio.run")
+def test_rebuild_indexes_task_success_path(mock_asyncio_run: MagicMock) -> None:
+    """Test the synchronous task wrapper success path."""
+    mock_result = {
+        "status": "success",
+        "rebuilt_count": 5,
+        "failed_count": 0,
+        "errors": [],
+    }
+    mock_asyncio_run.return_value = mock_result
+
+    result = rebuild_route_indexes_task(route_id="550e8400-e29b-41d4-a716-446655440000")
+
+    assert result == mock_result
+    mock_asyncio_run.assert_called_once()
+
+
+@patch("app.celery.tasks.asyncio.run")
+def test_rebuild_indexes_task_retry_on_error(mock_asyncio_run: MagicMock) -> None:
+    """Test that task retries on exception."""
+    # Mock asyncio.run to raise an exception
+    mock_asyncio_run.side_effect = RuntimeError("Database connection lost")
+
+    # Create a mock Celery task instance with retry method
+    task_instance = rebuild_route_indexes_task
+
+    # Execute the task and expect retry exception
+    with pytest.raises(Exception):  # noqa: B017, PT011  # Celery raises Retry exception
+        task_instance(route_id=None)
+
+
+@patch("app.celery.tasks.asyncio.run")
+def test_rebuild_indexes_task_logs_on_success(mock_asyncio_run: MagicMock) -> None:
+    """Test that task logs completion."""
+    mock_result = {
+        "status": "success",
+        "rebuilt_count": 3,
+        "failed_count": 0,
+        "errors": [],
+    }
+    mock_asyncio_run.return_value = mock_result
+
+    with patch("app.celery.tasks.logger") as mock_logger:
+        result = rebuild_route_indexes_task(route_id=None)
+
+        assert result == mock_result
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args
+        assert call_args[0][0] == "rebuild_indexes_task_completed"
+
+
+@patch("app.celery.tasks.asyncio.run")
+def test_rebuild_indexes_task_logs_on_error(mock_asyncio_run: MagicMock) -> None:
+    """Test that task logs errors before retry."""
+    mock_asyncio_run.side_effect = RuntimeError("Test error")
+
+    task_instance = rebuild_route_indexes_task
+
+    with patch("app.celery.tasks.logger") as mock_logger:
+        with pytest.raises(Exception):  # noqa: B017, PT011  # Celery raises Retry exception
+            task_instance(route_id="550e8400-e29b-41d4-a716-446655440000")
+
+        # Verify error was logged
+        mock_logger.error.assert_called_once()
+        call_args = mock_logger.error.call_args
+        assert call_args[0][0] == "rebuild_indexes_task_failed"

--- a/backend/tests/test_route_index_service.py
+++ b/backend/tests/test_route_index_service.py
@@ -1,0 +1,639 @@
+"""Tests for RouteIndexService."""
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from app.models.route import Route, RouteSegment
+from app.models.route_index import RouteStationIndex
+from app.models.tfl import Line
+from app.models.user import User
+from app.services.route_index_service import (
+    RouteIndexService,
+    deduplicate_preserving_order,
+    find_stations_between,
+)
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from tests.helpers.railway_network import TestRailwayNetwork
+
+# =============================================================================
+# Pure Function Tests
+# =============================================================================
+
+
+class TestPureFunctions:
+    """Tests for pure function helpers."""
+
+    def test_find_stations_between_forward_order(self) -> None:
+        """Test finding stations in forward order."""
+        stations = ["A", "B", "C", "D", "E"]
+        result = find_stations_between(stations, "B", "D")
+        assert result == ["B", "C", "D"]
+
+    def test_find_stations_between_reverse_order(self) -> None:
+        """Test finding stations in reverse order (should still return forward order)."""
+        stations = ["A", "B", "C", "D", "E"]
+        result = find_stations_between(stations, "D", "B")
+        assert result == ["B", "C", "D"]
+
+    def test_find_stations_between_same_station(self) -> None:
+        """Test finding stations when from and to are the same."""
+        stations = ["A", "B", "C"]
+        result = find_stations_between(stations, "B", "B")
+        assert result == ["B"]
+
+    def test_find_stations_between_not_found(self) -> None:
+        """Test finding stations when one is not in the list."""
+        stations = ["A", "B", "C"]
+        result = find_stations_between(stations, "A", "Z")
+        assert result is None
+
+    def test_find_stations_between_empty_list(self) -> None:
+        """Test finding stations in empty list."""
+        result = find_stations_between([], "A", "B")
+        assert result is None
+
+    def test_deduplicate_preserving_order(self) -> None:
+        """Test deduplicating while preserving order."""
+        items = ["A", "B", "A", "C", "B", "D"]
+        result = deduplicate_preserving_order(items)
+        assert result == ["A", "B", "C", "D"]
+
+    def test_deduplicate_preserving_order_no_duplicates(self) -> None:
+        """Test deduplicating list with no duplicates."""
+        items = ["A", "B", "C"]
+        result = deduplicate_preserving_order(items)
+        assert result == ["A", "B", "C"]
+
+    def test_deduplicate_preserving_order_empty(self) -> None:
+        """Test deduplicating empty list."""
+        result = deduplicate_preserving_order([])
+        assert result == []
+
+
+# =============================================================================
+# Service Tests
+# =============================================================================
+
+
+class TestRouteIndexService:
+    """Tests for RouteIndexService."""
+
+    @pytest.mark.asyncio
+    async def test_build_index_simple_two_stop_line(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> None:
+        """Test building index for simple two-stop route."""
+        # Create test network
+        line = TestRailwayNetwork.create_2stopline()
+        station1 = TestRailwayNetwork.create_twostop_west()
+        station2 = TestRailwayNetwork.create_twostop_east()
+
+        db_session.add_all([line, station1, station2])
+        await db_session.flush()
+
+        # Create route with 2 segments
+        route = Route(
+            user_id=test_user.id,
+            name="Test Route",
+            active=True,
+        )
+        db_session.add(route)
+        await db_session.flush()
+
+        segment1 = RouteSegment(
+            route_id=route.id,
+            sequence=1,
+            station_id=station1.id,
+            line_id=line.id,
+        )
+        segment2 = RouteSegment(
+            route_id=route.id,
+            sequence=2,
+            station_id=station2.id,
+            line_id=None,  # Destination segment
+        )
+        db_session.add_all([segment1, segment2])
+        await db_session.commit()
+
+        # Build index
+        service = RouteIndexService(db_session)
+        result = await service.build_route_station_index(route.id)
+
+        # Verify result statistics
+        assert result["segments_processed"] == 1
+        assert result["entries_created"] == 2  # Both stations on 2stopline
+
+        # Verify index entries were created
+        index_result = await db_session.execute(select(RouteStationIndex).where(RouteStationIndex.route_id == route.id))
+        index_entries = index_result.scalars().all()
+
+        assert len(index_entries) == 2
+        station_naptans = {entry.station_naptan for entry in index_entries}
+        assert station_naptans == {
+            TestRailwayNetwork.STATION_TWOSTOP_WEST,
+            TestRailwayNetwork.STATION_TWOSTOP_EAST,
+        }
+        # All entries should be for 2stopline
+        assert all(entry.line_tfl_id == TestRailwayNetwork.LINE_2STOPLINE for entry in index_entries)
+
+    @pytest.mark.asyncio
+    async def test_build_index_parallel_line_multi_variant(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> None:
+        """Test building index for route on line with multiple variants (Bank/Charing pattern)."""
+        # Create test network - parallelline has 4 variants (2 directions x 2 branches)
+        line = TestRailwayNetwork.create_parallelline()
+        station_north = TestRailwayNetwork.create_parallel_north()
+        station_south = TestRailwayNetwork.create_parallel_south()
+        station_split = TestRailwayNetwork.create_parallel_split()
+        station_rejoin = TestRailwayNetwork.create_parallel_rejoin()
+        station_bank1 = TestRailwayNetwork.create_via_bank_1()
+        station_bank2 = TestRailwayNetwork.create_via_bank_2()
+        station_charing1 = TestRailwayNetwork.create_via_charing_1()
+        station_charing2 = TestRailwayNetwork.create_via_charing_2()
+
+        db_session.add_all(
+            [
+                line,
+                station_north,
+                station_south,
+                station_split,
+                station_rejoin,
+                station_bank1,
+                station_bank2,
+                station_charing1,
+                station_charing2,
+            ]
+        )
+        await db_session.flush()
+
+        # Create route: parallel-north → parallel-south
+        route = Route(
+            user_id=test_user.id,
+            name="North to South Route",
+            active=True,
+        )
+        db_session.add(route)
+        await db_session.flush()
+
+        segment1 = RouteSegment(
+            route_id=route.id,
+            sequence=1,
+            station_id=station_north.id,
+            line_id=line.id,
+        )
+        segment2 = RouteSegment(
+            route_id=route.id,
+            sequence=2,
+            station_id=station_south.id,
+            line_id=None,
+        )
+        db_session.add_all([segment1, segment2])
+        await db_session.commit()
+
+        # Build index
+        service = RouteIndexService(db_session)
+        result = await service.build_route_station_index(route.id)
+
+        # Verify result statistics
+        assert result["segments_processed"] == 1
+
+        # Verify index entries - should include stations from BOTH Bank and Charing branches
+        index_result = await db_session.execute(select(RouteStationIndex).where(RouteStationIndex.route_id == route.id))
+        index_entries = index_result.scalars().all()
+
+        # Expected stations: north, split, bank1, bank2, rejoin, charing1, charing2, south
+        # (Deduplicated from both southbound variants)
+        station_naptans = {entry.station_naptan for entry in index_entries}
+        expected_stations = {
+            TestRailwayNetwork.STATION_PARALLEL_NORTH,
+            TestRailwayNetwork.STATION_PARALLEL_SPLIT,
+            TestRailwayNetwork.STATION_VIA_BANK_1,
+            TestRailwayNetwork.STATION_VIA_BANK_2,
+            TestRailwayNetwork.STATION_VIA_CHARING_1,
+            TestRailwayNetwork.STATION_VIA_CHARING_2,
+            TestRailwayNetwork.STATION_PARALLEL_REJOIN,
+            TestRailwayNetwork.STATION_PARALLEL_SOUTH,
+        }
+        assert station_naptans == expected_stations
+
+        # All entries should be for parallelline
+        assert all(entry.line_tfl_id == TestRailwayNetwork.LINE_PARALLELLINE for entry in index_entries)
+
+    @pytest.mark.asyncio
+    async def test_build_index_forked_line_y_shaped(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> None:
+        """Test building index for route on Y-shaped forked line."""
+        # Create test network
+        line = TestRailwayNetwork.create_forkedline()
+        station_west_fork = TestRailwayNetwork.create_west_fork()
+        station_junction = TestRailwayNetwork.create_fork_junction()
+        station_mid_1 = TestRailwayNetwork.create_fork_mid_1()
+        station_south = TestRailwayNetwork.create_fork_south_end()
+        station_west_fork_2 = TestRailwayNetwork.create_west_fork_2()
+
+        db_session.add_all(
+            [
+                line,
+                station_west_fork_2,
+                station_west_fork,
+                station_junction,
+                station_mid_1,
+                station_south,
+            ]
+        )
+        await db_session.flush()
+
+        # Create route: west-fork → fork-south-end (via junction)
+        route = Route(
+            user_id=test_user.id,
+            name="West Branch Route",
+            active=True,
+        )
+        db_session.add(route)
+        await db_session.flush()
+
+        segment1 = RouteSegment(
+            route_id=route.id,
+            sequence=1,
+            station_id=station_west_fork.id,
+            line_id=line.id,
+        )
+        segment2 = RouteSegment(
+            route_id=route.id,
+            sequence=2,
+            station_id=station_south.id,
+            line_id=None,
+        )
+        db_session.add_all([segment1, segment2])
+        await db_session.commit()
+
+        # Build index
+        service = RouteIndexService(db_session)
+        await service.build_route_station_index(route.id)
+
+        # Verify index entries
+        index_result = await db_session.execute(select(RouteStationIndex).where(RouteStationIndex.route_id == route.id))
+        index_entries = index_result.scalars().all()
+
+        # Expected: west-fork, fork-junction, fork-mid-1, fork-mid-2, fork-south-end
+        station_naptans = {entry.station_naptan for entry in index_entries}
+        expected_stations = {
+            TestRailwayNetwork.STATION_WEST_FORK,
+            TestRailwayNetwork.STATION_FORK_JUNCTION,
+            TestRailwayNetwork.STATION_FORK_MID_1,
+            TestRailwayNetwork.STATION_FORK_MID_2,
+            TestRailwayNetwork.STATION_FORK_SOUTH_END,
+        }
+        assert station_naptans == expected_stations
+
+    @pytest.mark.asyncio
+    async def test_build_index_multi_segment_route(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> None:
+        """Test building index for route with multiple segments across different lines."""
+        # Create test network - use two different lines
+        line1 = TestRailwayNetwork.create_2stopline()
+        line2 = TestRailwayNetwork.create_sharedline_a()
+
+        station1 = TestRailwayNetwork.create_twostop_west()
+        station2 = TestRailwayNetwork.create_twostop_east()
+        station3 = TestRailwayNetwork.create_shareda_1()
+        station4 = TestRailwayNetwork.create_shareda_2()
+
+        db_session.add_all([line1, line2, station1, station2, station3, station4])
+        await db_session.flush()
+
+        # Create route with 4 segments across 2 lines
+        route = Route(
+            user_id=test_user.id,
+            name="Multi-Line Route",
+            active=True,
+        )
+        db_session.add(route)
+        await db_session.flush()
+
+        segments = [
+            RouteSegment(route_id=route.id, sequence=1, station_id=station1.id, line_id=line1.id),
+            RouteSegment(route_id=route.id, sequence=2, station_id=station2.id, line_id=None),  # Interchange
+            RouteSegment(route_id=route.id, sequence=3, station_id=station3.id, line_id=line2.id),
+            RouteSegment(route_id=route.id, sequence=4, station_id=station4.id, line_id=None),  # Destination
+        ]
+        db_session.add_all(segments)
+        await db_session.commit()
+
+        # Build index
+        service = RouteIndexService(db_session)
+        result = await service.build_route_station_index(route.id)
+
+        # Verify result statistics
+        assert result["segments_processed"] == 3  # 4 segments = 3 pairs
+
+        # Verify index entries
+        index_result = await db_session.execute(select(RouteStationIndex).where(RouteStationIndex.route_id == route.id))
+        index_entries = index_result.scalars().all()
+
+        # Group entries by line
+        entries_by_line = {}
+        for entry in index_entries:
+            if entry.line_tfl_id not in entries_by_line:
+                entries_by_line[entry.line_tfl_id] = []
+            entries_by_line[entry.line_tfl_id].append(entry.station_naptan)
+
+        # Should have entries for both lines
+        assert TestRailwayNetwork.LINE_2STOPLINE in entries_by_line
+        assert TestRailwayNetwork.LINE_SHAREDLINE_A in entries_by_line
+
+        # 2stopline entries: twostop-west, twostop-east
+        assert set(entries_by_line[TestRailwayNetwork.LINE_2STOPLINE]) == {
+            TestRailwayNetwork.STATION_TWOSTOP_WEST,
+            TestRailwayNetwork.STATION_TWOSTOP_EAST,
+        }
+
+    @pytest.mark.asyncio
+    async def test_build_index_route_not_found(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test building index for non-existent route raises ValueError."""
+        service = RouteIndexService(db_session)
+        fake_route_id = uuid.uuid4()
+
+        with pytest.raises(ValueError, match=r"Route .* not found"):
+            await service.build_route_station_index(fake_route_id)
+
+    @pytest.mark.asyncio
+    async def test_build_index_route_with_insufficient_segments(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> None:
+        """Test building index for route with < 2 segments returns zero entries."""
+        # Create route with only 1 segment
+        route = Route(
+            user_id=test_user.id,
+            name="Single Segment Route",
+            active=True,
+        )
+        db_session.add(route)
+        await db_session.flush()
+
+        station = TestRailwayNetwork.create_twostop_west()
+        line = TestRailwayNetwork.create_2stopline()
+        db_session.add_all([station, line])
+        await db_session.flush()
+
+        segment = RouteSegment(
+            route_id=route.id,
+            sequence=1,
+            station_id=station.id,
+            line_id=line.id,
+        )
+        db_session.add(segment)
+        await db_session.commit()
+
+        # Build index
+        service = RouteIndexService(db_session)
+        result = await service.build_route_station_index(route.id)
+
+        # Should return zero entries
+        assert result["entries_created"] == 0
+        assert result["segments_processed"] == 0
+
+        # Verify no index entries created
+        index_result = await db_session.execute(select(RouteStationIndex).where(RouteStationIndex.route_id == route.id))
+        assert len(index_result.scalars().all()) == 0
+
+    @pytest.mark.asyncio
+    async def test_build_index_replaces_existing_entries(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> None:
+        """Test that building index deletes old entries before creating new ones."""
+        # Create test network
+        line = TestRailwayNetwork.create_2stopline()
+        station1 = TestRailwayNetwork.create_twostop_west()
+        station2 = TestRailwayNetwork.create_twostop_east()
+
+        db_session.add_all([line, station1, station2])
+        await db_session.flush()
+
+        # Create route
+        route = Route(
+            user_id=test_user.id,
+            name="Test Route",
+            active=True,
+        )
+        db_session.add(route)
+        await db_session.flush()
+
+        segment1 = RouteSegment(
+            route_id=route.id,
+            sequence=1,
+            station_id=station1.id,
+            line_id=line.id,
+        )
+        segment2 = RouteSegment(
+            route_id=route.id,
+            sequence=2,
+            station_id=station2.id,
+            line_id=None,
+        )
+        db_session.add_all([segment1, segment2])
+        await db_session.commit()
+
+        # Build index first time
+        service = RouteIndexService(db_session)
+        result1 = await service.build_route_station_index(route.id)
+        assert result1["entries_created"] == 2
+
+        # Build index again (simulating update)
+        result2 = await service.build_route_station_index(route.id)
+        assert result2["entries_created"] == 2
+
+        # Verify still only 2 entries (old ones were deleted)
+        index_result = await db_session.execute(select(RouteStationIndex).where(RouteStationIndex.route_id == route.id))
+        index_entries = index_result.scalars().all()
+        assert len(index_entries) == 2
+
+    @pytest.mark.asyncio
+    async def test_build_index_line_with_no_routes_data(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> None:
+        """Test building index for line with no routes data continues processing."""
+        # Create line with no routes data
+        line = Line(
+            tfl_id="testline",
+            name="Test Line",
+            mode="tube",
+            routes=None,  # No routes data
+            last_updated=datetime.now(UTC),
+        )
+        station1 = TestRailwayNetwork.create_twostop_west()
+        station2 = TestRailwayNetwork.create_twostop_east()
+
+        db_session.add_all([line, station1, station2])
+        await db_session.flush()
+
+        # Create route
+        route = Route(
+            user_id=test_user.id,
+            name="Test Route",
+            active=True,
+        )
+        db_session.add(route)
+        await db_session.flush()
+
+        segment1 = RouteSegment(
+            route_id=route.id,
+            sequence=1,
+            station_id=station1.id,
+            line_id=line.id,
+        )
+        segment2 = RouteSegment(
+            route_id=route.id,
+            sequence=2,
+            station_id=station2.id,
+            line_id=None,
+        )
+        db_session.add_all([segment1, segment2])
+        await db_session.commit()
+
+        # Build index - should log warning but not fail
+        service = RouteIndexService(db_session)
+        result = await service.build_route_station_index(route.id)
+
+        # Should return zero entries (failed to expand)
+        assert result["entries_created"] == 0
+
+    @pytest.mark.asyncio
+    async def test_build_index_stations_not_found_in_variant(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> None:
+        """Test building index when stations not found in any route variant."""
+        # Create line with routes that don't contain our test stations
+        line = TestRailwayNetwork.create_forkedline()  # Has specific stations
+        # But use stations from a different line
+        station1 = TestRailwayNetwork.create_twostop_west()  # Not on forkedline
+        station2 = TestRailwayNetwork.create_twostop_east()  # Not on forkedline
+
+        db_session.add_all([line, station1, station2])
+        await db_session.flush()
+
+        # Create route
+        route = Route(
+            user_id=test_user.id,
+            name="Test Route",
+            active=True,
+        )
+        db_session.add(route)
+        await db_session.flush()
+
+        segment1 = RouteSegment(
+            route_id=route.id,
+            sequence=1,
+            station_id=station1.id,
+            line_id=line.id,
+        )
+        segment2 = RouteSegment(
+            route_id=route.id,
+            sequence=2,
+            station_id=station2.id,
+            line_id=None,
+        )
+        db_session.add_all([segment1, segment2])
+        await db_session.commit()
+
+        # Build index - should log warning but not fail
+        service = RouteIndexService(db_session)
+        result = await service.build_route_station_index(route.id)
+
+        # Should return zero entries (failed to expand)
+        assert result["entries_created"] == 0
+
+    @pytest.mark.asyncio
+    async def test_build_index_transaction_rollback_on_error(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> None:
+        """Test that database transaction is rolled back on error."""
+        # Try to build index for non-existent route
+        service = RouteIndexService(db_session)
+        fake_route_id = uuid.uuid4()
+
+        with pytest.raises(ValueError, match=r"Route .* not found"):
+            await service.build_route_station_index(fake_route_id)
+
+        # Session should still be usable after rollback
+        result = await db_session.execute(select(Route))
+        routes = result.scalars().all()
+        assert isinstance(routes, list)  # Session still works
+
+    @pytest.mark.asyncio
+    async def test_build_index_stores_line_data_version(
+        self,
+        db_session: AsyncSession,
+        test_user: User,
+    ) -> None:
+        """Test that index entries store line.last_updated as line_data_version."""
+        # Create test network
+        line = TestRailwayNetwork.create_2stopline()
+        station1 = TestRailwayNetwork.create_twostop_west()
+        station2 = TestRailwayNetwork.create_twostop_east()
+
+        db_session.add_all([line, station1, station2])
+        await db_session.flush()
+
+        # Create route
+        route = Route(
+            user_id=test_user.id,
+            name="Test Route",
+            active=True,
+        )
+        db_session.add(route)
+        await db_session.flush()
+
+        segment1 = RouteSegment(
+            route_id=route.id,
+            sequence=1,
+            station_id=station1.id,
+            line_id=line.id,
+        )
+        segment2 = RouteSegment(
+            route_id=route.id,
+            sequence=2,
+            station_id=station2.id,
+            line_id=None,
+        )
+        db_session.add_all([segment1, segment2])
+        await db_session.commit()
+
+        # Build index
+        service = RouteIndexService(db_session)
+        await service.build_route_station_index(route.id)
+
+        # Verify line_data_version matches line.last_updated
+        index_result = await db_session.execute(select(RouteStationIndex).where(RouteStationIndex.route_id == route.id))
+        index_entries = index_result.scalars().all()
+
+        assert len(index_entries) > 0
+        for entry in index_entries:
+            assert entry.line_data_version == line.last_updated

--- a/backend/tests/test_route_index_service.py
+++ b/backend/tests/test_route_index_service.py
@@ -339,7 +339,9 @@ class TestRouteIndexService:
         result = await service.build_route_station_index(route.id)
 
         # Verify result statistics
-        assert result["segments_processed"] == 3  # 4 segments = 3 pairs
+        # 4 segments = 3 potential pairs, but only 2 are actually processed
+        # (pair starting from segment 2 is skipped because segment 2 has line_id=None)
+        assert result["segments_processed"] == 2
 
         # Verify index entries
         index_result = await db_session.execute(select(RouteStationIndex).where(RouteStationIndex.route_id == route.id))


### PR DESCRIPTION
- Added a new endpoint to the admin API for rebuilding route station indexes, allowing for single or all routes to be rebuilt.
- Introduced RouteIndexService to handle the logic for building and maintaining route station indexes.
- Updated Celery tasks to include a task for rebuilding route indexes, which can be triggered manually or scheduled.
- Created new schemas for the response of the rebuild operation.
- Enhanced the RouteService to automatically rebuild indexes after route modifications.
- Added comprehensive tests for the RouteIndexService, covering various scenarios including multi-variant lines and error handling.

Closes #128

## Summary by Sourcery

Implement end-to-end route station index management by introducing a dedicated service, API endpoint, and Celery task for rebuilding inverted (line, station)→route indexes, integrating automatic index updates on route changes, and adding full test coverage.

New Features:
- Add admin API endpoint POST /admin/routes/rebuild-indexes to rebuild station indexes for single or all routes
- Introduce RouteIndexService to build and maintain route station inverted indexes
- Implement Celery task rebuild_route_indexes_task for scheduled or manual index rebuilding

Enhancements:
- Enhance RouteService to automatically rebuild indexes after segment upserts, updates, and deletions
- Add type-safe task result protocols and TypedDicts for structured logging and retry behavior
- Improve session management and logging in async task implementations

Tests:
- Comprehensive tests for RouteIndexService pure functions, index building across varied line topologies, rebuild_routes logic, and auto-commit/error scenarios
- Add tests for Celery rebuild task behavior, including success, partial failure, retries, and session cleanup
- Add unit and integration tests for the admin rebuild-indexes endpoint, covering permission, error handling, and full database workflows