### PR TITLE
Feature/issue 130 staleness detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,9 @@ __pypackages__/
 
 # Celery stuff
 celerybeat-schedule
+celerybeat-schedule.db
+celerybeat-schedule-shm
+celerybeat-schedule-wal
 celerybeat.pid
 
 # Redis

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -63,6 +63,43 @@
       ],
       "cwd": "${workspaceFolder}/frontend",
       "console": "integratedTerminal"
+    },
+    {
+      "name": "Backend: Celery Worker",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "celery",
+      "args": [
+        "-A",
+        "app.celery.app",
+        "worker",
+        "--loglevel=info",
+        "--pool=solo"
+      ],
+      "cwd": "${workspaceFolder}/backend",
+      "console": "integratedTerminal",
+      "justMyCode": false,
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/backend"
+      }
+    },
+    {
+      "name": "Backend: Celery Beat",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "celery",
+      "args": [
+        "-A",
+        "app.celery.app",
+        "beat",
+        "--loglevel=info"
+      ],
+      "cwd": "${workspaceFolder}/backend",
+      "console": "integratedTerminal",
+      "justMyCode": false,
+      "env": {
+        "PYTHONPATH": "${workspaceFolder}/backend"
+      }
     }
   ],
   "compounds": [
@@ -77,6 +114,21 @@
         "hidden": false,
         "group": "development",
         "order": 1
+      }
+    },
+    {
+      "name": "Full Stack + Background Tasks",
+      "configurations": [
+        "Backend: FastAPI",
+        "Backend: Celery Worker",
+        "Backend: Celery Beat",
+        "Frontend: Vite Dev Server"
+      ],
+      "stopAll": true,
+      "presentation": {
+        "hidden": false,
+        "group": "development",
+        "order": 2
       }
     }
   ]

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -88,9 +88,8 @@ async def create_route(
     service = RouteService(db)
     route = await service.create_route(current_user.id, request)
 
-    # Refresh to load empty relationships
-    await db.refresh(route, ["segments", "schedules"])
-    return route
+    # Reload with full relationships for response serialization
+    return await service.get_route_by_id(route.id, current_user.id, load_relationships=True)
 
 
 @router.get("/{route_id}", response_model=RouteResponse)
@@ -142,11 +141,10 @@ async def update_route(
         HTTPException: 404 if route not found or doesn't belong to user
     """
     service = RouteService(db)
-    route = await service.update_route(route_id, current_user.id, request)
+    await service.update_route(route_id, current_user.id, request)
 
-    # Refresh to load relationships
-    await db.refresh(route, ["segments", "schedules"])
-    return route
+    # Reload with full relationships for response serialization
+    return await service.get_route_by_id(route_id, current_user.id, load_relationships=True)
 
 
 @router.delete("/{route_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/celery/schedules.py
+++ b/backend/app/celery/schedules.py
@@ -3,10 +3,13 @@
 This module configures the schedule for periodic tasks that run automatically
 via Celery Beat. The check_disruptions_and_alert task runs every 30 seconds
 to monitor TfL status and send alerts to users with matching notification preferences.
+
+The detect_and_rebuild_stale_routes task runs daily at 3 AM to ensure route
+station indexes stay accurate as TfL line data changes over time.
 """
 
 from app.celery.app import celery_app
-from celery.schedules import schedule
+from celery.schedules import crontab, schedule
 
 # Configure Celery Beat schedule
 celery_app.conf.beat_schedule = {
@@ -15,6 +18,13 @@ celery_app.conf.beat_schedule = {
         "schedule": schedule(run_every=30.0),  # Run every 30 seconds
         "options": {
             "expires": 60,  # Task expires if not picked up within 60 seconds
+        },
+    },
+    "detect-stale-routes": {
+        "task": "app.celery.tasks.detect_and_rebuild_stale_routes",
+        "schedule": crontab(hour=3, minute=0),  # Run daily at 3 AM
+        "options": {
+            "expires": 3600,  # Task expires if not picked up within 1 hour
         },
     },
 }

--- a/backend/app/celery/schedules.py
+++ b/backend/app/celery/schedules.py
@@ -4,12 +4,12 @@ This module configures the schedule for periodic tasks that run automatically
 via Celery Beat. The check_disruptions_and_alert task runs every 30 seconds
 to monitor TfL status and send alerts to users with matching notification preferences.
 
-The detect_and_rebuild_stale_routes task runs daily at 3 AM to ensure route
-station indexes stay accurate as TfL line data changes over time.
+Note: Route index staleness detection is event-driven (triggered after TfL data updates)
+rather than scheduled. See POST /admin/tfl/build-graph endpoint.
 """
 
 from app.celery.app import celery_app
-from celery.schedules import crontab, schedule
+from celery.schedules import schedule
 
 # Configure Celery Beat schedule
 celery_app.conf.beat_schedule = {
@@ -18,13 +18,6 @@ celery_app.conf.beat_schedule = {
         "schedule": schedule(run_every=30.0),  # Run every 30 seconds
         "options": {
             "expires": 60,  # Task expires if not picked up within 60 seconds
-        },
-    },
-    "detect-stale-routes": {
-        "task": "app.celery.tasks.detect_and_rebuild_stale_routes",
-        "schedule": crontab(hour=3, minute=0),  # Run daily at 3 AM
-        "options": {
-            "expires": 3600,  # Task expires if not picked up within 1 hour
         },
     },
 }

--- a/backend/app/celery/tasks.py
+++ b/backend/app/celery/tasks.py
@@ -9,9 +9,14 @@ from typing import Protocol, TypedDict
 from uuid import UUID
 
 import structlog
+from sqlalchemy import distinct, select
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.celery.app import celery_app
 from app.celery.database import worker_session_factory
+from app.models.route import RouteSegment
+from app.models.route_index import RouteStationIndex
+from app.models.tfl import Line
 from app.services.alert_service import AlertService, get_redis_client
 from app.services.route_index_service import RouteIndexService
 
@@ -62,6 +67,16 @@ class RebuildIndexesResult(TypedDict):
     status: str
     rebuilt_count: int
     failed_count: int
+    errors: list[str]
+
+
+class DetectStaleRoutesResult(TypedDict):
+    """Result from detect_and_rebuild_stale_routes task."""
+
+    status: str
+    checked_count: int
+    stale_count: int
+    triggered_count: int
     errors: list[str]
 
 
@@ -228,6 +243,161 @@ async def _rebuild_indexes_async(route_id_str: str | None = None) -> RebuildInde
             rebuilt_count=result["rebuilt_count"],
             failed_count=result["failed_count"],
             errors=result["errors"],
+        )
+
+    finally:
+        # Ensure resources are properly closed
+        if session is not None:
+            await session.close()
+
+
+# Pure helper functions for staleness detection
+
+
+async def find_stale_route_ids(session: AsyncSession) -> list[UUID]:
+    """
+    Find routes with stale index entries (where line data has been updated).
+
+    This is a pure query function that identifies routes whose station indexes
+    are out of date compared to the TfL line data they reference.
+
+    Args:
+        session: Database session
+
+    Returns:
+        List of route UUIDs with stale indexes (distinct, no duplicates)
+
+    Algorithm:
+        1. Join RouteStationIndex → RouteSegment → Line
+        2. Filter: WHERE line_data_version < Line.last_updated
+        3. Return distinct route_ids (a route may have multiple stale entries)
+    """
+    # Query for routes where index is stale
+    # Use DISTINCT because a route can have multiple index entries on the same line
+    # Example: Route with 5 stations on Piccadilly → 5 index entries → could match 5 times
+    stmt = (
+        select(distinct(RouteStationIndex.route_id))
+        .join(RouteSegment, RouteSegment.route_id == RouteStationIndex.route_id)
+        .join(Line, Line.id == RouteSegment.line_id)
+        .where(RouteStationIndex.line_data_version < Line.last_updated)
+    )
+
+    result = await session.execute(stmt)
+    return [row[0] for row in result.all()]
+
+
+@celery_app.task(  # type: ignore[arg-type]
+    bind=True,
+    max_retries=3,
+    name="app.celery.tasks.detect_and_rebuild_stale_routes",
+)
+def detect_and_rebuild_stale_routes(self: BoundTask) -> DetectStaleRoutesResult:
+    """
+    Detect routes with stale indexes and trigger rebuild tasks.
+
+    This task runs periodically (daily at 3 AM) to ensure route station indexes
+    stay accurate as TfL line data changes over time. When Line.routes JSON is
+    updated, the indexes built from that data become stale.
+
+    Algorithm:
+        1. Query routes where line_data_version < Line.last_updated
+        2. For each stale route, trigger rebuild_route_indexes_task.delay()
+        3. Return statistics for monitoring
+
+    Execution Strategy:
+        - Triggers individual rebuild tasks for better parallelization
+        - Each rebuild is isolated (one failure doesn't affect others)
+        - Leverages existing tested rebuild infrastructure
+
+    Args:
+        self: Celery task instance (bound via bind=True)
+
+    Returns:
+        DetectStaleRoutesResult: Execution statistics including stale_count,
+                                  triggered_count, and any errors
+
+    Raises:
+        Retry: If the task should be retried due to transient failure
+    """
+    try:
+        # asyncio.run() creates a new event loop for this worker thread.
+        # This is the standard pattern for Celery tasks calling async code.
+        # Not blocking since each task runs in its own worker thread.
+        result = asyncio.run(_detect_stale_routes_async())
+        logger.info(
+            "detect_stale_routes_task_completed",
+            result=result,
+        )
+        return result
+
+    except Exception as exc:
+        logger.error(
+            "detect_stale_routes_task_failed",
+            error=str(exc),
+            error_type=type(exc).__name__,
+            retry_count=self.request.retries,
+        )
+        # Retry with exponential backoff (60s countdown)
+        raise self.retry(exc=exc, countdown=60) from exc
+
+
+async def _detect_stale_routes_async() -> DetectStaleRoutesResult:
+    """
+    Async implementation of staleness detection logic.
+
+    This function:
+        1. Queries for stale route_ids using the pure helper function
+        2. Triggers individual rebuild tasks for each stale route
+        3. Collects statistics for monitoring
+
+    Returns:
+        DetectStaleRoutesResult: Execution statistics including:
+            - checked_count: Total routes examined
+            - stale_count: Number of stale routes found
+            - triggered_count: Number of rebuild tasks successfully triggered
+            - errors: List of any errors encountered
+    """
+    session = None
+    errors: list[str] = []
+    triggered_count = 0
+
+    try:
+        # Create database session for this task
+        session = worker_session_factory()
+
+        # Use pure helper function to find stale routes
+        logger.info("detect_stale_routes_started")
+        stale_route_ids = await find_stale_route_ids(session)
+        logger.info("stale_routes_found", count=len(stale_route_ids))
+
+        # Trigger individual rebuild task for each stale route
+        # This provides better parallelization and fault isolation
+        for route_id in stale_route_ids:
+            try:
+                rebuild_route_indexes_task.delay(str(route_id))
+                triggered_count += 1
+                logger.debug(
+                    "rebuild_task_triggered",
+                    route_id=str(route_id),
+                )
+            except Exception as exc:
+                error_msg = f"Failed to trigger rebuild for route {route_id}: {exc}"
+                logger.warning(
+                    "rebuild_trigger_failed",
+                    route_id=str(route_id),
+                    error=str(exc),
+                )
+                errors.append(error_msg)
+
+        # Determine overall status
+        status = "success" if triggered_count == len(stale_route_ids) else "partial_failure"
+
+        return DetectStaleRoutesResult(
+            status=status,
+            checked_count=len(stale_route_ids),
+            stale_count=len(stale_route_ids),
+            triggered_count=triggered_count,
+            errors=errors,
         )
 
     finally:

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -1,0 +1,56 @@
+"""Logging configuration for the application.
+
+Configures structlog to integrate with Python's logging module so that:
+- Logs have correct log levels (not all WARNING)
+- Celery workers properly capture and display task logs
+- Structured logging works consistently across API and worker processes
+"""
+
+import logging
+import sys
+
+import structlog
+
+
+def configure_logging(*, log_level: str = "INFO") -> None:
+    """
+    Configure structlog to integrate with Python's logging module.
+
+    This ensures:
+    - Structlog logs use proper log levels (info, warning, error, etc.)
+    - Celery workers correctly capture task logs at the right level
+    - Logs are output to stdout with consistent formatting
+
+    Args:
+        log_level: Log level string (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+    """
+    # Configure Python's logging module
+    logging.basicConfig(
+        format="%(message)s",
+        stream=sys.stdout,
+        level=getattr(logging, log_level.upper()),
+    )
+
+    # Configure structlog to use Python's logging
+    structlog.configure(
+        processors=[
+            # Add log level to event dict
+            structlog.stdlib.add_log_level,
+            # Add logger name
+            structlog.stdlib.add_logger_name,
+            # Add timestamp
+            structlog.processors.TimeStamper(fmt="iso"),
+            # Stack info for exceptions
+            structlog.processors.StackInfoRenderer(),
+            # Format exceptions
+            structlog.processors.format_exc_info,
+            # Render as JSON or key-value depending on environment
+            structlog.processors.JSONRenderer() if log_level.upper() == "DEBUG" else structlog.dev.ConsoleRenderer(),
+        ],
+        # Use LoggerFactory for stdlib integration
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        # Use BoundLogger for stdlib integration
+        wrapper_class=structlog.stdlib.BoundLogger,
+        # Cache logger instances for performance
+        cache_logger_on_first_use=True,
+    )

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -789,7 +789,6 @@ async def test_detect_stale_routes_async_no_stale_routes(
 
     # Verify result
     assert result["status"] == "success"
-    assert result["checked_count"] == 0
     assert result["stale_count"] == 0
     assert result["triggered_count"] == 0
     assert result["errors"] == []
@@ -828,7 +827,6 @@ async def test_detect_stale_routes_async_single_stale_route(
 
     # Verify result
     assert result["status"] == "success"
-    assert result["checked_count"] == 1
     assert result["stale_count"] == 1
     assert result["triggered_count"] == 1
     assert result["errors"] == []
@@ -867,7 +865,6 @@ async def test_detect_stale_routes_async_multiple_stale_routes(
 
     # Verify result
     assert result["status"] == "success"
-    assert result["checked_count"] == 3
     assert result["stale_count"] == 3
     assert result["triggered_count"] == 3
     assert result["errors"] == []
@@ -917,7 +914,6 @@ async def test_detect_stale_routes_async_partial_trigger_failure(
 
     # Verify result shows partial failure
     assert result["status"] == "partial_failure"
-    assert result["checked_count"] == 3
     assert result["stale_count"] == 3
     assert result["triggered_count"] == 2  # Only 2 succeeded
     assert len(result["errors"]) == 1
@@ -956,9 +952,8 @@ async def test_detect_stale_routes_async_all_triggers_fail(
     # Execute async function
     result = await _detect_stale_routes_async()
 
-    # Verify result shows partial failure
-    assert result["status"] == "partial_failure"
-    assert result["checked_count"] == 2
+    # Verify result shows total failure (0 triggers succeeded)
+    assert result["status"] == "failure"
     assert result["stale_count"] == 2
     assert result["triggered_count"] == 0  # None succeeded
     assert len(result["errors"]) == 2
@@ -1018,7 +1013,6 @@ async def test_detect_stale_routes_async_returns_correct_structure(
 
     # Verify result structure
     assert "status" in result
-    assert "checked_count" in result
     assert "stale_count" in result
     assert "triggered_count" in result
     assert "errors" in result
@@ -1030,7 +1024,6 @@ def test_detect_stale_routes_task_success_path(mock_asyncio_run: MagicMock) -> N
     """Test the synchronous task wrapper success path."""
     mock_result = {
         "status": "success",
-        "checked_count": 5,
         "stale_count": 5,
         "triggered_count": 5,
         "errors": [],
@@ -1062,7 +1055,6 @@ def test_detect_stale_routes_task_logs_on_success(mock_asyncio_run: MagicMock) -
     """Test that task logs completion."""
     mock_result = {
         "status": "success",
-        "checked_count": 3,
         "stale_count": 3,
         "triggered_count": 3,
         "errors": [],

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -1,13 +1,16 @@
 """Tests for Celery tasks."""
 
 from unittest.mock import AsyncMock, MagicMock, patch
-from uuid import UUID
+from uuid import UUID, uuid4
 
 import pytest
 from app.celery.tasks import (
     _check_disruptions_async,
+    _detect_stale_routes_async,
     _rebuild_indexes_async,
     check_disruptions_and_alert,
+    detect_and_rebuild_stale_routes,
+    find_stale_route_ids,
     rebuild_route_indexes_task,
 )
 
@@ -681,3 +684,412 @@ def test_rebuild_indexes_task_logs_on_error(mock_asyncio_run: MagicMock) -> None
         mock_logger.error.assert_called_once()
         call_args = mock_logger.error.call_args
         assert call_args[0][0] == "rebuild_indexes_task_failed"
+
+
+# ==================== detect_and_rebuild_stale_routes Tests ====================
+
+
+def test_detect_stale_routes_task_registered() -> None:
+    """Test that detect_and_rebuild_stale_routes task function exists."""
+    assert detect_and_rebuild_stale_routes is not None
+
+
+@pytest.mark.asyncio
+async def test_find_stale_route_ids_empty_result() -> None:
+    """Test find_stale_route_ids returns empty list when no stale routes."""
+    # Mock session and query result
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    # Execute pure helper function
+    stale_ids = await find_stale_route_ids(mock_session)
+
+    # Verify result
+    assert stale_ids == []
+    mock_session.execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_find_stale_route_ids_single_route() -> None:
+    """Test find_stale_route_ids with single stale route."""
+    # Mock session and query result
+    mock_session = AsyncMock()
+    test_route_id = uuid4()
+    mock_result = MagicMock()
+    mock_result.all.return_value = [(test_route_id,)]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    # Execute pure helper function
+    stale_ids = await find_stale_route_ids(mock_session)
+
+    # Verify result
+    assert len(stale_ids) == 1
+    assert stale_ids[0] == test_route_id
+    mock_session.execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_find_stale_route_ids_multiple_routes() -> None:
+    """Test find_stale_route_ids with multiple stale routes."""
+    # Mock session and query result
+    mock_session = AsyncMock()
+    test_route_ids = [uuid4(), uuid4(), uuid4()]
+    mock_result = MagicMock()
+    mock_result.all.return_value = [(rid,) for rid in test_route_ids]
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    # Execute pure helper function
+    stale_ids = await find_stale_route_ids(mock_session)
+
+    # Verify result
+    assert len(stale_ids) == 3
+    assert stale_ids == test_route_ids
+    mock_session.execute.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_find_stale_route_ids_query_uses_distinct() -> None:
+    """Test that find_stale_route_ids uses DISTINCT to avoid duplicates."""
+    # Mock session
+    mock_session = AsyncMock()
+    mock_result = MagicMock()
+    mock_result.all.return_value = []
+    mock_session.execute = AsyncMock(return_value=mock_result)
+
+    # Execute pure helper function
+    await find_stale_route_ids(mock_session)
+
+    # Verify session.execute was called (query uses DISTINCT)
+    mock_session.execute.assert_called_once()
+    # The actual DISTINCT usage is verified by the query construction in the function
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.rebuild_route_indexes_task")
+@patch("app.celery.tasks.find_stale_route_ids")
+@patch("app.celery.tasks.worker_session_factory")
+async def test_detect_stale_routes_async_no_stale_routes(
+    mock_session_factory: MagicMock,
+    mock_find_stale: MagicMock,
+    mock_rebuild_task: MagicMock,
+) -> None:
+    """Test async function when no stale routes found."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock find_stale_route_ids to return empty list
+    mock_find_stale.return_value = []
+
+    # Execute async function
+    result = await _detect_stale_routes_async()
+
+    # Verify result
+    assert result["status"] == "success"
+    assert result["checked_count"] == 0
+    assert result["stale_count"] == 0
+    assert result["triggered_count"] == 0
+    assert result["errors"] == []
+
+    # Verify no rebuild tasks were triggered
+    mock_rebuild_task.delay.assert_not_called()
+
+    # Verify session was closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.rebuild_route_indexes_task")
+@patch("app.celery.tasks.find_stale_route_ids")
+@patch("app.celery.tasks.worker_session_factory")
+async def test_detect_stale_routes_async_single_stale_route(
+    mock_session_factory: MagicMock,
+    mock_find_stale: MagicMock,
+    mock_rebuild_task: MagicMock,
+) -> None:
+    """Test async function with single stale route."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock find_stale_route_ids to return one route
+    test_route_id = uuid4()
+    mock_find_stale.return_value = [test_route_id]
+
+    # Mock rebuild task
+    mock_rebuild_task.delay = MagicMock()
+
+    # Execute async function
+    result = await _detect_stale_routes_async()
+
+    # Verify result
+    assert result["status"] == "success"
+    assert result["checked_count"] == 1
+    assert result["stale_count"] == 1
+    assert result["triggered_count"] == 1
+    assert result["errors"] == []
+
+    # Verify rebuild task was triggered with correct route_id
+    mock_rebuild_task.delay.assert_called_once_with(str(test_route_id))
+
+    # Verify session was closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.rebuild_route_indexes_task")
+@patch("app.celery.tasks.find_stale_route_ids")
+@patch("app.celery.tasks.worker_session_factory")
+async def test_detect_stale_routes_async_multiple_stale_routes(
+    mock_session_factory: MagicMock,
+    mock_find_stale: MagicMock,
+    mock_rebuild_task: MagicMock,
+) -> None:
+    """Test async function with multiple stale routes."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock find_stale_route_ids to return multiple routes
+    test_route_ids = [uuid4(), uuid4(), uuid4()]
+    mock_find_stale.return_value = test_route_ids
+
+    # Mock rebuild task
+    mock_rebuild_task.delay = MagicMock()
+
+    # Execute async function
+    result = await _detect_stale_routes_async()
+
+    # Verify result
+    assert result["status"] == "success"
+    assert result["checked_count"] == 3
+    assert result["stale_count"] == 3
+    assert result["triggered_count"] == 3
+    assert result["errors"] == []
+
+    # Verify rebuild task was triggered for each route
+    assert mock_rebuild_task.delay.call_count == 3
+    for route_id in test_route_ids:
+        mock_rebuild_task.delay.assert_any_call(str(route_id))
+
+    # Verify session was closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.rebuild_route_indexes_task")
+@patch("app.celery.tasks.find_stale_route_ids")
+@patch("app.celery.tasks.worker_session_factory")
+async def test_detect_stale_routes_async_partial_trigger_failure(
+    mock_session_factory: MagicMock,
+    mock_find_stale: MagicMock,
+    mock_rebuild_task: MagicMock,
+) -> None:
+    """Test async function when some rebuild task triggers fail."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock find_stale_route_ids to return multiple routes
+    test_route_ids = [uuid4(), uuid4(), uuid4()]
+    mock_find_stale.return_value = test_route_ids
+
+    # Mock rebuild task to fail on second route
+    call_count = 0
+
+    def side_effect_delay(route_id: str) -> None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            error_msg = "Celery queue full"
+            raise RuntimeError(error_msg)
+
+    mock_rebuild_task.delay = MagicMock(side_effect=side_effect_delay)
+
+    # Execute async function
+    result = await _detect_stale_routes_async()
+
+    # Verify result shows partial failure
+    assert result["status"] == "partial_failure"
+    assert result["checked_count"] == 3
+    assert result["stale_count"] == 3
+    assert result["triggered_count"] == 2  # Only 2 succeeded
+    assert len(result["errors"]) == 1
+    assert "Celery queue full" in result["errors"][0]
+
+    # Verify rebuild task was attempted for all routes
+    assert mock_rebuild_task.delay.call_count == 3
+
+    # Verify session was closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.rebuild_route_indexes_task")
+@patch("app.celery.tasks.find_stale_route_ids")
+@patch("app.celery.tasks.worker_session_factory")
+async def test_detect_stale_routes_async_all_triggers_fail(
+    mock_session_factory: MagicMock,
+    mock_find_stale: MagicMock,
+    mock_rebuild_task: MagicMock,
+) -> None:
+    """Test async function when all rebuild task triggers fail."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock find_stale_route_ids to return multiple routes
+    test_route_ids = [uuid4(), uuid4()]
+    mock_find_stale.return_value = test_route_ids
+
+    # Mock rebuild task to always fail
+    error_msg = "Celery unavailable"
+    mock_rebuild_task.delay = MagicMock(side_effect=RuntimeError(error_msg))
+
+    # Execute async function
+    result = await _detect_stale_routes_async()
+
+    # Verify result shows partial failure
+    assert result["status"] == "partial_failure"
+    assert result["checked_count"] == 2
+    assert result["stale_count"] == 2
+    assert result["triggered_count"] == 0  # None succeeded
+    assert len(result["errors"]) == 2
+
+    # Verify session was closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.find_stale_route_ids")
+@patch("app.celery.tasks.worker_session_factory")
+async def test_detect_stale_routes_async_closes_session_on_error(
+    mock_session_factory: MagicMock,
+    mock_find_stale: MagicMock,
+) -> None:
+    """Test that async function closes session even when error occurs."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock find_stale_route_ids to raise error
+    mock_find_stale.side_effect = RuntimeError("Database query failed")
+
+    # Execute async function and catch exception
+    with pytest.raises(RuntimeError, match="Database query failed"):
+        await _detect_stale_routes_async()
+
+    # Verify session was still closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.rebuild_route_indexes_task")
+@patch("app.celery.tasks.find_stale_route_ids")
+@patch("app.celery.tasks.worker_session_factory")
+async def test_detect_stale_routes_async_returns_correct_structure(
+    mock_session_factory: MagicMock,
+    mock_find_stale: MagicMock,
+    mock_rebuild_task: MagicMock,
+) -> None:
+    """Test that async function returns correct DetectStaleRoutesResult structure."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock find_stale_route_ids
+    test_route_ids = [uuid4(), uuid4()]
+    mock_find_stale.return_value = test_route_ids
+
+    # Mock rebuild task
+    mock_rebuild_task.delay = MagicMock()
+
+    # Execute async function
+    result = await _detect_stale_routes_async()
+
+    # Verify result structure
+    assert "status" in result
+    assert "checked_count" in result
+    assert "stale_count" in result
+    assert "triggered_count" in result
+    assert "errors" in result
+    assert isinstance(result["errors"], list)
+
+
+@patch("app.celery.tasks.asyncio.run")
+def test_detect_stale_routes_task_success_path(mock_asyncio_run: MagicMock) -> None:
+    """Test the synchronous task wrapper success path."""
+    mock_result = {
+        "status": "success",
+        "checked_count": 5,
+        "stale_count": 5,
+        "triggered_count": 5,
+        "errors": [],
+    }
+    mock_asyncio_run.return_value = mock_result
+
+    result = detect_and_rebuild_stale_routes()
+
+    assert result == mock_result
+    mock_asyncio_run.assert_called_once()
+
+
+@patch("app.celery.tasks.asyncio.run")
+def test_detect_stale_routes_task_retry_on_error(mock_asyncio_run: MagicMock) -> None:
+    """Test that task retries on exception."""
+    # Mock asyncio.run to raise an exception
+    mock_asyncio_run.side_effect = RuntimeError("Database connection lost")
+
+    # Create a mock Celery task instance with retry method
+    task_instance = detect_and_rebuild_stale_routes
+
+    # Execute the task and expect retry exception
+    with pytest.raises(Exception):  # noqa: B017, PT011  # Celery raises Retry exception
+        task_instance()
+
+
+@patch("app.celery.tasks.asyncio.run")
+def test_detect_stale_routes_task_logs_on_success(mock_asyncio_run: MagicMock) -> None:
+    """Test that task logs completion."""
+    mock_result = {
+        "status": "success",
+        "checked_count": 3,
+        "stale_count": 3,
+        "triggered_count": 3,
+        "errors": [],
+    }
+    mock_asyncio_run.return_value = mock_result
+
+    with patch("app.celery.tasks.logger") as mock_logger:
+        result = detect_and_rebuild_stale_routes()
+
+        assert result == mock_result
+        mock_logger.info.assert_called_once()
+        call_args = mock_logger.info.call_args
+        assert call_args[0][0] == "detect_stale_routes_task_completed"
+
+
+@patch("app.celery.tasks.asyncio.run")
+def test_detect_stale_routes_task_logs_on_error(mock_asyncio_run: MagicMock) -> None:
+    """Test that task logs errors before retry."""
+    mock_asyncio_run.side_effect = RuntimeError("Test error")
+
+    task_instance = detect_and_rebuild_stale_routes
+
+    with patch("app.celery.tasks.logger") as mock_logger:
+        with pytest.raises(Exception):  # noqa: B017, PT011  # Celery raises Retry exception
+            task_instance()
+
+        # Verify error was logged
+        mock_logger.error.assert_called_once()
+        call_args = mock_logger.error.call_args
+        assert call_args[0][0] == "detect_stale_routes_task_failed"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,52 +34,56 @@ services:
       retries: 5
     command: redis-server --appendonly yes
 
-  celery-worker:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
-    platform: linux/amd64  # For Colima with Rosetta support
-    container_name: isthetube-celery-worker
-    restart: unless-stopped
-    command: uv run celery -A app.celery.app worker --loglevel=info
-    env_file:
-      - ./backend/.env
-    environment:
-      - DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/isthetube
-      - REDIS_URL=redis://redis:6379/0
-      - CELERY_BROKER_URL=redis://redis:6379/1
-      - CELERY_RESULT_BACKEND=redis://redis:6379/2
-    depends_on:
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    volumes:
-      - ./backend:/app:ro
-    networks:
-      - default
+  # Celery services commented out for local development
+  # Run via VSCode launch configs instead to see logs in integrated terminal
+  # Uncomment for production/containerized development
 
-  celery-beat:
-    build:
-      context: ./backend
-      dockerfile: Dockerfile
-    platform: linux/amd64  # For Colima with Rosetta support
-    container_name: isthetube-celery-beat
-    restart: unless-stopped
-    command: uv run celery -A app.celery.app beat --loglevel=info
-    env_file:
-      - ./backend/.env
-    environment:
-      - DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/isthetube
-      - REDIS_URL=redis://redis:6379/0
-      - CELERY_BROKER_URL=redis://redis:6379/1
-      - CELERY_RESULT_BACKEND=redis://redis:6379/2
-    depends_on:
-      - redis
-    volumes:
-      - ./backend:/app:ro
-    networks:
-      - default
+  # celery-worker:
+  #   build:
+  #     context: ./backend
+  #     dockerfile: Dockerfile
+  #   platform: linux/amd64  # For Colima with Rosetta support
+  #   container_name: isthetube-celery-worker
+  #   restart: unless-stopped
+  #   command: uv run celery -A app.celery.app worker --loglevel=info
+  #   env_file:
+  #     - ./backend/.env
+  #   environment:
+  #     - DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/isthetube
+  #     - REDIS_URL=redis://redis:6379/0
+  #     - CELERY_BROKER_URL=redis://redis:6379/1
+  #     - CELERY_RESULT_BACKEND=redis://redis:6379/2
+  #   depends_on:
+  #     postgres:
+  #       condition: service_healthy
+  #     redis:
+  #       condition: service_healthy
+  #   volumes:
+  #     - ./backend:/app:ro
+  #   networks:
+  #     - default
+
+  # celery-beat:
+  #   build:
+  #     context: ./backend
+  #     dockerfile: Dockerfile
+  #   platform: linux/amd64  # For Colima with Rosetta support
+  #   container_name: isthetube-celery-beat
+  #   restart: unless-stopped
+  #   command: uv run celery -A app.celery.app beat --loglevel=info
+  #   env_file:
+  #     - ./backend/.env
+  #   environment:
+  #     - DATABASE_URL=postgresql+asyncpg://postgres:postgres@postgres:5432/isthetube
+  #     - REDIS_URL=redis://redis:6379/0
+  #     - CELERY_BROKER_URL=redis://redis:6379/1
+  #     - CELERY_RESULT_BACKEND=redis://redis:6379/2
+  #   depends_on:
+  #     - redis
+  #   volumes:
+  #     - ./backend:/app:ro
+  #   networks:
+  #     - default
 
 volumes:
   postgres_data:

--- a/docs/adr/08-background-jobs.md
+++ b/docs/adr/08-background-jobs.md
@@ -126,6 +126,42 @@ Hybrid approach: synchronous for route CRUD operations (part of same transaction
 
 ---
 
+## Automatic Staleness Detection for Route Indexes
+
+### Status
+Active
+
+### Context
+Route station indexes store a `line_data_version` timestamp (copy of `Line.last_updated`) to track when the index was built. TfL line data changes over time as route sequences are updated (stations added/removed/reordered). Stale indexes reference outdated TfL data, causing inaccurate alert matching. Need automatic detection and rebuild without manual intervention.
+
+### Decision
+Daily Celery Beat task (`detect_and_rebuild_stale_routes`) at 3 AM (low traffic) to find and rebuild stale route indexes. Task queries for routes where `index.line_data_version < Line.last_updated`, then triggers individual `rebuild_route_indexes_task.delay(route_id)` for each stale route.
+
+**Implementation:**
+- **Pure helper function:** `find_stale_route_ids(session)` performs staleness query with DISTINCT to avoid duplicates
+- **Query pattern:** `SELECT DISTINCT route_id FROM route_station_index JOIN route_segments JOIN lines WHERE line_data_version < Line.last_updated`
+- **Execution strategy:** Trigger individual rebuild tasks (parallelization + fault isolation)
+- **Scheduling:** Daily at 3 AM via Celery Beat (`crontab(hour=3, minute=0)`)
+- **Task expiry:** 1 hour (task expires if not picked up within 60 minutes)
+- **Structured logging:** Logs stale route count, triggered count, partial failures
+
+### Consequences
+**Easier:**
+- **Zero manual intervention:** Indexes stay accurate automatically as TfL data changes
+- **Efficient detection:** Single query finds all stale routes across all lines
+- **Leverages existing infrastructure:** Reuses tested `rebuild_route_indexes_task()`
+- **Parallelization:** Individual rebuild tasks can run concurrently across workers
+- **Fault isolation:** One route rebuild failure doesn't block others
+- **Monitoring-friendly:** Structured logging for Sentry/alerting integration
+- **Off-peak execution:** 3 AM runs avoid user-facing performance impact
+
+**More Difficult:**
+- **Requires Line.last_updated tracking:** Depends on TfL service updating this field when fetching line data
+- **Potential for mass rebuilds:** If many lines update simultaneously, many routes rebuild at once (mitigated by Celery's task queue buffering)
+- **Rebuild delay:** Up to 24 hours between TfL data update and index rebuild (acceptable trade-off for low traffic execution)
+
+---
+
 ## Inverted Index for Alert Matching
 
 ### Status


### PR DESCRIPTION
closes #130

## Summary by Sourcery

Introduce event-driven detection and rebuild of stale route indexes whenever TfL line data updates by adding a new Celery task, integrating it into the admin API, and covering the feature with tests and documentation.

New Features:
- Add detect_and_rebuild_stale_routes Celery task with async implementation to find stale route indexes and trigger rebuilds
- Implement find_stale_route_ids helper to query and return routes with outdated index versions
- Queue the staleness detection task automatically in the POST /admin/tfl/build-graph endpoint after rebuilding the station graph

Documentation:
- Document the event-driven staleness detection approach in ADR 08-background-jobs

Tests:
- Add unit tests for find_stale_route_ids and _detect_stale_routes_async covering success, partial failure, and error scenarios
- Add tests for the detect_and_rebuild_stale_routes task wrapper logging, retry behavior, and result structure
- Add integration test to verify staleness detection task is queued by the admin TfL graph build endpoint