### PR TITLE
feat: Implement Celery worker database connection handling to prevent event loop conflicts

### DIFF
--- a/backend/app/celery/database.py
+++ b/backend/app/celery/database.py
@@ -2,33 +2,107 @@
 
 Workers need their own database engine and session factory separate from the
 FastAPI application to avoid sharing connections across different processes.
+
+IMPORTANT: When using Celery's ForkPoolWorker (default), the database engine
+must be disposed after forking to avoid asyncpg errors. The worker_process_init
+signal handler below ensures each forked worker creates fresh connections
+instead of inheriting the parent's pooled connections.
+
+See Issue #147 and ADR 08 "Worker Pool Fork Safety" for details.
 """
 
+import asyncio
 from collections.abc import AsyncGenerator
 
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.pool import NullPool
+import structlog
+from celery.signals import worker_process_init
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.config import settings
 
-# Create separate async engine for workers (separate from FastAPI app engine)
-# Use NullPool in tests to avoid event loop issues with pytest-asyncio
-# Use default async pool (AsyncAdaptedQueuePool) in production for performance
-worker_engine = create_async_engine(
-    settings.DATABASE_URL,
-    echo=settings.DATABASE_ECHO,
-    future=True,
-    poolclass=NullPool if settings.DEBUG else None,
-)
+# Worker engine - created lazily per task to avoid event loop conflicts
+# When using fork pool, creating the engine at import time causes asyncio.Queue
+# objects inside the connection pool to be bound to the parent's event loop.
+# Additionally, since each task gets a fresh event loop via run_async_task(),
+# the engine must be recreated for each task to bind asyncio primitives to the
+# correct event loop.
+_worker_engine = None
+_worker_session_factory = None
 
-# Create async session factory for workers
-worker_session_factory = async_sessionmaker(
-    worker_engine,
-    class_=AsyncSession,
-    expire_on_commit=False,
-    autocommit=False,
-    autoflush=False,
-)
+
+def reset_worker_engine() -> None:
+    """
+    Reset worker engine globals to force fresh creation on next access.
+
+    This must be called at the start of each task to ensure the engine's
+    asyncio primitives are bound to the current task's event loop.
+    """
+    global _worker_engine, _worker_session_factory  # noqa: PLW0603
+    _worker_engine = None
+    _worker_session_factory = None
+
+
+def _get_worker_engine() -> AsyncEngine:
+    """Get or create the worker database engine.
+
+    Lazily creates the engine on first access. This ensures each forked
+    worker process creates its own engine with fresh asyncio primitives,
+    avoiding "Future attached to a different loop" errors.
+
+    Uses connection pooling (AsyncAdaptedQueuePool) in all environments for
+    consistency. The lazy initialization pattern ensures each worker process
+    gets its own pool with asyncio primitives bound to the correct event loop.
+    """
+    global _worker_engine  # noqa: PLW0603
+    if _worker_engine is None:
+        _worker_engine = create_async_engine(
+            settings.DATABASE_URL,
+            echo=settings.DATABASE_ECHO,
+            future=True,
+            pool_size=settings.DATABASE_POOL_SIZE,
+            max_overflow=settings.DATABASE_MAX_OVERFLOW,
+        )
+    return _worker_engine
+
+
+def worker_session_factory() -> AsyncSession:
+    """Get a worker session factory.
+
+    Creates the session factory on first access, using the lazily-created engine.
+    """
+    global _worker_session_factory  # noqa: PLW0603
+    if _worker_session_factory is None:
+        _worker_session_factory = async_sessionmaker(
+            _get_worker_engine(),
+            class_=AsyncSession,
+            expire_on_commit=False,
+            autocommit=False,
+            autoflush=False,
+        )
+    return _worker_session_factory()
+
+
+@worker_process_init.connect
+def init_worker_db(**kwargs: object) -> None:
+    """
+    Reset asyncio state after worker process fork.
+
+    Celery's ForkPoolWorker (default) creates child processes by forking the
+    parent process. This function ensures each forked worker starts with a
+    clean asyncio state by resetting the event loop policy.
+
+    Note: With lazy engine initialization, we don't need to dispose anything
+    at fork time - each worker will create its own fresh engine on first use.
+
+    Args:
+        **kwargs: Signal arguments (unused, required by Celery signal signature)
+    """
+    logger = structlog.get_logger(__name__)
+    logger.info("worker_process_forked_resetting_event_loop")
+
+    # Reset asyncio event loop policy to clear any inherited event loop state
+    # This ensures fresh event loops in each worker process
+    asyncio.set_event_loop_policy(None)
 
 
 async def get_worker_session() -> AsyncGenerator[AsyncSession]:

--- a/backend/app/celery/tasks.py
+++ b/backend/app/celery/tasks.py
@@ -5,7 +5,8 @@ periodic task that checks for TfL disruptions and sends alerts to users.
 """
 
 import asyncio
-from typing import Protocol, TypedDict
+from collections.abc import Awaitable, Callable
+from typing import Any, Protocol, TypedDict
 from uuid import UUID
 
 import structlog
@@ -13,13 +14,64 @@ from sqlalchemy import distinct, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.celery.app import celery_app
-from app.celery.database import worker_session_factory
+from app.celery.database import reset_worker_engine, worker_session_factory
 from app.models.route_index import RouteStationIndex
 from app.models.tfl import Line
 from app.services.alert_service import AlertService, get_redis_client
 from app.services.route_index_service import RouteIndexService
 
 logger = structlog.get_logger(__name__)
+
+
+def run_async_task[T](
+    coro_func: Callable[..., Awaitable[T]],
+    *args: Any,  # noqa: ANN401 - Pass-through args to async function
+    **kwargs: Any,  # noqa: ANN401 - Pass-through kwargs to async function
+) -> T:
+    """
+    Run an async function in a fresh, isolated event loop.
+
+    This function creates a new event loop, calls the async function within it,
+    and ensures proper cleanup. This is necessary for Celery workers using fork
+    pool to avoid event loop state contamination between task executions.
+
+    The pattern explicitly:
+    1. Creates a new event loop
+    2. Sets it as the current event loop
+    3. Calls the async function to create the coroutine
+    4. Runs the coroutine
+    5. Closes the loop
+    6. Sets event loop to None (cleanup)
+
+    This ensures each task execution has a completely isolated event loop,
+    preventing "Future attached to a different loop" errors.
+
+    Args:
+        coro_func: An async function (not coroutine) to execute
+        *args: Positional arguments to pass to the async function
+        **kwargs: Keyword arguments to pass to the async function
+
+    Returns:
+        The return value of the async function
+    """
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        # Create the coroutine INSIDE the fresh event loop
+        coro = coro_func(*args, **kwargs)
+        return loop.run_until_complete(coro)
+    finally:
+        try:
+            # Cancel any pending tasks
+            pending = asyncio.all_tasks(loop)
+            for task in pending:
+                task.cancel()
+            # Run loop once more to let tasks clean up
+            if pending:
+                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
 
 
 # Protocol for Celery task request
@@ -106,10 +158,10 @@ def check_disruptions_and_alert(self: BoundTask) -> DisruptionCheckResult:
         Retry: If the task should be retried due to transient failure
     """
     try:
-        # asyncio.run() creates a new event loop for this worker thread.
-        # This is the standard pattern for Celery tasks calling async code.
-        # Not blocking since each task runs in its own worker thread.
-        result = asyncio.run(_check_disruptions_async())
+        # run_async_task() creates a fresh event loop for this task.
+        # This is necessary for Celery workers using fork pool to avoid
+        # event loop state contamination between task executions.
+        result = run_async_task(_check_disruptions_async)
         logger.info(
             "check_disruptions_task_completed",
             result=result,
@@ -138,6 +190,9 @@ async def _check_disruptions_async() -> DisruptionCheckResult:
     Returns:
         DisruptionCheckResult: Execution statistics including routes_checked, alerts_sent, and errors
     """
+    # Reset engine to bind asyncio primitives to this task's event loop
+    reset_worker_engine()
+
     session = None
     redis_client = None
     try:
@@ -191,10 +246,10 @@ def rebuild_route_indexes_task(
         Retry: If the task should be retried due to transient failure
     """
     try:
-        # asyncio.run() creates a new event loop for this worker thread.
-        # This is the standard pattern for Celery tasks calling async code.
-        # Not blocking since each task runs in its own worker thread.
-        result = asyncio.run(_rebuild_indexes_async(route_id))
+        # run_async_task() creates a fresh event loop and calls the async function.
+        # This is necessary for Celery workers using fork pool to avoid
+        # event loop state contamination between task executions.
+        result = run_async_task(_rebuild_indexes_async, route_id)
         logger.info(
             "rebuild_indexes_task_completed",
             route_id=route_id,
@@ -224,6 +279,9 @@ async def _rebuild_indexes_async(route_id_str: str | None = None) -> RebuildInde
     Returns:
         RebuildIndexesResult: Execution statistics including rebuilt_count, failed_count, and errors
     """
+    # Reset engine to bind asyncio primitives to this task's event loop
+    reset_worker_engine()
+
     session = None
     try:
         # Create database session for this task
@@ -319,10 +377,10 @@ def detect_and_rebuild_stale_routes(self: BoundTask) -> DetectStaleRoutesResult:
         Retry: If the task should be retried due to transient failure
     """
     try:
-        # asyncio.run() creates a new event loop for this worker thread.
-        # This is the standard pattern for Celery tasks calling async code.
-        # Not blocking since each task runs in its own worker thread.
-        result = asyncio.run(_detect_stale_routes_async())
+        # run_async_task() creates a fresh event loop for this task.
+        # This is necessary for Celery workers using fork pool to avoid
+        # event loop state contamination between task executions.
+        result = run_async_task(_detect_stale_routes_async)
         logger.info(
             "detect_stale_routes_task_completed",
             result=result,
@@ -355,6 +413,9 @@ async def _detect_stale_routes_async() -> DetectStaleRoutesResult:
             - triggered_count: Number of rebuild tasks successfully triggered
             - errors: List of any errors encountered
     """
+    # Reset engine to bind asyncio primitives to this task's event loop
+    reset_worker_engine()
+
     session = None
     errors: list[str] = []
     triggered_count = 0

--- a/backend/tests/test_celery_database.py
+++ b/backend/tests/test_celery_database.py
@@ -1,19 +1,32 @@
 """Tests for Celery database utilities."""
 
 import pytest
-from app.celery.database import get_worker_session
+from app.celery.database import get_worker_session, get_worker_session_context
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
 @pytest.mark.asyncio
-async def test_get_worker_session_yields_session() -> None:
-    """Test get_worker_session async generator properly closes session."""
+async def test_get_worker_session_context_yields_session() -> None:
+    """Test get_worker_session_context async generator properly closes session."""
 
     session_obj = None
-    async for session in get_worker_session():
+    async for session in get_worker_session_context():
         session_obj = session
         assert session_obj is not None
-        # Test that session gets closed in finally block (lines 61-65)
+        # Test that session gets closed in finally block
         break
 
     # Session should be closed after exiting async generator
     assert session_obj is not None
+
+
+@pytest.mark.asyncio
+async def test_get_worker_session_returns_session() -> None:
+    """Test get_worker_session returns an AsyncSession instance."""
+    session = get_worker_session()
+    try:
+        assert session is not None
+        # Verify we can use the session
+        assert isinstance(session, AsyncSession)
+    finally:
+        await session.close()

--- a/backend/tests/test_celery_database_integration.py
+++ b/backend/tests/test_celery_database_integration.py
@@ -1,0 +1,100 @@
+"""Integration tests for Celery database connection handling.
+
+Tests the worker_process_init signal handler and lazy engine initialization
+that prevent asyncpg event loop conflicts in forked worker processes.
+
+See Issue #147 and ADR 08 "Worker Pool Fork Safety" for context.
+"""
+
+import pytest
+from app.celery.database import _get_worker_engine, init_worker_db, worker_session_factory
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+def test_init_worker_db_exists_and_callable() -> None:
+    """
+    Test that init_worker_db function exists and can be called.
+
+    This verifies the signal handler is properly defined.
+    """
+    assert callable(init_worker_db)
+    # Should run without error in test environment (DEBUG=true)
+    init_worker_db()
+
+
+def test_init_worker_db_accepts_kwargs() -> None:
+    """
+    Test that init_worker_db accepts **kwargs.
+
+    Celery signals pass arbitrary keyword arguments, so the handler
+    must accept **kwargs even if it doesn't use them.
+    """
+    # Call with various kwargs (simulating Celery signal behavior)
+    try:
+        init_worker_db(sender="test", signal="test_signal", extra="data")
+        # If we got here, kwargs are accepted
+        assert True
+    except TypeError:
+        pytest.fail("init_worker_db should accept **kwargs")
+
+
+def test_init_worker_db_resets_event_loop_policy() -> None:
+    """
+    Test that init_worker_db resets the asyncio event loop policy.
+
+    With lazy initialization, the signal handler only needs to reset
+    the event loop policy - each worker will create its own engine on first use.
+    """
+    # The function should run without error in any environment
+    init_worker_db()
+    # Function completed successfully
+    assert True
+
+
+@pytest.mark.asyncio
+async def test_worker_session_factory_creates_session() -> None:
+    """
+    Test that session factory creates working session.
+
+    This verifies that after engine disposal (or with NullPool), the
+    session factory can still create functional sessions.
+    """
+    # Create a session using the factory
+    session = worker_session_factory()
+    try:
+        # Basic test - verify we can create and close session
+        assert session is not None
+        # Verify session is an AsyncSession
+        assert isinstance(session, AsyncSession)
+    finally:
+        # Clean up
+        await session.close()
+
+
+@pytest.mark.asyncio
+async def test_lazy_engine_initialization() -> None:
+    """
+    Test that engine is created lazily on first access.
+
+    This verifies the lazy initialization pattern:
+    1. Engine is None initially (per process)
+    2. First access creates the engine
+    3. Subsequent accesses reuse the same engine
+    """
+    # Get the engine (will create if needed)
+    engine1 = _get_worker_engine()
+    assert engine1 is not None
+
+    # Get it again - should be the same instance
+    engine2 = _get_worker_engine()
+    assert engine1 is engine2
+
+    # Verify we can create a session and execute a query
+    session = worker_session_factory()
+    try:
+        result = await session.execute(text("SELECT 1"))
+        row = result.scalar()
+        assert row == 1
+    finally:
+        await session.close()

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -323,8 +323,8 @@ async def test_check_disruptions_async_closes_redis_when_service_fails(
     mock_session.close.assert_called_once()
 
 
-@patch("app.celery.tasks.asyncio.run")
-def test_check_disruptions_task_success_path(mock_asyncio_run: MagicMock) -> None:
+@patch("app.celery.tasks.run_async_task")
+def test_check_disruptions_task_success_path(mock_run_async_task: MagicMock) -> None:
     """Test the synchronous task wrapper success path."""
     mock_result = {
         "status": "success",
@@ -332,19 +332,19 @@ def test_check_disruptions_task_success_path(mock_asyncio_run: MagicMock) -> Non
         "alerts_sent": 2,
         "errors": 0,
     }
-    mock_asyncio_run.return_value = mock_result
+    mock_run_async_task.return_value = mock_result
 
     result = check_disruptions_and_alert()
 
     assert result == mock_result
-    mock_asyncio_run.assert_called_once()
+    mock_run_async_task.assert_called_once()
 
 
-@patch("app.celery.tasks.asyncio.run")
-def test_check_disruptions_task_retry_on_error(mock_asyncio_run: MagicMock) -> None:
+@patch("app.celery.tasks.run_async_task")
+def test_check_disruptions_task_retry_on_error(mock_run_async_task: MagicMock) -> None:
     """Test that task retries on exception (lines 55-63)."""
     # Mock asyncio.run to raise an exception
-    mock_asyncio_run.side_effect = RuntimeError("Database connection lost")
+    mock_run_async_task.side_effect = RuntimeError("Database connection lost")
 
     # Create a mock Celery task instance with retry method
     task_instance = check_disruptions_and_alert
@@ -354,8 +354,8 @@ def test_check_disruptions_task_retry_on_error(mock_asyncio_run: MagicMock) -> N
         task_instance()
 
 
-@patch("app.celery.tasks.asyncio.run")
-def test_check_disruptions_task_logs_on_success(mock_asyncio_run: MagicMock) -> None:
+@patch("app.celery.tasks.run_async_task")
+def test_check_disruptions_task_logs_on_success(mock_run_async_task: MagicMock) -> None:
     """Test that task logs completion (lines 49-52)."""
     mock_result = {
         "status": "success",
@@ -363,7 +363,7 @@ def test_check_disruptions_task_logs_on_success(mock_asyncio_run: MagicMock) -> 
         "alerts_sent": 1,
         "errors": 0,
     }
-    mock_asyncio_run.return_value = mock_result
+    mock_run_async_task.return_value = mock_result
 
     with patch("app.celery.tasks.logger") as mock_logger:
         result = check_disruptions_and_alert()
@@ -374,10 +374,10 @@ def test_check_disruptions_task_logs_on_success(mock_asyncio_run: MagicMock) -> 
         assert call_args[0][0] == "check_disruptions_task_completed"
 
 
-@patch("app.celery.tasks.asyncio.run")
-def test_check_disruptions_task_logs_on_error(mock_asyncio_run: MagicMock) -> None:
+@patch("app.celery.tasks.run_async_task")
+def test_check_disruptions_task_logs_on_error(mock_run_async_task: MagicMock) -> None:
     """Test that task logs errors before retry (lines 56-61)."""
-    mock_asyncio_run.side_effect = RuntimeError("Test error")
+    mock_run_async_task.side_effect = RuntimeError("Test error")
 
     task_instance = check_disruptions_and_alert
 
@@ -618,8 +618,8 @@ async def test_rebuild_indexes_async_closes_session_when_service_fails(
     mock_session.close.assert_called_once()
 
 
-@patch("app.celery.tasks.asyncio.run")
-def test_rebuild_indexes_task_success_path(mock_asyncio_run: MagicMock) -> None:
+@patch("app.celery.tasks.run_async_task")
+def test_rebuild_indexes_task_success_path(mock_run_async_task: MagicMock) -> None:
     """Test the synchronous task wrapper success path."""
     mock_result = {
         "status": "success",
@@ -627,19 +627,19 @@ def test_rebuild_indexes_task_success_path(mock_asyncio_run: MagicMock) -> None:
         "failed_count": 0,
         "errors": [],
     }
-    mock_asyncio_run.return_value = mock_result
+    mock_run_async_task.return_value = mock_result
 
     result = rebuild_route_indexes_task(route_id="550e8400-e29b-41d4-a716-446655440000")
 
     assert result == mock_result
-    mock_asyncio_run.assert_called_once()
+    mock_run_async_task.assert_called_once()
 
 
-@patch("app.celery.tasks.asyncio.run")
-def test_rebuild_indexes_task_retry_on_error(mock_asyncio_run: MagicMock) -> None:
+@patch("app.celery.tasks.run_async_task")
+def test_rebuild_indexes_task_retry_on_error(mock_run_async_task: MagicMock) -> None:
     """Test that task retries on exception."""
     # Mock asyncio.run to raise an exception
-    mock_asyncio_run.side_effect = RuntimeError("Database connection lost")
+    mock_run_async_task.side_effect = RuntimeError("Database connection lost")
 
     # Create a mock Celery task instance with retry method
     task_instance = rebuild_route_indexes_task
@@ -649,8 +649,8 @@ def test_rebuild_indexes_task_retry_on_error(mock_asyncio_run: MagicMock) -> Non
         task_instance(route_id=None)
 
 
-@patch("app.celery.tasks.asyncio.run")
-def test_rebuild_indexes_task_logs_on_success(mock_asyncio_run: MagicMock) -> None:
+@patch("app.celery.tasks.run_async_task")
+def test_rebuild_indexes_task_logs_on_success(mock_run_async_task: MagicMock) -> None:
     """Test that task logs completion."""
     mock_result = {
         "status": "success",
@@ -658,7 +658,7 @@ def test_rebuild_indexes_task_logs_on_success(mock_asyncio_run: MagicMock) -> No
         "failed_count": 0,
         "errors": [],
     }
-    mock_asyncio_run.return_value = mock_result
+    mock_run_async_task.return_value = mock_result
 
     with patch("app.celery.tasks.logger") as mock_logger:
         result = rebuild_route_indexes_task(route_id=None)
@@ -669,10 +669,10 @@ def test_rebuild_indexes_task_logs_on_success(mock_asyncio_run: MagicMock) -> No
         assert call_args[0][0] == "rebuild_indexes_task_completed"
 
 
-@patch("app.celery.tasks.asyncio.run")
-def test_rebuild_indexes_task_logs_on_error(mock_asyncio_run: MagicMock) -> None:
+@patch("app.celery.tasks.run_async_task")
+def test_rebuild_indexes_task_logs_on_error(mock_run_async_task: MagicMock) -> None:
     """Test that task logs errors before retry."""
-    mock_asyncio_run.side_effect = RuntimeError("Test error")
+    mock_run_async_task.side_effect = RuntimeError("Test error")
 
     task_instance = rebuild_route_indexes_task
 
@@ -1019,8 +1019,8 @@ async def test_detect_stale_routes_async_returns_correct_structure(
     assert isinstance(result["errors"], list)
 
 
-@patch("app.celery.tasks.asyncio.run")
-def test_detect_stale_routes_task_success_path(mock_asyncio_run: MagicMock) -> None:
+@patch("app.celery.tasks.run_async_task")
+def test_detect_stale_routes_task_success_path(mock_run_async_task: MagicMock) -> None:
     """Test the synchronous task wrapper success path."""
     mock_result = {
         "status": "success",
@@ -1028,19 +1028,19 @@ def test_detect_stale_routes_task_success_path(mock_asyncio_run: MagicMock) -> N
         "triggered_count": 5,
         "errors": [],
     }
-    mock_asyncio_run.return_value = mock_result
+    mock_run_async_task.return_value = mock_result
 
     result = detect_and_rebuild_stale_routes()
 
     assert result == mock_result
-    mock_asyncio_run.assert_called_once()
+    mock_run_async_task.assert_called_once()
 
 
-@patch("app.celery.tasks.asyncio.run")
-def test_detect_stale_routes_task_retry_on_error(mock_asyncio_run: MagicMock) -> None:
+@patch("app.celery.tasks.run_async_task")
+def test_detect_stale_routes_task_retry_on_error(mock_run_async_task: MagicMock) -> None:
     """Test that task retries on exception."""
     # Mock asyncio.run to raise an exception
-    mock_asyncio_run.side_effect = RuntimeError("Database connection lost")
+    mock_run_async_task.side_effect = RuntimeError("Database connection lost")
 
     # Create a mock Celery task instance with retry method
     task_instance = detect_and_rebuild_stale_routes
@@ -1050,8 +1050,8 @@ def test_detect_stale_routes_task_retry_on_error(mock_asyncio_run: MagicMock) ->
         task_instance()
 
 
-@patch("app.celery.tasks.asyncio.run")
-def test_detect_stale_routes_task_logs_on_success(mock_asyncio_run: MagicMock) -> None:
+@patch("app.celery.tasks.run_async_task")
+def test_detect_stale_routes_task_logs_on_success(mock_run_async_task: MagicMock) -> None:
     """Test that task logs completion."""
     mock_result = {
         "status": "success",
@@ -1059,7 +1059,7 @@ def test_detect_stale_routes_task_logs_on_success(mock_asyncio_run: MagicMock) -
         "triggered_count": 3,
         "errors": [],
     }
-    mock_asyncio_run.return_value = mock_result
+    mock_run_async_task.return_value = mock_result
 
     with patch("app.celery.tasks.logger") as mock_logger:
         result = detect_and_rebuild_stale_routes()
@@ -1070,10 +1070,10 @@ def test_detect_stale_routes_task_logs_on_success(mock_asyncio_run: MagicMock) -
         assert call_args[0][0] == "detect_stale_routes_task_completed"
 
 
-@patch("app.celery.tasks.asyncio.run")
-def test_detect_stale_routes_task_logs_on_error(mock_asyncio_run: MagicMock) -> None:
+@patch("app.celery.tasks.run_async_task")
+def test_detect_stale_routes_task_logs_on_error(mock_run_async_task: MagicMock) -> None:
     """Test that task logs errors before retry."""
-    mock_asyncio_run.side_effect = RuntimeError("Test error")
+    mock_run_async_task.side_effect = RuntimeError("Test error")
 
     task_instance = detect_and_rebuild_stale_routes
 

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -26,7 +26,7 @@ def test_check_disruptions_task_registered() -> None:
 @pytest.mark.asyncio
 @patch("app.celery.tasks.AlertService")
 @patch("app.celery.tasks.get_redis_client")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_check_disruptions_async_success(
     mock_session_factory: MagicMock,
     mock_redis_func: MagicMock,
@@ -73,7 +73,7 @@ async def test_check_disruptions_async_success(
 @pytest.mark.asyncio
 @patch("app.celery.tasks.AlertService")
 @patch("app.celery.tasks.get_redis_client")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_check_disruptions_async_returns_stats(
     mock_session_factory: MagicMock,
     mock_redis_func: MagicMock,
@@ -115,7 +115,7 @@ async def test_check_disruptions_async_returns_stats(
 @pytest.mark.asyncio
 @patch("app.celery.tasks.get_redis_client")
 @patch("app.celery.tasks.AlertService")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_check_disruptions_async_closes_resources(
     mock_session_factory: MagicMock,
     mock_alert_class: MagicMock,
@@ -154,7 +154,7 @@ async def test_check_disruptions_async_closes_resources(
 @pytest.mark.asyncio
 @patch("app.celery.tasks.get_redis_client")
 @patch("app.celery.tasks.AlertService")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_check_disruptions_async_closes_resources_on_error(
     mock_session_factory: MagicMock,
     mock_alert_class: MagicMock,
@@ -188,7 +188,7 @@ async def test_check_disruptions_async_closes_resources_on_error(
 @pytest.mark.asyncio
 @patch("app.celery.tasks.get_redis_client")
 @patch("app.celery.tasks.AlertService")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_check_disruptions_async_no_routes_checked(
     mock_session_factory: MagicMock,
     mock_alert_class: MagicMock,
@@ -229,7 +229,7 @@ async def test_check_disruptions_async_no_routes_checked(
 @pytest.mark.asyncio
 @patch("app.celery.tasks.get_redis_client")
 @patch("app.celery.tasks.AlertService")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_check_disruptions_async_with_errors(
     mock_session_factory: MagicMock,
     mock_alert_class: MagicMock,
@@ -269,7 +269,7 @@ async def test_check_disruptions_async_with_errors(
 
 @pytest.mark.asyncio
 @patch("app.celery.tasks.get_redis_client")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_check_disruptions_async_closes_session_when_redis_fails(
     mock_session_factory: MagicMock,
     mock_redis_func: MagicMock,
@@ -294,7 +294,7 @@ async def test_check_disruptions_async_closes_session_when_redis_fails(
 @pytest.mark.asyncio
 @patch("app.celery.tasks.AlertService")
 @patch("app.celery.tasks.get_redis_client")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_check_disruptions_async_closes_redis_when_service_fails(
     mock_session_factory: MagicMock,
     mock_redis_func: MagicMock,
@@ -323,7 +323,7 @@ async def test_check_disruptions_async_closes_redis_when_service_fails(
     mock_session.close.assert_called_once()
 
 
-@patch("app.celery.tasks.run_async_task")
+@patch("app.celery.tasks.run_in_isolated_loop")
 def test_check_disruptions_task_success_path(mock_run_async_task: MagicMock) -> None:
     """Test the synchronous task wrapper success path."""
     mock_result = {
@@ -340,7 +340,7 @@ def test_check_disruptions_task_success_path(mock_run_async_task: MagicMock) -> 
     mock_run_async_task.assert_called_once()
 
 
-@patch("app.celery.tasks.run_async_task")
+@patch("app.celery.tasks.run_in_isolated_loop")
 def test_check_disruptions_task_retry_on_error(mock_run_async_task: MagicMock) -> None:
     """Test that task retries on exception (lines 55-63)."""
     # Mock asyncio.run to raise an exception
@@ -354,7 +354,7 @@ def test_check_disruptions_task_retry_on_error(mock_run_async_task: MagicMock) -
         task_instance()
 
 
-@patch("app.celery.tasks.run_async_task")
+@patch("app.celery.tasks.run_in_isolated_loop")
 def test_check_disruptions_task_logs_on_success(mock_run_async_task: MagicMock) -> None:
     """Test that task logs completion (lines 49-52)."""
     mock_result = {
@@ -374,7 +374,7 @@ def test_check_disruptions_task_logs_on_success(mock_run_async_task: MagicMock) 
         assert call_args[0][0] == "check_disruptions_task_completed"
 
 
-@patch("app.celery.tasks.run_async_task")
+@patch("app.celery.tasks.run_in_isolated_loop")
 def test_check_disruptions_task_logs_on_error(mock_run_async_task: MagicMock) -> None:
     """Test that task logs errors before retry (lines 56-61)."""
     mock_run_async_task.side_effect = RuntimeError("Test error")
@@ -402,7 +402,7 @@ def test_rebuild_indexes_task_registered() -> None:
 
 @pytest.mark.asyncio
 @patch("app.celery.tasks.RouteIndexService")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_success_single_route(
     mock_session_factory: MagicMock,
     mock_service_class: MagicMock,
@@ -446,7 +446,7 @@ async def test_rebuild_indexes_async_success_single_route(
 
 @pytest.mark.asyncio
 @patch("app.celery.tasks.RouteIndexService")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_success_all_routes(
     mock_session_factory: MagicMock,
     mock_service_class: MagicMock,
@@ -486,7 +486,7 @@ async def test_rebuild_indexes_async_success_all_routes(
 
 @pytest.mark.asyncio
 @patch("app.celery.tasks.RouteIndexService")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_partial_failure(
     mock_session_factory: MagicMock,
     mock_service_class: MagicMock,
@@ -519,7 +519,7 @@ async def test_rebuild_indexes_async_partial_failure(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_invalid_uuid(
     mock_session_factory: MagicMock,
 ) -> None:
@@ -539,7 +539,7 @@ async def test_rebuild_indexes_async_invalid_uuid(
 
 @pytest.mark.asyncio
 @patch("app.celery.tasks.RouteIndexService")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_closes_session_on_success(
     mock_session_factory: MagicMock,
     mock_service_class: MagicMock,
@@ -570,7 +570,7 @@ async def test_rebuild_indexes_async_closes_session_on_success(
 
 @pytest.mark.asyncio
 @patch("app.celery.tasks.RouteIndexService")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_closes_session_on_error(
     mock_session_factory: MagicMock,
     mock_service_class: MagicMock,
@@ -596,7 +596,7 @@ async def test_rebuild_indexes_async_closes_session_on_error(
 
 @pytest.mark.asyncio
 @patch("app.celery.tasks.RouteIndexService")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_closes_session_when_service_fails(
     mock_session_factory: MagicMock,
     mock_service_class: MagicMock,
@@ -618,7 +618,7 @@ async def test_rebuild_indexes_async_closes_session_when_service_fails(
     mock_session.close.assert_called_once()
 
 
-@patch("app.celery.tasks.run_async_task")
+@patch("app.celery.tasks.run_in_isolated_loop")
 def test_rebuild_indexes_task_success_path(mock_run_async_task: MagicMock) -> None:
     """Test the synchronous task wrapper success path."""
     mock_result = {
@@ -635,7 +635,7 @@ def test_rebuild_indexes_task_success_path(mock_run_async_task: MagicMock) -> No
     mock_run_async_task.assert_called_once()
 
 
-@patch("app.celery.tasks.run_async_task")
+@patch("app.celery.tasks.run_in_isolated_loop")
 def test_rebuild_indexes_task_retry_on_error(mock_run_async_task: MagicMock) -> None:
     """Test that task retries on exception."""
     # Mock asyncio.run to raise an exception
@@ -649,7 +649,7 @@ def test_rebuild_indexes_task_retry_on_error(mock_run_async_task: MagicMock) -> 
         task_instance(route_id=None)
 
 
-@patch("app.celery.tasks.run_async_task")
+@patch("app.celery.tasks.run_in_isolated_loop")
 def test_rebuild_indexes_task_logs_on_success(mock_run_async_task: MagicMock) -> None:
     """Test that task logs completion."""
     mock_result = {
@@ -669,7 +669,7 @@ def test_rebuild_indexes_task_logs_on_success(mock_run_async_task: MagicMock) ->
         assert call_args[0][0] == "rebuild_indexes_task_completed"
 
 
-@patch("app.celery.tasks.run_async_task")
+@patch("app.celery.tasks.run_in_isolated_loop")
 def test_rebuild_indexes_task_logs_on_error(mock_run_async_task: MagicMock) -> None:
     """Test that task logs errors before retry."""
     mock_run_async_task.side_effect = RuntimeError("Test error")
@@ -769,7 +769,7 @@ async def test_find_stale_route_ids_query_uses_distinct() -> None:
 @pytest.mark.asyncio
 @patch("app.celery.tasks.rebuild_route_indexes_task")
 @patch("app.celery.tasks.find_stale_route_ids")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_detect_stale_routes_async_no_stale_routes(
     mock_session_factory: MagicMock,
     mock_find_stale: MagicMock,
@@ -803,7 +803,7 @@ async def test_detect_stale_routes_async_no_stale_routes(
 @pytest.mark.asyncio
 @patch("app.celery.tasks.rebuild_route_indexes_task")
 @patch("app.celery.tasks.find_stale_route_ids")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_detect_stale_routes_async_single_stale_route(
     mock_session_factory: MagicMock,
     mock_find_stale: MagicMock,
@@ -841,7 +841,7 @@ async def test_detect_stale_routes_async_single_stale_route(
 @pytest.mark.asyncio
 @patch("app.celery.tasks.rebuild_route_indexes_task")
 @patch("app.celery.tasks.find_stale_route_ids")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_detect_stale_routes_async_multiple_stale_routes(
     mock_session_factory: MagicMock,
     mock_find_stale: MagicMock,
@@ -881,7 +881,7 @@ async def test_detect_stale_routes_async_multiple_stale_routes(
 @pytest.mark.asyncio
 @patch("app.celery.tasks.rebuild_route_indexes_task")
 @patch("app.celery.tasks.find_stale_route_ids")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_detect_stale_routes_async_partial_trigger_failure(
     mock_session_factory: MagicMock,
     mock_find_stale: MagicMock,
@@ -929,7 +929,7 @@ async def test_detect_stale_routes_async_partial_trigger_failure(
 @pytest.mark.asyncio
 @patch("app.celery.tasks.rebuild_route_indexes_task")
 @patch("app.celery.tasks.find_stale_route_ids")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_detect_stale_routes_async_all_triggers_fail(
     mock_session_factory: MagicMock,
     mock_find_stale: MagicMock,
@@ -964,7 +964,7 @@ async def test_detect_stale_routes_async_all_triggers_fail(
 
 @pytest.mark.asyncio
 @patch("app.celery.tasks.find_stale_route_ids")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_detect_stale_routes_async_closes_session_on_error(
     mock_session_factory: MagicMock,
     mock_find_stale: MagicMock,
@@ -989,7 +989,7 @@ async def test_detect_stale_routes_async_closes_session_on_error(
 @pytest.mark.asyncio
 @patch("app.celery.tasks.rebuild_route_indexes_task")
 @patch("app.celery.tasks.find_stale_route_ids")
-@patch("app.celery.tasks.worker_session_factory")
+@patch("app.celery.tasks.get_worker_session")
 async def test_detect_stale_routes_async_returns_correct_structure(
     mock_session_factory: MagicMock,
     mock_find_stale: MagicMock,
@@ -1019,7 +1019,7 @@ async def test_detect_stale_routes_async_returns_correct_structure(
     assert isinstance(result["errors"], list)
 
 
-@patch("app.celery.tasks.run_async_task")
+@patch("app.celery.tasks.run_in_isolated_loop")
 def test_detect_stale_routes_task_success_path(mock_run_async_task: MagicMock) -> None:
     """Test the synchronous task wrapper success path."""
     mock_result = {
@@ -1036,7 +1036,7 @@ def test_detect_stale_routes_task_success_path(mock_run_async_task: MagicMock) -
     mock_run_async_task.assert_called_once()
 
 
-@patch("app.celery.tasks.run_async_task")
+@patch("app.celery.tasks.run_in_isolated_loop")
 def test_detect_stale_routes_task_retry_on_error(mock_run_async_task: MagicMock) -> None:
     """Test that task retries on exception."""
     # Mock asyncio.run to raise an exception
@@ -1050,7 +1050,7 @@ def test_detect_stale_routes_task_retry_on_error(mock_run_async_task: MagicMock)
         task_instance()
 
 
-@patch("app.celery.tasks.run_async_task")
+@patch("app.celery.tasks.run_in_isolated_loop")
 def test_detect_stale_routes_task_logs_on_success(mock_run_async_task: MagicMock) -> None:
     """Test that task logs completion."""
     mock_result = {
@@ -1070,7 +1070,7 @@ def test_detect_stale_routes_task_logs_on_success(mock_run_async_task: MagicMock
         assert call_args[0][0] == "detect_stale_routes_task_completed"
 
 
-@patch("app.celery.tasks.run_async_task")
+@patch("app.celery.tasks.run_in_isolated_loop")
 def test_detect_stale_routes_task_logs_on_error(mock_run_async_task: MagicMock) -> None:
     """Test that task logs errors before retry."""
     mock_run_async_task.side_effect = RuntimeError("Test error")

--- a/docs/adr/08-background-jobs.md
+++ b/docs/adr/08-background-jobs.md
@@ -86,6 +86,8 @@ Celery workers need database access but share the same database as FastAPI app. 
 ### Decision
 Celery workers use separate async SQLAlchemy engine/session factory from FastAPI app. Uses NullPool in tests for isolation, QueuePool in production for connection reuse. Workers get sessions via `get_worker_session()` helper with proper cleanup.
 
+**See also:** "Worker Pool Fork Safety" below for how connection pooling is handled across forked worker processes.
+
 ### Consequences
 **Easier:**
 - Prevents connection pool conflicts
@@ -97,6 +99,40 @@ Celery workers use separate async SQLAlchemy engine/session factory from FastAPI
 - Must maintain two database engines (app, worker)
 - More complex configuration
 - Need to ensure both engines use correct pool settings
+
+---
+
+## Worker Pool Fork Safety
+
+### Status
+Active (Implemented 2025-11-14, Issue #147)
+
+### Context
+Celery workers using fork pool with SQLAlchemy async engine experience asyncpg InterfaceError ("cannot perform operation: another operation is in progress") and RuntimeError ("Future attached to a different loop"). Root cause: SQLAlchemy's async engine creates asyncio.Queue objects bound to the event loop that created them. With forked workers and per-task event loops, these Queue objects become bound to the wrong loop.
+
+**Related ADRs:**
+- ADR 10 "NullPool for Async Test Isolation" - Similar event loop binding issue in pytest-asyncio
+
+### Decision
+Use lazy engine initialization with per-task reset:
+1. Defer engine creation until first access (not at module import time)
+2. Reset engine globals at start of each task to force fresh engine creation
+3. Reset event loop policy after worker fork
+
+This ensures each task's engine binds asyncio primitives to the correct event loop.
+
+See `docs/celery-fork-safety.md` for implementation details.
+
+### Consequences
+**Easier:**
+- Connection pooling works in all environments without conditional logic
+- Complete event loop isolation between tasks and workers
+- No asyncpg InterfaceError or event loop conflicts
+
+**More Difficult:**
+- Engine recreated per task (small overhead, necessary for correctness)
+- Must call `reset_worker_engine()` at start of each new async task function
+- More complex initialization pattern than simple import-time creation
 
 ---
 

--- a/docs/celery-fork-safety.md
+++ b/docs/celery-fork-safety.md
@@ -33,11 +33,16 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 # Module-level globals for lazy initialization
 _worker_engine: AsyncEngine | None = None
-_worker_session_factory = None
+_worker_session_factory: async_sessionmaker[AsyncSession] | None = None
 
-def reset_worker_engine() -> None:
-    """Reset engine globals to force fresh creation on next access."""
+async def reset_worker_engine() -> None:
+    """Reset engine globals to force fresh creation on next access.
+
+    Disposes the old engine before resetting to avoid connection leaks.
+    """
     global _worker_engine, _worker_session_factory  # noqa: PLW0603
+    if _worker_engine is not None:
+        await _worker_engine.dispose()
     _worker_engine = None
     _worker_session_factory = None
 
@@ -49,17 +54,21 @@ def _get_worker_engine() -> AsyncEngine:
             settings.DATABASE_URL,
             pool_size=settings.DATABASE_POOL_SIZE,
             max_overflow=settings.DATABASE_MAX_OVERFLOW,
+            echo=settings.DATABASE_ECHO,
+            future=True,
         )
     return _worker_engine
 
-def worker_session_factory() -> AsyncSession:
-    """Get a worker session factory."""
+def get_worker_session() -> AsyncSession:
+    """Get a worker database session."""
     global _worker_session_factory  # noqa: PLW0603
     if _worker_session_factory is None:
         _worker_session_factory = async_sessionmaker(
             _get_worker_engine(),
             class_=AsyncSession,
             expire_on_commit=False,
+            autocommit=False,
+            autoflush=False,
         )
     return _worker_session_factory()
 
@@ -71,19 +80,19 @@ def init_worker_db(**kwargs: object) -> None:
 
 ### 2. tasks.py - Per-Task Reset
 
-Add `reset_worker_engine()` call at the start of each async task function:
+Add `await reset_worker_engine()` call at the start of each async task function:
 
 ```python
-from app.celery.database import reset_worker_engine, worker_session_factory
+from app.celery.database import get_worker_session, reset_worker_engine
 
 async def _check_disruptions_async() -> DisruptionCheckResult:
     # Force fresh engine for this task's event loop
-    reset_worker_engine()
+    await reset_worker_engine()
 
     session = None
     redis_client = None
     try:
-        session = worker_session_factory()
+        session = get_worker_session()
         redis_client = await get_redis_client()
         # ... rest of task logic
 ```
@@ -95,10 +104,10 @@ Apply the same pattern to all async task functions:
 
 ### 3. tasks.py - Event Loop Helper
 
-The `run_async_task()` helper creates a fresh, isolated event loop for each task:
+The `run_in_isolated_loop()` helper creates a fresh, isolated event loop for each task:
 
 ```python
-def run_async_task(coro_func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+def run_in_isolated_loop(coro_func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
     """Run an async function in a fresh, isolated event loop."""
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
@@ -118,11 +127,11 @@ def run_async_task(coro_func: Callable[..., Any], *args: Any, **kwargs: Any) -> 
 
 ## Key Insight
 
-Since each task gets a fresh event loop via `run_async_task()`, the engine's asyncio primitives must be recreated for each task to bind to the correct loop. This is achieved by resetting the engine globals, forcing lazy re-initialization per task.
+Since each task gets a fresh event loop via `run_in_isolated_loop()`, the engine's asyncio primitives must be recreated for each task to bind to the correct loop. This is achieved by resetting the engine globals, forcing lazy re-initialization per task.
 
 ## Testing
 
-Updated test mocks from `@patch("app.celery.tasks.asyncio.run")` to `@patch("app.celery.tasks.run_async_task")` since we now use the custom helper.
+Updated test mocks from `@patch("app.celery.tasks.asyncio.run")` to `@patch("app.celery.tasks.run_in_isolated_loop")` since we now use the custom helper.
 
 ## Trade-offs
 
@@ -133,14 +142,14 @@ Updated test mocks from `@patch("app.celery.tasks.asyncio.run")` to `@patch("app
 
 **Cons:**
 - Engine is recreated per task (small overhead, but necessary for correctness)
-- Connection pool is not shared across tasks in same worker process
-- Must remember to call `reset_worker_engine()` at start of new async tasks
+- Connection pool is not shared across tasks in the same worker process
+- Must remember to call `await reset_worker_engine()` at start of new async tasks
 
 ## Files Changed
 
 - `backend/app/celery/database.py` - Lazy initialization with per-task reset
-- `backend/app/celery/tasks.py` - Added `reset_worker_engine()` calls to all async task functions
-- `backend/tests/test_celery_tasks.py` - Updated mocks to patch `run_async_task`
+- `backend/app/celery/tasks.py` - Added `await reset_worker_engine()` calls to all async task functions
+- `backend/tests/test_celery_tasks.py` - Updated mocks to patch `run_in_isolated_loop`
 - `backend/tests/test_celery_database_integration.py` - Added/updated integration tests
 - `docs/adr/08-background-jobs.md` - Documented decision
 

--- a/docs/celery-fork-safety.md
+++ b/docs/celery-fork-safety.md
@@ -1,0 +1,151 @@
+# Celery Fork Safety Implementation
+
+This document describes the implementation details for Issue #147 - Celery worker database connection errors with asyncpg.
+
+## Problem
+
+SQLAlchemy's async engine creates `asyncio.Queue` objects at construction time that become permanently bound to the event loop that created them. This causes conflicts in two scenarios:
+
+1. **Cross-process binding:** Engine created at import time → forked workers inherit Queue objects bound to parent's event loop
+2. **Cross-task binding:** Engine created lazily but persists across tasks → each task gets fresh event loop but reuses engine with Queue objects bound to first task's event loop
+
+Both cause:
+```
+RuntimeError: Task <Task> got Future <Future> attached to a different loop
+asyncpg.exceptions._base.InterfaceError: cannot perform operation: another operation is in progress
+```
+
+## Solution
+
+Combine three techniques:
+
+1. **Lazy engine initialization** - Defer creation until first access
+2. **Per-task engine reset** - Reset globals at start of each task
+3. **Event loop policy reset** - Clear inherited state after fork
+
+## Implementation
+
+### 1. database.py - Lazy Initialization
+
+```python
+import asyncio
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+
+# Module-level globals for lazy initialization
+_worker_engine: AsyncEngine | None = None
+_worker_session_factory = None
+
+def reset_worker_engine() -> None:
+    """Reset engine globals to force fresh creation on next access."""
+    global _worker_engine, _worker_session_factory  # noqa: PLW0603
+    _worker_engine = None
+    _worker_session_factory = None
+
+def _get_worker_engine() -> AsyncEngine:
+    """Get or create worker engine (lazy initialization)."""
+    global _worker_engine  # noqa: PLW0603
+    if _worker_engine is None:
+        _worker_engine = create_async_engine(
+            settings.DATABASE_URL,
+            pool_size=settings.DATABASE_POOL_SIZE,
+            max_overflow=settings.DATABASE_MAX_OVERFLOW,
+        )
+    return _worker_engine
+
+def worker_session_factory() -> AsyncSession:
+    """Get a worker session factory."""
+    global _worker_session_factory  # noqa: PLW0603
+    if _worker_session_factory is None:
+        _worker_session_factory = async_sessionmaker(
+            _get_worker_engine(),
+            class_=AsyncSession,
+            expire_on_commit=False,
+        )
+    return _worker_session_factory()
+
+@worker_process_init.connect
+def init_worker_db(**kwargs: object) -> None:
+    """Reset asyncio event loop policy after fork."""
+    asyncio.set_event_loop_policy(None)
+```
+
+### 2. tasks.py - Per-Task Reset
+
+Add `reset_worker_engine()` call at the start of each async task function:
+
+```python
+from app.celery.database import reset_worker_engine, worker_session_factory
+
+async def _check_disruptions_async() -> DisruptionCheckResult:
+    # Force fresh engine for this task's event loop
+    reset_worker_engine()
+
+    session = None
+    redis_client = None
+    try:
+        session = worker_session_factory()
+        redis_client = await get_redis_client()
+        # ... rest of task logic
+```
+
+Apply the same pattern to all async task functions:
+- `_check_disruptions_async()`
+- `_rebuild_indexes_async()`
+- `_detect_stale_routes_async()`
+
+### 3. tasks.py - Event Loop Helper
+
+The `run_async_task()` helper creates a fresh, isolated event loop for each task:
+
+```python
+def run_async_task(coro_func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
+    """Run an async function in a fresh, isolated event loop."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        coro = coro_func(*args, **kwargs)
+        return loop.run_until_complete(coro)
+    finally:
+        # Cancel any pending tasks
+        pending = asyncio.all_tasks(loop)
+        for task in pending:
+            task.cancel()
+        if pending:
+            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        loop.close()
+        asyncio.set_event_loop(None)
+```
+
+## Key Insight
+
+Since each task gets a fresh event loop via `run_async_task()`, the engine's asyncio primitives must be recreated for each task to bind to the correct loop. This is achieved by resetting the engine globals, forcing lazy re-initialization per task.
+
+## Testing
+
+Updated test mocks from `@patch("app.celery.tasks.asyncio.run")` to `@patch("app.celery.tasks.run_async_task")` since we now use the custom helper.
+
+## Trade-offs
+
+**Pros:**
+- Complete event loop isolation between tasks and workers
+- Connection pooling works in all environments (no DEBUG conditional)
+- No asyncpg errors or event loop conflicts
+
+**Cons:**
+- Engine is recreated per task (small overhead, but necessary for correctness)
+- Connection pool is not shared across tasks in same worker process
+- Must remember to call `reset_worker_engine()` at start of new async tasks
+
+## Files Changed
+
+- `backend/app/celery/database.py` - Lazy initialization with per-task reset
+- `backend/app/celery/tasks.py` - Added `reset_worker_engine()` calls to all async task functions
+- `backend/tests/test_celery_tasks.py` - Updated mocks to patch `run_async_task`
+- `backend/tests/test_celery_database_integration.py` - Added/updated integration tests
+- `docs/adr/08-background-jobs.md` - Documented decision
+
+## References
+
+- Issue #147: https://github.com/mnbf9rca/IsTheTubeRunning/issues/147
+- SQLAlchemy docs: [Using Connection Pools with Multiprocessing](https://docs.sqlalchemy.org/en/20/core/pooling.html#using-connection-pools-with-multiprocessing-or-os-fork)
+- Celery signals: [worker_process_init](https://docs.celeryq.dev/en/stable/userguide/signals.html#worker-process-init)


### PR DESCRIPTION
resolves #147

## Summary by Sourcery

Implement robust database connection handling for Celery workers to prevent async event loop conflicts by lazily initializing the SQLAlchemy engine per task, resetting it and the event loop in each forked process, and updating task execution to use isolated event loops.

New Features:
- Add run_async_task helper to run async functions in fresh, isolated event loops for Celery tasks
- Introduce lazy initialization and reset_worker_engine to defer and refresh the Celery worker database engine and session factory per task

Enhancements:
- Hook into Celery’s worker_process_init signal to reset asyncio event loop policy after forking
- Replace asyncio.run calls in Celery tasks with run_async_task and call reset_worker_engine at the start of async functions

Documentation:
- Update ADR 08 to reference worker pool fork safety and add new celery-fork-safety.md detailing the implementation

Tests:
- Update unit tests to patch run_async_task instead of asyncio.run
- Add integration tests for worker_process_init handler, lazy engine initialization, and session creation