### PR TITLE
feat: Update tests to use AsyncMock for reset_worker_engine patching

### DIFF
--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -24,7 +24,7 @@ def test_check_disruptions_task_registered() -> None:
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.AlertService")
 @patch("app.celery.tasks.get_redis_client")
 @patch("app.celery.tasks.get_worker_session")
@@ -32,10 +32,9 @@ async def test_check_disruptions_async_success(
     mock_session_factory: MagicMock,
     mock_redis_func: MagicMock,
     mock_alert_class: MagicMock,
-    mock_reset_engine: MagicMock,
+    mock_reset_engine: AsyncMock,
 ) -> None:
     """Test successful execution of _check_disruptions_async function."""
-    mock_reset_engine.return_value = AsyncMock()
     # Mock database session
     mock_session = AsyncMock()
     mock_session.close = AsyncMock()
@@ -74,7 +73,7 @@ async def test_check_disruptions_async_success(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.AlertService")
 @patch("app.celery.tasks.get_redis_client")
 @patch("app.celery.tasks.get_worker_session")
@@ -82,10 +81,9 @@ async def test_check_disruptions_async_returns_stats(
     mock_session_factory: MagicMock,
     mock_redis_func: MagicMock,
     mock_alert_class: MagicMock,
-    mock_reset_engine: MagicMock,
+    mock_reset_engine: AsyncMock,
 ) -> None:
     """Test that async function returns correct statistics structure."""
-    mock_reset_engine.return_value = AsyncMock()
     # Mock database session
     mock_session = AsyncMock()
     mock_session.close = AsyncMock()
@@ -119,7 +117,7 @@ async def test_check_disruptions_async_returns_stats(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.get_redis_client")
 @patch("app.celery.tasks.AlertService")
 @patch("app.celery.tasks.get_worker_session")
@@ -127,7 +125,7 @@ async def test_check_disruptions_async_closes_resources(
     mock_session_factory: MagicMock,
     mock_alert_class: MagicMock,
     mock_redis_func: MagicMock,
-    mock_reset_engine: MagicMock,
+    mock_reset_engine: AsyncMock,
 ) -> None:
     """Test that async function properly closes Redis and database connections."""
     # Mock database session
@@ -160,7 +158,7 @@ async def test_check_disruptions_async_closes_resources(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.get_redis_client")
 @patch("app.celery.tasks.AlertService")
 @patch("app.celery.tasks.get_worker_session")
@@ -168,7 +166,7 @@ async def test_check_disruptions_async_closes_resources_on_error(
     mock_session_factory: MagicMock,
     mock_alert_class: MagicMock,
     mock_redis_func: MagicMock,
-    mock_reset_engine: MagicMock,
+    mock_reset_engine: AsyncMock,
 ) -> None:
     """Test that async function closes resources even when error occurs."""
     # Mock database session
@@ -196,7 +194,7 @@ async def test_check_disruptions_async_closes_resources_on_error(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.get_redis_client")
 @patch("app.celery.tasks.AlertService")
 @patch("app.celery.tasks.get_worker_session")
@@ -204,7 +202,7 @@ async def test_check_disruptions_async_no_routes_checked(
     mock_session_factory: MagicMock,
     mock_alert_class: MagicMock,
     mock_redis_func: MagicMock,
-    mock_reset_engine: MagicMock,
+    mock_reset_engine: AsyncMock,
 ) -> None:
     """Test async function when no routes are checked (no active routes)."""
     # Mock database session
@@ -239,7 +237,7 @@ async def test_check_disruptions_async_no_routes_checked(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.get_redis_client")
 @patch("app.celery.tasks.AlertService")
 @patch("app.celery.tasks.get_worker_session")
@@ -247,7 +245,7 @@ async def test_check_disruptions_async_with_errors(
     mock_session_factory: MagicMock,
     mock_alert_class: MagicMock,
     mock_redis_func: MagicMock,
-    mock_reset_engine: MagicMock,
+    mock_reset_engine: AsyncMock,
 ) -> None:
     """Test async function when some routes have errors but function completes."""
     # Mock database session
@@ -282,11 +280,11 @@ async def test_check_disruptions_async_with_errors(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.get_redis_client")
 @patch("app.celery.tasks.get_worker_session")
 async def test_check_disruptions_async_closes_session_when_redis_fails(
-    mock_session_factory: MagicMock, mock_redis_func: MagicMock, mock_reset_engine: MagicMock
+    mock_session_factory: MagicMock, mock_redis_func: MagicMock, mock_reset_engine: AsyncMock
 ) -> None:
     """Test that session is closed even when Redis client creation fails."""
     # Mock database session
@@ -306,7 +304,7 @@ async def test_check_disruptions_async_closes_session_when_redis_fails(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.AlertService")
 @patch("app.celery.tasks.get_redis_client")
 @patch("app.celery.tasks.get_worker_session")
@@ -314,7 +312,7 @@ async def test_check_disruptions_async_closes_redis_when_service_fails(
     mock_session_factory: MagicMock,
     mock_redis_func: MagicMock,
     mock_alert_class: MagicMock,
-    mock_reset_engine: MagicMock,
+    mock_reset_engine: AsyncMock,
 ) -> None:
     """Test that Redis is closed even when AlertService instantiation fails."""
     # Mock database session
@@ -417,11 +415,11 @@ def test_rebuild_indexes_task_registered() -> None:
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.RouteIndexService")
 @patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_success_single_route(
-    mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: MagicMock
+    mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: AsyncMock
 ) -> None:
     """Test successful execution for a single route."""
     # Mock database session
@@ -461,11 +459,11 @@ async def test_rebuild_indexes_async_success_single_route(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.RouteIndexService")
 @patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_success_all_routes(
-    mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: MagicMock
+    mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: AsyncMock
 ) -> None:
     """Test successful execution for all routes."""
     # Mock database session
@@ -501,11 +499,11 @@ async def test_rebuild_indexes_async_success_all_routes(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.RouteIndexService")
 @patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_partial_failure(
-    mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: MagicMock
+    mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: AsyncMock
 ) -> None:
     """Test async function when some routes fail."""
     # Mock database session
@@ -535,10 +533,10 @@ async def test_rebuild_indexes_async_partial_failure(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_invalid_uuid(
-    mock_session_factory: MagicMock, mock_reset_engine: MagicMock
+    mock_session_factory: MagicMock, mock_reset_engine: AsyncMock
 ) -> None:
     """Test that invalid UUID string raises ValueError."""
     # Mock database session
@@ -555,11 +553,11 @@ async def test_rebuild_indexes_async_invalid_uuid(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.RouteIndexService")
 @patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_closes_session_on_success(
-    mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: MagicMock
+    mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: AsyncMock
 ) -> None:
     """Test that async function properly closes database connection."""
     # Mock database session
@@ -586,11 +584,11 @@ async def test_rebuild_indexes_async_closes_session_on_success(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.RouteIndexService")
 @patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_closes_session_on_error(
-    mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: MagicMock
+    mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: AsyncMock
 ) -> None:
     """Test that async function closes session even when error occurs."""
     # Mock database session
@@ -612,11 +610,11 @@ async def test_rebuild_indexes_async_closes_session_on_error(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.RouteIndexService")
 @patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_closes_session_when_service_fails(
-    mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: MagicMock
+    mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: AsyncMock
 ) -> None:
     """Test that session is closed even when RouteIndexService instantiation fails."""
     # Mock database session
@@ -784,7 +782,7 @@ async def test_find_stale_route_ids_query_uses_distinct() -> None:
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.rebuild_route_indexes_task")
 @patch("app.celery.tasks.find_stale_route_ids")
 @patch("app.celery.tasks.get_worker_session")
@@ -792,7 +790,7 @@ async def test_detect_stale_routes_async_no_stale_routes(
     mock_session_factory: MagicMock,
     mock_find_stale: MagicMock,
     mock_rebuild_task: MagicMock,
-    mock_reset_engine: MagicMock,
+    mock_reset_engine: AsyncMock,
 ) -> None:
     """Test async function when no stale routes found."""
     # Mock database session
@@ -820,7 +818,7 @@ async def test_detect_stale_routes_async_no_stale_routes(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.rebuild_route_indexes_task")
 @patch("app.celery.tasks.find_stale_route_ids")
 @patch("app.celery.tasks.get_worker_session")
@@ -828,7 +826,7 @@ async def test_detect_stale_routes_async_single_stale_route(
     mock_session_factory: MagicMock,
     mock_find_stale: MagicMock,
     mock_rebuild_task: MagicMock,
-    mock_reset_engine: MagicMock,
+    mock_reset_engine: AsyncMock,
 ) -> None:
     """Test async function with single stale route."""
     # Mock database session
@@ -860,7 +858,7 @@ async def test_detect_stale_routes_async_single_stale_route(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.rebuild_route_indexes_task")
 @patch("app.celery.tasks.find_stale_route_ids")
 @patch("app.celery.tasks.get_worker_session")
@@ -868,7 +866,7 @@ async def test_detect_stale_routes_async_multiple_stale_routes(
     mock_session_factory: MagicMock,
     mock_find_stale: MagicMock,
     mock_rebuild_task: MagicMock,
-    mock_reset_engine: MagicMock,
+    mock_reset_engine: AsyncMock,
 ) -> None:
     """Test async function with multiple stale routes."""
     # Mock database session
@@ -902,7 +900,7 @@ async def test_detect_stale_routes_async_multiple_stale_routes(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.rebuild_route_indexes_task")
 @patch("app.celery.tasks.find_stale_route_ids")
 @patch("app.celery.tasks.get_worker_session")
@@ -910,7 +908,7 @@ async def test_detect_stale_routes_async_partial_trigger_failure(
     mock_session_factory: MagicMock,
     mock_find_stale: MagicMock,
     mock_rebuild_task: MagicMock,
-    mock_reset_engine: MagicMock,
+    mock_reset_engine: AsyncMock,
 ) -> None:
     """Test async function when some rebuild task triggers fail."""
     # Mock database session
@@ -952,7 +950,7 @@ async def test_detect_stale_routes_async_partial_trigger_failure(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.rebuild_route_indexes_task")
 @patch("app.celery.tasks.find_stale_route_ids")
 @patch("app.celery.tasks.get_worker_session")
@@ -960,7 +958,7 @@ async def test_detect_stale_routes_async_all_triggers_fail(
     mock_session_factory: MagicMock,
     mock_find_stale: MagicMock,
     mock_rebuild_task: MagicMock,
-    mock_reset_engine: MagicMock,
+    mock_reset_engine: AsyncMock,
 ) -> None:
     """Test async function when all rebuild task triggers fail."""
     # Mock database session
@@ -990,11 +988,11 @@ async def test_detect_stale_routes_async_all_triggers_fail(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.find_stale_route_ids")
 @patch("app.celery.tasks.get_worker_session")
 async def test_detect_stale_routes_async_closes_session_on_error(
-    mock_session_factory: MagicMock, mock_find_stale: MagicMock, mock_reset_engine: MagicMock
+    mock_session_factory: MagicMock, mock_find_stale: MagicMock, mock_reset_engine: AsyncMock
 ) -> None:
     """Test that async function closes session even when error occurs."""
     # Mock database session
@@ -1014,7 +1012,7 @@ async def test_detect_stale_routes_async_closes_session_on_error(
 
 
 @pytest.mark.asyncio
-@patch("app.celery.tasks.reset_worker_engine")
+@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
 @patch("app.celery.tasks.rebuild_route_indexes_task")
 @patch("app.celery.tasks.find_stale_route_ids")
 @patch("app.celery.tasks.get_worker_session")
@@ -1022,7 +1020,7 @@ async def test_detect_stale_routes_async_returns_correct_structure(
     mock_session_factory: MagicMock,
     mock_find_stale: MagicMock,
     mock_rebuild_task: MagicMock,
-    mock_reset_engine: MagicMock,
+    mock_reset_engine: AsyncMock,
 ) -> None:
     """Test that async function returns correct DetectStaleRoutesResult structure."""
     # Mock database session


### PR DESCRIPTION
fix improperly configured the reset_worker_engine mocks.

The Problem

When you await reset_worker_engine(), you're awaiting the function call itself, not its return value. My original approach:

@patch("app.celery.tasks.reset_worker_engine")  # Returns MagicMock
async def test_...(mock_reset_engine: MagicMock):
    mock_reset_engine.return_value = AsyncMock()  # ❌ Wrong!

This doesn't work because:
- mock_reset_engine is a MagicMock (not awaitable)
- Calling mock_reset_engine() returns mock_reset_engine.return_value
- We need the call to be awaitable, not the return value

The Fix

Changed all 22 test functions to use new_callable=AsyncMock:

@patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)  # ✅ Correct!
async def test_...(mock_reset_engine: AsyncMock):
    # No setup needed - AsyncMock is already awaitable

This makes the mock itself async, so await reset_worker_engine() works correctly.

Changes Made

File: backend/tests/test_celery_tasks.py

1. Updated all 22 @patch("app.celery.tasks.reset_worker_engine") decorators to use new_callable=AsyncMock
2. Changed type hints from mock_reset_engine: MagicMock → mock_reset_engine: AsyncMock
3. Removed all mock_reset_engine.return_value = AsyncMock() lines (no longer needed)