### PR TITLE
feat: Implement lazy initialization for database engine and session factory to ensure fork safety in FastAPI with multiple workers

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -44,7 +44,6 @@
       "Bash(gh issue comment:*)",
       "Bash(gh issue view:*)",
       "Bash(gh pr view:*)",
-      "Bash(git commit:*)",
       "Bash(./scripts/gh_pr_comment_action.sh:*)"
     ],
     "deny": [
@@ -53,6 +52,7 @@
     "ask": [
 
       "Bash(git push:*)",
+      "Bash(git commit:*)",
       "Bash(gh pr create:*)"
     ]
   }

--- a/backend/app/celery/database.py
+++ b/backend/app/celery/database.py
@@ -62,7 +62,6 @@ def _get_worker_engine() -> AsyncEngine:
         _worker_engine = create_async_engine(
             settings.DATABASE_URL,
             echo=settings.DATABASE_ECHO,
-            future=True,
             pool_size=settings.DATABASE_POOL_SIZE,
             max_overflow=settings.DATABASE_MAX_OVERFLOW,
         )

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -2,28 +2,72 @@
 
 from collections.abc import AsyncGenerator
 
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
 from sqlalchemy.pool import NullPool
 
 from app.core.config import settings
 
-# Create async engine
-# Use NullPool in tests to avoid event loop issues with pytest-asyncio
-engine = create_async_engine(
-    settings.DATABASE_URL,
-    echo=settings.DATABASE_ECHO,
-    future=True,
-    poolclass=NullPool if settings.DEBUG else None,
-)
+# Module-level globals for lazy initialization (fork-safety)
+_engine: AsyncEngine | None = None
+_session_factory: async_sessionmaker[AsyncSession] | None = None
 
-# Create async session maker
-AsyncSessionLocal = async_sessionmaker(
-    engine,
-    class_=AsyncSession,
-    expire_on_commit=False,
-    autocommit=False,
-    autoflush=False,
-)
+
+def get_engine() -> AsyncEngine:
+    """
+    Get or create database engine (lazy initialization).
+
+    Lazy initialization prevents forked worker processes from inheriting
+    the parent's engine with asyncio primitives bound to the parent's event loop.
+
+    This is critical when deploying FastAPI with multiple uvicorn workers
+    (--workers > 1) which use os.fork() to create worker processes.
+
+    Returns:
+        AsyncEngine: SQLAlchemy async engine
+    """
+    global _engine  # noqa: PLW0603
+    if _engine is None:
+        if settings.DEBUG:
+            # Use NullPool in DEBUG mode to avoid event loop issues with pytest-asyncio
+            # NullPool doesn't accept pool_size/max_overflow parameters
+            _engine = create_async_engine(
+                settings.DATABASE_URL,
+                echo=settings.DATABASE_ECHO,
+                poolclass=NullPool,
+            )
+        else:
+            # Use connection pooling in production for better performance
+            _engine = create_async_engine(
+                settings.DATABASE_URL,
+                echo=settings.DATABASE_ECHO,
+                pool_size=settings.DATABASE_POOL_SIZE,
+                max_overflow=settings.DATABASE_MAX_OVERFLOW,
+            )
+    return _engine
+
+
+def get_session_factory() -> async_sessionmaker[AsyncSession]:
+    """
+    Get or create session factory (lazy initialization).
+
+    Returns:
+        async_sessionmaker[AsyncSession]: SQLAlchemy async session factory
+    """
+    global _session_factory  # noqa: PLW0603
+    if _session_factory is None:
+        _session_factory = async_sessionmaker(
+            get_engine(),
+            class_=AsyncSession,
+            expire_on_commit=False,
+            autocommit=False,
+            autoflush=False,
+        )
+    return _session_factory
 
 
 async def get_db() -> AsyncGenerator[AsyncSession]:
@@ -33,7 +77,7 @@ async def get_db() -> AsyncGenerator[AsyncSession]:
     Yields:
         AsyncSession: Database session
     """
-    async with AsyncSessionLocal() as session:
+    async with get_session_factory()() as session:
         try:
             yield session
         finally:

--- a/backend/app/core/database.py
+++ b/backend/app/core/database.py
@@ -48,7 +48,6 @@ def get_engine() -> AsyncEngine:
                     _engine = create_async_engine(
                         settings.DATABASE_URL,
                         echo=settings.DATABASE_ECHO,
-                        future=True,
                         poolclass=NullPool,
                     )
                 else:
@@ -56,7 +55,6 @@ def get_engine() -> AsyncEngine:
                     _engine = create_async_engine(
                         settings.DATABASE_URL,
                         echo=settings.DATABASE_ECHO,
-                        future=True,
                         pool_size=settings.DATABASE_POOL_SIZE,
                         max_overflow=settings.DATABASE_MAX_OVERFLOW,
                     )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -16,7 +16,7 @@ from sqlalchemy.engine import Connection
 from app import __version__
 from app.api import admin, auth, contacts, notification_preferences, routes, tfl
 from app.core.config import settings
-from app.core.database import engine
+from app.core.database import get_engine
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +79,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     logger.info("Starting up: Validating database...")
 
     try:
-        async with engine.begin() as conn:
+        async with get_engine().begin() as conn:
             # Check database connectivity
             await conn.execute(text("SELECT 1"))
             logger.info("✓ Database connection successful")
@@ -104,7 +104,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     # Shutdown
     logger.info("Shutting down...")
-    await engine.dispose()
+    await get_engine().dispose()
     logger.info("✓ Shutdown complete")
 
 

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -1,7 +1,7 @@
 """Tests for database configuration and session management."""
 
 import pytest
-from app.core.database import AsyncSessionLocal, engine, get_db
+from app.core.database import get_db, get_engine, get_session_factory
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,15 +11,17 @@ class TestDatabaseConfiguration:
 
     def test_engine_configuration(self) -> None:
         """Test that engine is properly configured."""
+        engine = get_engine()
         assert engine is not None
         assert engine.url.drivername == "postgresql+asyncpg"
 
     def test_session_maker_configuration(self) -> None:
         """Test that session maker is properly configured."""
-        assert AsyncSessionLocal is not None
-        assert AsyncSessionLocal.kw["expire_on_commit"] is False
-        assert AsyncSessionLocal.kw["autocommit"] is False
-        assert AsyncSessionLocal.kw["autoflush"] is False
+        session_factory = get_session_factory()
+        assert session_factory is not None
+        assert session_factory.kw["expire_on_commit"] is False
+        assert session_factory.kw["autocommit"] is False
+        assert session_factory.kw["autoflush"] is False
 
 
 class TestGetDb:

--- a/backend/tests/test_database_fork_safety.py
+++ b/backend/tests/test_database_fork_safety.py
@@ -1,0 +1,240 @@
+"""Tests for database fork safety (lazy initialization pattern)."""
+
+import app.core.database as database_module
+import pytest
+from app.core.config import settings
+from app.core.database import get_db, get_engine, get_session_factory
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from sqlalchemy.pool import NullPool
+
+
+class TestLazyInitialization:
+    """Tests for lazy initialization of database engine and session factory."""
+
+    def test_engine_initially_none(self) -> None:
+        """Test that engine global is None before first access."""
+        # Reset the module-level globals
+        database_module._engine = None
+        database_module._session_factory = None
+
+        assert database_module._engine is None
+
+    def test_lazy_engine_initialization(self) -> None:
+        """Test that engine is created on first call to get_engine()."""
+        # Reset the module-level globals
+        database_module._engine = None
+        database_module._session_factory = None
+
+        # First call should create the engine
+        engine = get_engine()
+
+        assert engine is not None
+        assert isinstance(engine, AsyncEngine)
+        assert database_module._engine is not None
+        assert database_module._engine is engine
+
+    def test_engine_singleton_pattern(self) -> None:
+        """Test that multiple calls to get_engine() return the same instance."""
+        # Reset the module-level globals
+        database_module._engine = None
+        database_module._session_factory = None
+
+        # Get engine twice
+        engine1 = get_engine()
+        engine2 = get_engine()
+
+        # Should be the exact same object
+        assert engine1 is engine2
+
+    def test_session_factory_initially_none(self) -> None:
+        """Test that session factory global is None before first access."""
+        # Reset the module-level globals
+        database_module._engine = None
+        database_module._session_factory = None
+
+        assert database_module._session_factory is None
+
+    def test_lazy_session_factory_initialization(self) -> None:
+        """Test that session factory is created on first call to get_session_factory()."""
+        # Reset the module-level globals
+        database_module._engine = None
+        database_module._session_factory = None
+
+        # First call should create the session factory
+        session_factory = get_session_factory()
+
+        assert session_factory is not None
+        assert isinstance(session_factory, async_sessionmaker)
+        assert database_module._session_factory is not None
+        assert database_module._session_factory is session_factory
+
+    def test_session_factory_singleton_pattern(self) -> None:
+        """Test that multiple calls to get_session_factory() return the same instance."""
+        # Reset the module-level globals
+        database_module._engine = None
+        database_module._session_factory = None
+
+        # Get session factory twice
+        factory1 = get_session_factory()
+        factory2 = get_session_factory()
+
+        # Should be the exact same object
+        assert factory1 is factory2
+
+    def test_session_factory_uses_lazy_engine(self) -> None:
+        """Test that session factory creation triggers engine creation."""
+        # Reset the module-level globals
+        database_module._engine = None
+        database_module._session_factory = None
+
+        # Engine should be None initially
+        assert database_module._engine is None
+
+        # Get session factory (which calls get_engine() internally)
+        session_factory = get_session_factory()
+
+        # Now engine should also be created
+        assert database_module._engine is not None
+        assert session_factory is not None
+
+
+class TestPoolConfiguration:
+    """Tests for database pool configuration."""
+
+    def test_engine_uses_pool_settings_in_production(self) -> None:
+        """Test that engine uses configured pool settings when DEBUG=false."""
+        # Reset the module-level globals
+        database_module._engine = None
+        database_module._session_factory = None
+
+        # Get engine
+        engine = get_engine()
+
+        # In DEBUG mode (default for tests), should use NullPool
+        if settings.DEBUG:
+            assert isinstance(engine.pool, NullPool)
+        else:
+            # In production mode, should use AsyncAdaptedQueuePool with custom settings
+            # Pool size and max overflow are passed to create_async_engine
+            # We can verify they're set by checking the pool configuration
+            assert engine.pool is not None
+            # The actual pool type will be AsyncAdaptedQueuePool (not NullPool)
+            assert not isinstance(engine.pool, NullPool)
+
+    def test_engine_uses_correct_pool_size(self) -> None:
+        """Test that engine configuration includes pool size settings."""
+        # Reset the module-level globals
+        database_module._engine = None
+        database_module._session_factory = None
+
+        # Get engine
+        engine = get_engine()
+
+        # Verify the engine was created with correct parameters
+        # Note: In DEBUG mode (tests), NullPool is used and pool_size is ignored
+        # In production mode, pool_size and max_overflow are applied
+        assert engine is not None
+
+        if not settings.DEBUG:
+            # In production, verify pool settings are applied
+            # The pool object should have these attributes set
+            pool = engine.pool
+            # AsyncAdaptedQueuePool will have _pool_size and _max_overflow
+            # but they're private attributes, so we just verify it's not NullPool
+            assert not isinstance(pool, NullPool)
+
+
+class TestGetDb:
+    """Tests for get_db dependency with lazy initialization."""
+
+    @pytest.mark.asyncio
+    async def test_get_db_with_lazy_initialization(self) -> None:
+        """Test that get_db() works correctly with lazy initialization."""
+        # Reset the module-level globals
+        database_module._engine = None
+        database_module._session_factory = None
+
+        # get_db() should trigger lazy initialization
+        async for session in get_db():
+            # Session should be created successfully
+            assert session is not None
+            # Engine and session factory should now be initialized
+            assert database_module._engine is not None
+            assert database_module._session_factory is not None
+            break
+
+    @pytest.mark.asyncio
+    async def test_get_db_uses_singleton_session_factory(self) -> None:
+        """Test that get_db() uses the singleton session factory."""
+        # Reset the module-level globals
+        database_module._engine = None
+        database_module._session_factory = None
+
+        # Create session factory first
+        original_factory = get_session_factory()
+
+        # get_db() should use the same factory
+        async for _session in get_db():
+            # The session factory should not have changed
+            assert database_module._session_factory is original_factory
+            break
+
+
+class TestEngineConfiguration:
+    """Tests for engine configuration details."""
+
+    def test_engine_url_configuration(self) -> None:
+        """Test that engine is configured with correct database URL."""
+        # Reset the module-level globals
+        database_module._engine = None
+        database_module._session_factory = None
+
+        engine = get_engine()
+
+        # Verify engine uses PostgreSQL with asyncpg driver
+        assert engine.url.drivername == "postgresql+asyncpg"
+        # Verify it uses the configured DATABASE_URL components
+        # Note: str(engine.url) redacts password to ***, so we check components
+        assert engine.url.database == "isthetube"
+        assert engine.url.host == "localhost"
+        assert engine.url.port == 5432
+
+    def test_engine_echo_configuration(self) -> None:
+        """Test that engine echo setting matches configuration."""
+        # Reset the module-level globals
+        database_module._engine = None
+        database_module._session_factory = None
+
+        engine = get_engine()
+
+        # Verify echo setting matches config
+        assert engine.echo == settings.DATABASE_ECHO
+
+
+class TestSessionFactoryConfiguration:
+    """Tests for session factory configuration."""
+
+    def test_session_factory_settings(self) -> None:
+        """Test that session factory has correct settings."""
+        # Reset the module-level globals
+        database_module._engine = None
+        database_module._session_factory = None
+
+        factory = get_session_factory()
+
+        # Verify session factory configuration
+        assert factory.kw["expire_on_commit"] is False
+        assert factory.kw["autocommit"] is False
+        assert factory.kw["autoflush"] is False
+
+    def test_session_factory_uses_async_session(self) -> None:
+        """Test that session factory creates AsyncSession instances."""
+        # Reset the module-level globals
+        database_module._engine = None
+        database_module._session_factory = None
+
+        factory = get_session_factory()
+
+        # Verify the session class is AsyncSession
+        # In SQLAlchemy 2.0, the class is stored in .class_ attribute (not in .kw)
+        assert factory.class_ is AsyncSession

--- a/backend/tests/test_database_fork_safety.py
+++ b/backend/tests/test_database_fork_safety.py
@@ -1,7 +1,7 @@
 """Tests for database fork safety (lazy initialization pattern)."""
 
-import app.core.database as database_module
 import pytest
+from app.core import database as database_module
 from app.core.config import settings
 from app.core.database import get_db, get_engine, get_session_factory
 from sqlalchemy.engine.url import make_url
@@ -9,23 +9,25 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 from sqlalchemy.pool import NullPool
 
 
+@pytest.fixture(autouse=True)
+def reset_database_globals():
+    """Reset database module globals before and after each test for isolation."""
+    database_module._engine = None
+    database_module._session_factory = None
+    yield
+    database_module._engine = None
+    database_module._session_factory = None
+
+
 class TestLazyInitialization:
     """Tests for lazy initialization of database engine and session factory."""
 
     def test_engine_initially_none(self) -> None:
         """Test that engine global is None before first access."""
-        # Reset the module-level globals
-        database_module._engine = None
-        database_module._session_factory = None
-
         assert database_module._engine is None
 
     def test_lazy_engine_initialization(self) -> None:
         """Test that engine is created on first call to get_engine()."""
-        # Reset the module-level globals
-        database_module._engine = None
-        database_module._session_factory = None
-
         # First call should create the engine
         engine = get_engine()
 
@@ -36,10 +38,6 @@ class TestLazyInitialization:
 
     def test_engine_singleton_pattern(self) -> None:
         """Test that multiple calls to get_engine() return the same instance."""
-        # Reset the module-level globals
-        database_module._engine = None
-        database_module._session_factory = None
-
         # Get engine twice
         engine1 = get_engine()
         engine2 = get_engine()
@@ -49,18 +47,10 @@ class TestLazyInitialization:
 
     def test_session_factory_initially_none(self) -> None:
         """Test that session factory global is None before first access."""
-        # Reset the module-level globals
-        database_module._engine = None
-        database_module._session_factory = None
-
         assert database_module._session_factory is None
 
     def test_lazy_session_factory_initialization(self) -> None:
         """Test that session factory is created on first call to get_session_factory()."""
-        # Reset the module-level globals
-        database_module._engine = None
-        database_module._session_factory = None
-
         # First call should create the session factory
         session_factory = get_session_factory()
 
@@ -71,10 +61,6 @@ class TestLazyInitialization:
 
     def test_session_factory_singleton_pattern(self) -> None:
         """Test that multiple calls to get_session_factory() return the same instance."""
-        # Reset the module-level globals
-        database_module._engine = None
-        database_module._session_factory = None
-
         # Get session factory twice
         factory1 = get_session_factory()
         factory2 = get_session_factory()
@@ -84,10 +70,6 @@ class TestLazyInitialization:
 
     def test_session_factory_uses_lazy_engine(self) -> None:
         """Test that session factory creation triggers engine creation."""
-        # Reset the module-level globals
-        database_module._engine = None
-        database_module._session_factory = None
-
         # Engine should be None initially
         assert database_module._engine is None
 
@@ -104,10 +86,6 @@ class TestPoolConfiguration:
 
     def test_engine_uses_pool_settings_in_production(self) -> None:
         """Test that engine uses configured pool settings when DEBUG=false."""
-        # Reset the module-level globals
-        database_module._engine = None
-        database_module._session_factory = None
-
         # Get engine
         engine = get_engine()
 
@@ -124,10 +102,6 @@ class TestPoolConfiguration:
 
     def test_engine_uses_correct_pool_size(self) -> None:
         """Test that engine configuration includes pool size settings."""
-        # Reset the module-level globals
-        database_module._engine = None
-        database_module._session_factory = None
-
         # Get engine
         engine = get_engine()
 
@@ -151,10 +125,6 @@ class TestGetDb:
     @pytest.mark.asyncio
     async def test_get_db_with_lazy_initialization(self) -> None:
         """Test that get_db() works correctly with lazy initialization."""
-        # Reset the module-level globals
-        database_module._engine = None
-        database_module._session_factory = None
-
         # get_db() should trigger lazy initialization
         async for session in get_db():
             # Session should be created successfully
@@ -167,10 +137,6 @@ class TestGetDb:
     @pytest.mark.asyncio
     async def test_get_db_uses_singleton_session_factory(self) -> None:
         """Test that get_db() uses the singleton session factory."""
-        # Reset the module-level globals
-        database_module._engine = None
-        database_module._session_factory = None
-
         # Create session factory first
         original_factory = get_session_factory()
 
@@ -186,10 +152,6 @@ class TestEngineConfiguration:
 
     def test_engine_url_configuration(self) -> None:
         """Test that engine is configured with correct database URL from settings."""
-        # Reset the module-level globals
-        database_module._engine = None
-        database_module._session_factory = None
-
         engine = get_engine()
 
         # Verify engine uses PostgreSQL with asyncpg driver
@@ -207,10 +169,6 @@ class TestEngineConfiguration:
 
     def test_engine_echo_configuration(self) -> None:
         """Test that engine echo setting matches configuration."""
-        # Reset the module-level globals
-        database_module._engine = None
-        database_module._session_factory = None
-
         engine = get_engine()
 
         # Verify echo setting matches config
@@ -222,10 +180,6 @@ class TestSessionFactoryConfiguration:
 
     def test_session_factory_settings(self) -> None:
         """Test that session factory has correct settings."""
-        # Reset the module-level globals
-        database_module._engine = None
-        database_module._session_factory = None
-
         factory = get_session_factory()
 
         # Verify session factory configuration
@@ -235,10 +189,6 @@ class TestSessionFactoryConfiguration:
 
     def test_session_factory_uses_async_session(self) -> None:
         """Test that session factory creates AsyncSession instances."""
-        # Reset the module-level globals
-        database_module._engine = None
-        database_module._session_factory = None
-
         factory = get_session_factory()
 
         # Verify the session class is AsyncSession

--- a/scripts/test_fork_safety.sh
+++ b/scripts/test_fork_safety.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+# Script to test FastAPI fork safety with multiple uvicorn workers
+# Issue #151: Reproduce asyncpg event loop binding issue
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+BACKEND_DIR="$PROJECT_ROOT/backend"
+ENV_FILE="$BACKEND_DIR/.env"
+ENV_BACKUP="$BACKEND_DIR/.env.backup.$$"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}FastAPI Fork Safety Test (Issue #151)${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Function to cleanup on exit
+cleanup() {
+    echo ""
+    echo -e "${YELLOW}Cleaning up...${NC}"
+
+    # Kill uvicorn if running
+    if [ -n "$UVICORN_PID" ]; then
+        echo "Stopping uvicorn (PID: $UVICORN_PID)"
+        kill $UVICORN_PID 2>/dev/null || true
+        wait $UVICORN_PID 2>/dev/null || true
+    fi
+
+    # Restore .env if backed up
+    if [ -f "$ENV_BACKUP" ]; then
+        echo "Restoring .env file"
+        mv "$ENV_BACKUP" "$ENV_FILE"
+    fi
+
+    echo -e "${GREEN}Cleanup complete${NC}"
+
+    # Keep log file for inspection
+    if [ -f "$LOG_FILE" ]; then
+        echo -e "${YELLOW}Log file preserved at: $LOG_FILE${NC}"
+    fi
+}
+
+trap cleanup EXIT INT TERM
+
+# Check if backend directory exists
+if [ ! -d "$BACKEND_DIR" ]; then
+    echo -e "${RED}Error: Backend directory not found at $BACKEND_DIR${NC}"
+    exit 1
+fi
+
+cd "$BACKEND_DIR"
+
+# Check if .env exists
+if [ ! -f "$ENV_FILE" ]; then
+    echo -e "${RED}Error: .env file not found at $ENV_FILE${NC}"
+    exit 1
+fi
+
+# Backup .env file
+echo -e "${BLUE}1. Backing up .env file${NC}"
+cp "$ENV_FILE" "$ENV_BACKUP"
+
+# Set DEBUG=false in .env
+echo -e "${BLUE}2. Setting DEBUG=false in .env (enables connection pooling)${NC}"
+if grep -q "^DEBUG=" "$ENV_FILE"; then
+    # Replace existing DEBUG line
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' 's/^DEBUG=.*/DEBUG=false/' "$ENV_FILE"
+    else
+        sed -i 's/^DEBUG=.*/DEBUG=false/' "$ENV_FILE"
+    fi
+else
+    # Add DEBUG line if it doesn't exist
+    echo "DEBUG=false" >> "$ENV_FILE"
+fi
+
+# Verify DEBUG is set to false
+if grep -q "^DEBUG=false" "$ENV_FILE"; then
+    echo -e "${GREEN}   ✓ DEBUG=false set${NC}"
+else
+    echo -e "${RED}   ✗ Failed to set DEBUG=false${NC}"
+    exit 1
+fi
+
+# Create log file
+LOG_FILE="/tmp/uvicorn_fork_test_$$.log"
+echo -e "${BLUE}3. Starting uvicorn with 4 workers${NC}"
+echo "   Log file: $LOG_FILE"
+
+# Start uvicorn in background with 4 workers
+uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --workers 4 > "$LOG_FILE" 2>&1 &
+UVICORN_PID=$!
+
+echo "   Uvicorn PID: $UVICORN_PID"
+
+# Wait for uvicorn to start
+echo -e "${BLUE}4. Waiting for uvicorn to start...${NC}"
+MAX_WAIT=30
+WAIT_COUNT=0
+while [ $WAIT_COUNT -lt $MAX_WAIT ]; do
+    if curl -s http://localhost:8000/health > /dev/null 2>&1; then
+        echo -e "${GREEN}   ✓ Uvicorn started successfully${NC}"
+        break
+    fi
+    sleep 1
+    WAIT_COUNT=$((WAIT_COUNT + 1))
+    echo -n "."
+done
+
+if [ $WAIT_COUNT -eq $MAX_WAIT ]; then
+    echo ""
+    echo -e "${RED}   ✗ Uvicorn failed to start within ${MAX_WAIT} seconds${NC}"
+    echo -e "${YELLOW}   Last 20 lines of log:${NC}"
+    tail -20 "$LOG_FILE"
+    exit 1
+fi
+
+# Make concurrent requests to trigger the issue
+echo ""
+echo -e "${BLUE}5. Making concurrent requests to trigger fork safety issue${NC}"
+echo "   Sending 50 concurrent requests to database-intensive endpoints..."
+
+# Create a temporary script for concurrent requests
+CONCURRENT_SCRIPT="/tmp/concurrent_requests_$$.sh"
+cat > "$CONCURRENT_SCRIPT" << 'EOFSCRIPT'
+#!/bin/bash
+for i in {1..50}; do
+    # Try different endpoints that use the database
+    curl -s http://localhost:8000/health > /dev/null 2>&1 &
+    curl -s http://localhost:8000/docs > /dev/null 2>&1 &
+done
+wait
+EOFSCRIPT
+chmod +x "$CONCURRENT_SCRIPT"
+
+# Run concurrent requests
+bash "$CONCURRENT_SCRIPT"
+rm -f "$CONCURRENT_SCRIPT"
+
+echo -e "${GREEN}   ✓ Requests sent${NC}"
+
+# Wait a bit for any errors to appear in logs
+echo -e "${BLUE}6. Waiting for logs (5 seconds)...${NC}"
+sleep 5
+
+# Check logs for errors
+echo ""
+echo -e "${BLUE}7. Checking logs for fork safety errors${NC}"
+echo -e "${YELLOW}   Looking for:${NC}"
+echo "   - 'Task got Future attached to a different loop'"
+echo "   - 'asyncpg.exceptions.*InterfaceError'"
+echo "   - 'cannot perform operation: another operation is in progress'"
+echo ""
+
+ERRORS_FOUND=false
+
+if grep -i "Task.*got Future.*attached to a different loop" "$LOG_FILE" > /dev/null 2>&1; then
+    echo -e "${RED}   ✗ Found event loop error!${NC}"
+    grep -i "Task.*got Future.*attached to a different loop" "$LOG_FILE" | head -5
+    ERRORS_FOUND=true
+fi
+
+if grep -i "asyncpg.*InterfaceError" "$LOG_FILE" > /dev/null 2>&1; then
+    echo -e "${RED}   ✗ Found asyncpg InterfaceError!${NC}"
+    grep -i "asyncpg.*InterfaceError" "$LOG_FILE" | head -5
+    ERRORS_FOUND=true
+fi
+
+if grep -i "cannot perform operation.*another operation is in progress" "$LOG_FILE" > /dev/null 2>&1; then
+    echo -e "${RED}   ✗ Found asyncpg operation conflict!${NC}"
+    grep -i "cannot perform operation.*another operation is in progress" "$LOG_FILE" | head -5
+    ERRORS_FOUND=true
+fi
+
+# Check for general errors or warnings
+ERROR_COUNT=$(grep -i "error" "$LOG_FILE" | grep -v "INFO" | wc -l | tr -d ' ')
+WARNING_COUNT=$(grep -i "warning" "$LOG_FILE" | wc -l | tr -d ' ')
+
+echo ""
+echo -e "${BLUE}8. Summary${NC}"
+echo "   Errors found: $ERROR_COUNT"
+echo "   Warnings found: $WARNING_COUNT"
+
+if [ "$ERRORS_FOUND" = true ]; then
+    echo ""
+    echo -e "${RED}========================================${NC}"
+    echo -e "${RED}FORK SAFETY ISSUE DETECTED! ✗${NC}"
+    echo -e "${RED}========================================${NC}"
+    echo ""
+    echo "The fork safety issue (Issue #151) has been reproduced."
+    echo "This confirms that the bug exists when running with multiple workers."
+    echo ""
+    echo -e "${YELLOW}Full log available at: $LOG_FILE${NC}"
+    echo ""
+    echo "To view full log:"
+    echo "  cat $LOG_FILE"
+    echo ""
+    echo "To view errors only:"
+    echo "  grep -i error $LOG_FILE"
+    exit 1
+else
+    echo ""
+    echo -e "${GREEN}========================================${NC}"
+    echo -e "${GREEN}NO FORK SAFETY ERRORS DETECTED ✓${NC}"
+    echo -e "${GREEN}========================================${NC}"
+    echo ""
+
+    if [ $ERROR_COUNT -gt 0 ]; then
+        echo -e "${YELLOW}Note: Some errors were found, but they don't appear to be${NC}"
+        echo -e "${YELLOW}related to fork safety. Check the log for details.${NC}"
+        echo ""
+        echo -e "${YELLOW}Recent errors from log:${NC}"
+        grep -i "error" "$LOG_FILE" | grep -v "INFO" | tail -10
+    else
+        echo "Either:"
+        echo "  1. The issue has been successfully fixed, OR"
+        echo "  2. The issue wasn't triggered by these test requests"
+        echo ""
+        echo "If this is a before-fix test, try:"
+        echo "  - Running the script multiple times"
+        echo "  - Increasing the number of concurrent requests"
+        echo "  - Testing with authenticated endpoints that hit the database more"
+    fi
+
+    echo ""
+    echo -e "${YELLOW}Full log available at: $LOG_FILE${NC}"
+    exit 0
+fi


### PR DESCRIPTION
This PR implements lazy initialization for the database engine and session factory to ensure fork safety when deploying FastAPI with multiple uvicorn workers. The changes address Issue #151 by preventing forked worker processes from inheriting the parent's database engine with asyncio primitives bound to the wrong event loop.

**Key changes:**
- Converted module-level `engine` and `AsyncSessionLocal` to lazy-initialized singletons via `get_engine()` and `get_session_factory()` functions
- Updated all imports and usages throughout the codebase to use the new getter functions
- Added comprehensive test suite for fork safety and lazy initialization patterns
- Included bash test script to validate fork safety in multi-worker deployment

fixes #151

## Summary by Sourcery

Implement thread-safe lazy initialization for SQLAlchemy AsyncEngine and session factory to prevent event loop binding issues in forked FastAPI workers, update dependency and lifespan logic accordingly, and add tests, docs, and scripts to validate fork safety.

New Features:
- Introduce get_engine() and get_session_factory() for lazy, thread-safe singleton initialization of AsyncEngine and session factory
- Add scripts/test_fork_safety.sh to reproduce and validate fork safety issues with multiple uvicorn workers
- Add comprehensive test suite (test_database_fork_safety.py) to verify lazy initialization, singleton patterns, and pool configuration

Enhancements:
- Update get_db dependency and FastAPI lifespan hooks to use lazy initialization functions
- Refactor existing database tests and main lifespan tests to adopt the new initialization approach

Documentation:
- Document FastAPI worker fork safety decision and implementation in ADR 08

Tests:
- Refactor test_main.py and test_database.py to use get_engine() and get_session_factory()
- Enhance coverage for DEBUG vs production pool settings and get_db behavior