### PR TITLE
feat: Add admin user management utilities and CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,20 +270,28 @@ The backend supports mock JWT mode for development without Auth0. When `DEBUG=Tr
 
 Certain endpoints require admin privileges for system management and monitoring. Admin status is tracked in the `admin_users` table and checked via the `require_admin()` dependency.
 
-### Granting Admin Access
+### Creating Admin Users
 
-Admin users must be manually created in the database. To grant admin privileges to a user:
+Use the CLI tool to create admin users for local development and testing:
 
-```sql
--- Get the user's ID
-SELECT id FROM users WHERE external_id = 'auth0|your_user_id';
+```bash
+# uses backend config to connect to the database
+cd backend
 
--- Grant admin role
-INSERT INTO admin_users (user_id, role, granted_at)
-VALUES ('user-uuid-here', 'admin', NOW());
+# Create an admin user (returns UUID)
+uv run python -m app.cli create-admin
+
+# Grant admin to existing user
+uv run python -m app.cli grant-admin <user-id>
+
+# List all admins
+uv run python -m app.cli list-admins
+
+# See all commands
+uv run python -m app.cli --help
 ```
 
-**Note:** Production deployments should implement a secure admin management interface. Manual database access is acceptable for the MVP (Phase 8).
+**Note:** For production deployments, use a secure admin management interface (Phase 10 PR5).
 
 ### Available Admin Endpoints
 

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -1,0 +1,465 @@
+#!/usr/bin/env python3
+"""CLI tool for admin user management.
+
+This module provides command-line tools for creating and managing admin users
+in local development environments. It eliminates the need for manual SQL commands
+and provides a convenient interface for common admin operations.
+
+Usage:
+    # Create an admin user (most common use case)
+    uv run python -m app.cli create-admin
+
+    # Create a regular user
+    uv run python -m app.cli create-user
+
+    # Grant admin privileges to existing user
+    uv run python -m app.cli grant-admin <user-id>
+
+    # List all admin users
+    uv run python -m app.cli list-admins
+
+    # List all users
+    uv run python -m app.cli list-users
+
+    # Revoke admin privileges
+    uv run python -m app.cli revoke-admin <user-id>
+"""
+
+import argparse
+import asyncio
+import sys
+import uuid
+
+from app.core.database import get_session_factory
+from app.models.admin import AdminRole
+from app.utils.admin_helpers import (
+    create_admin_user,
+    create_user,
+    find_user_by_external_id,
+    get_user_by_id,
+    grant_admin,
+    list_admin_users,
+    list_users,
+    revoke_admin,
+)
+
+
+async def cmd_create_admin(args: argparse.Namespace) -> int:
+    """
+    Create a new admin user.
+
+    Args:
+        args: Parsed command-line arguments
+
+    Returns:
+        Exit code (0 for success, 1 for error)
+    """
+    async with get_session_factory()() as session:
+        try:
+            external_id = args.external_id if args.external_id else None
+            role = AdminRole.SUPERADMIN if args.superadmin else AdminRole.ADMIN
+
+            user, admin = await create_admin_user(session, external_id=external_id, role=role)
+
+            print("✅ Created admin user successfully!")
+            print(f"   User ID:     {user.id}")
+            print(f"   External ID: {user.external_id}")
+            print(f"   Provider:    {user.auth_provider}")
+            print(f"   Role:        {admin.role.value}")
+            print(f"   Granted at:  {admin.granted_at}")
+            print()
+            print("💡 Save the User ID to use with other CLI commands")
+            return 0
+
+        except ValueError as e:
+            print(f"❌ Error: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"❌ Unexpected error: {e}", file=sys.stderr)
+            return 1
+
+
+async def cmd_create_user(args: argparse.Namespace) -> int:
+    """
+    Create a new regular user.
+
+    Args:
+        args: Parsed command-line arguments
+
+    Returns:
+        Exit code (0 for success, 1 for error)
+    """
+    async with get_session_factory()() as session:
+        try:
+            external_id = args.external_id if args.external_id else None
+
+            user = await create_user(session, external_id=external_id)
+
+            print("✅ Created user successfully!")
+            print(f"   User ID:     {user.id}")
+            print(f"   External ID: {user.external_id}")
+            print(f"   Provider:    {user.auth_provider}")
+            print(f"   Created at:  {user.created_at}")
+            print()
+            print("💡 Use 'grant-admin {user_id}' to make this user an admin")
+            return 0
+
+        except ValueError as e:
+            print(f"❌ Error: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"❌ Unexpected error: {e}", file=sys.stderr)
+            return 1
+
+
+async def cmd_grant_admin(args: argparse.Namespace) -> int:
+    """
+    Grant admin privileges to an existing user.
+
+    Args:
+        args: Parsed command-line arguments
+
+    Returns:
+        Exit code (0 for success, 1 for error)
+    """
+    async with get_session_factory()() as session:
+        try:
+            # Parse user identifier
+            if args.external_id:
+                user = await find_user_by_external_id(session, args.identifier, auth_provider=args.provider)
+                if not user:
+                    print(
+                        f"❌ Error: User with external_id '{args.identifier}' not found (provider: {args.provider})",
+                        file=sys.stderr,
+                    )
+                    return 1
+                user_id = user.id
+            else:
+                try:
+                    user_id = uuid.UUID(args.identifier)
+                except ValueError:
+                    print(
+                        f"❌ Error: Invalid UUID '{args.identifier}'. "
+                        "Use --external-id flag if providing an external ID",
+                        file=sys.stderr,
+                    )
+                    return 1
+
+            # Grant admin
+            role = AdminRole.SUPERADMIN if args.superadmin else AdminRole.ADMIN
+            admin = await grant_admin(session, user_id=user_id, role=role)
+
+            # Get user details for display
+            user = await get_user_by_id(session, user_id)
+
+            print("✅ Granted admin privileges successfully!")
+            print(f"   User ID:     {user_id}")
+            if user:
+                print(f"   External ID: {user.external_id}")
+                print(f"   Provider:    {user.auth_provider}")
+            print(f"   Role:        {admin.role.value}")
+            print(f"   Granted at:  {admin.granted_at}")
+            return 0
+
+        except ValueError as e:
+            print(f"❌ Error: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"❌ Unexpected error: {e}", file=sys.stderr)
+            return 1
+
+
+async def cmd_revoke_admin(args: argparse.Namespace) -> int:
+    """
+    Revoke admin privileges from a user.
+
+    Args:
+        args: Parsed command-line arguments
+
+    Returns:
+        Exit code (0 for success, 1 for error)
+    """
+    async with get_session_factory()() as session:
+        try:
+            # Parse user identifier
+            if args.external_id:
+                user = await find_user_by_external_id(session, args.identifier, auth_provider=args.provider)
+                if not user:
+                    print(
+                        f"❌ Error: User with external_id '{args.identifier}' not found (provider: {args.provider})",
+                        file=sys.stderr,
+                    )
+                    return 1
+                user_id = user.id
+            else:
+                try:
+                    user_id = uuid.UUID(args.identifier)
+                except ValueError:
+                    print(
+                        f"❌ Error: Invalid UUID '{args.identifier}'. "
+                        "Use --external-id flag if providing an external ID",
+                        file=sys.stderr,
+                    )
+                    return 1
+
+            # Revoke admin
+            was_revoked = await revoke_admin(session, user_id=user_id)
+
+            if was_revoked:
+                print(f"✅ Revoked admin privileges from user {user_id}")
+                return 0
+            print(
+                f"Info: User {user_id} was not an admin (no action taken)",
+                file=sys.stderr,
+            )
+            return 0
+
+        except ValueError as e:
+            print(f"❌ Error: {e}", file=sys.stderr)
+            return 1
+        except Exception as e:
+            print(f"❌ Unexpected error: {e}", file=sys.stderr)
+            return 1
+
+
+async def cmd_list_admins(args: argparse.Namespace) -> int:
+    """
+    List all admin users.
+
+    Args:
+        args: Parsed command-line arguments
+
+    Returns:
+        Exit code (0 for success, 1 for error)
+    """
+    async with get_session_factory()() as session:
+        try:
+            admins = await list_admin_users(session)
+
+            if not admins:
+                print("No admin users found")
+                return 0
+
+            print(f"Found {len(admins)} admin user(s):\n")
+            print(f"{'User ID':<38} {'External ID':<30} {'Role':<12} {'Granted At'}")
+            print("-" * 110)
+
+            for user, admin in admins:
+                granted_at_str = admin.granted_at.strftime("%Y-%m-%d %H:%M:%S")
+                print(f"{user.id!s:<38} {user.external_id:<30} {admin.role.value:<12} {granted_at_str}")
+
+            return 0
+
+        except Exception as e:
+            print(f"❌ Unexpected error: {e}", file=sys.stderr)
+            return 1
+
+
+async def cmd_list_users(args: argparse.Namespace) -> int:
+    """
+    List all users with pagination.
+
+    Args:
+        args: Parsed command-line arguments
+
+    Returns:
+        Exit code (0 for success, 1 for error)
+    """
+    async with get_session_factory()() as session:
+        try:
+            users = await list_users(session, limit=args.limit, offset=args.offset)
+
+            if not users:
+                print("No users found")
+                return 0
+
+            print(f"Showing {len(users)} user(s) (limit: {args.limit}, offset: {args.offset}):\n")
+            print(f"{'User ID':<38} {'External ID':<30} {'Provider':<12} {'Created At'}")
+            print("-" * 110)
+
+            for user in users:
+                created_at_str = user.created_at.strftime("%Y-%m-%d %H:%M:%S")
+                print(f"{user.id!s:<38} {user.external_id:<30} {user.auth_provider:<12} {created_at_str}")
+
+            print("\n💡 Use --limit and --offset to paginate results (e.g., --limit 50 --offset 50 for next page)")
+            return 0
+
+        except Exception as e:
+            print(f"❌ Unexpected error: {e}", file=sys.stderr)
+            return 1
+
+
+def main() -> int:
+    """
+    Main entry point for the CLI tool.
+
+    Returns:
+        Exit code (0 for success, non-zero for error)
+    """
+    parser = argparse.ArgumentParser(
+        description="Admin user management CLI tool",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Create an admin user (most common)
+  uv run python -m app.cli create-admin
+
+  # Create an admin user with custom external ID
+  uv run python -m app.cli create-admin --external-id "auth0|abc123"
+
+  # Create a regular user
+  uv run python -m app.cli create-user
+
+  # Grant admin to existing user by UUID
+  uv run python -m app.cli grant-admin 550e8400-e29b-41d4-a716-446655440000
+
+  # Grant admin to existing user by external ID
+  uv run python -m app.cli grant-admin auth0|abc123 --external-id
+
+  # List all admin users
+  uv run python -m app.cli list-admins
+
+  # List users
+  uv run python -m app.cli list-users --limit 20
+
+  # Revoke admin privileges
+  uv run python -m app.cli revoke-admin 550e8400-e29b-41d4-a716-446655440000
+        """,
+    )
+
+    subparsers = parser.add_subparsers(dest="command", help="Command to execute")
+
+    # create-admin command
+    create_admin_parser = subparsers.add_parser(
+        "create-admin",
+        help="Create a new admin user (user + admin privileges)",
+        description="Create a new user and immediately grant admin privileges. "
+        "This is the most common command for local development.",
+    )
+    create_admin_parser.add_argument(
+        "--external-id",
+        type=str,
+        help="Custom external ID (e.g., 'auth0|abc123'). If not provided, generates 'cli|<random>'",
+    )
+    create_admin_parser.add_argument(
+        "--superadmin",
+        action="store_true",
+        help="Grant superadmin role instead of regular admin",
+    )
+
+    # create-user command
+    create_user_parser = subparsers.add_parser(
+        "create-user",
+        help="Create a new regular user (no admin privileges)",
+        description="Create a new user without admin privileges. Use 'grant-admin' to promote later.",
+    )
+    create_user_parser.add_argument(
+        "--external-id",
+        type=str,
+        help="Custom external ID (e.g., 'auth0|abc123'). If not provided, generates 'cli|<random>'",
+    )
+
+    # grant-admin command
+    grant_admin_parser = subparsers.add_parser(
+        "grant-admin",
+        help="Grant admin privileges to an existing user",
+        description="Grant admin privileges to an existing user by UUID or external ID.",
+    )
+    grant_admin_parser.add_argument(
+        "identifier",
+        type=str,
+        help="User UUID or external ID (use --external-id flag if providing external ID)",
+    )
+    grant_admin_parser.add_argument(
+        "--external-id",
+        action="store_true",
+        help="Treat identifier as external ID instead of UUID",
+    )
+    grant_admin_parser.add_argument(
+        "--provider",
+        type=str,
+        default="auth0",
+        help="Auth provider (default: auth0). Only used with --external-id",
+    )
+    grant_admin_parser.add_argument(
+        "--superadmin",
+        action="store_true",
+        help="Grant superadmin role instead of regular admin",
+    )
+
+    # revoke-admin command
+    revoke_admin_parser = subparsers.add_parser(
+        "revoke-admin",
+        help="Revoke admin privileges from a user",
+        description="Remove admin privileges from an existing admin user.",
+    )
+    revoke_admin_parser.add_argument(
+        "identifier",
+        type=str,
+        help="User UUID or external ID (use --external-id flag if providing external ID)",
+    )
+    revoke_admin_parser.add_argument(
+        "--external-id",
+        action="store_true",
+        help="Treat identifier as external ID instead of UUID",
+    )
+    revoke_admin_parser.add_argument(
+        "--provider",
+        type=str,
+        default="auth0",
+        help="Auth provider (default: auth0). Only used with --external-id",
+    )
+
+    # list-admins command
+    subparsers.add_parser(
+        "list-admins",
+        help="List all admin users",
+        description="Display a list of all users with admin privileges.",
+    )
+
+    # list-users command
+    list_users_parser = subparsers.add_parser(
+        "list-users",
+        help="List all users with pagination",
+        description="Display a paginated list of all users in the system.",
+    )
+    list_users_parser.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        help="Maximum number of users to display (default: 50)",
+    )
+    list_users_parser.add_argument(
+        "--offset",
+        type=int,
+        default=0,
+        help="Number of users to skip (default: 0)",
+    )
+
+    # Parse arguments
+    args = parser.parse_args()
+
+    # Show help if no command provided
+    if not args.command:
+        parser.print_help()
+        return 1
+
+    # Dispatch to command handler
+    command_handlers = {
+        "create-admin": cmd_create_admin,
+        "create-user": cmd_create_user,
+        "grant-admin": cmd_grant_admin,
+        "revoke-admin": cmd_revoke_admin,
+        "list-admins": cmd_list_admins,
+        "list-users": cmd_list_users,
+    }
+
+    handler = command_handlers.get(args.command)
+    if handler:
+        return asyncio.run(handler(args))
+    print(f"❌ Unknown command: {args.command}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/app/utils/__init__.py
+++ b/backend/app/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility functions for the application."""

--- a/backend/app/utils/admin_helpers.py
+++ b/backend/app/utils/admin_helpers.py
@@ -41,8 +41,7 @@ async def create_user(
 
     # Check if user already exists
     result = await db.execute(select(User).where(User.external_id == external_id, User.auth_provider == auth_provider))
-    existing_user = result.scalar_one_or_none()
-    if existing_user:
+    if existing_user := result.scalar_one_or_none():
         msg = (
             f"User with external_id '{external_id}' and auth_provider "
             f"'{auth_provider}' already exists (id: {existing_user.id})"
@@ -87,8 +86,7 @@ async def grant_admin(
 
     # Check not already admin
     admin_result = await db.execute(select(AdminUser).where(AdminUser.user_id == user_id))
-    existing_admin = admin_result.scalar_one_or_none()
-    if existing_admin:
+    if existing_admin := admin_result.scalar_one_or_none():
         msg = f"User {user_id} is already an admin with role {existing_admin.role.value}"
         raise ValueError(msg)
 

--- a/backend/app/utils/admin_helpers.py
+++ b/backend/app/utils/admin_helpers.py
@@ -1,0 +1,239 @@
+"""Utility functions for admin user management.
+
+This module provides reusable functions for creating and managing admin users,
+primarily for local development and testing purposes. These functions are used by
+both the CLI tool and test fixtures to maintain DRY principles.
+"""
+
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.admin import AdminRole, AdminUser
+from app.models.user import User
+
+
+async def create_user(
+    db: AsyncSession,
+    external_id: str | None = None,
+    auth_provider: str = "cli",
+) -> User:
+    """
+    Create a new user record.
+
+    Args:
+        db: Database session
+        external_id: Optional external ID (e.g., "auth0|123"). If not provided,
+                     generates "cli|<uuid>"
+        auth_provider: Auth provider name (default: "cli" for CLI-created users)
+
+    Returns:
+        Created User object
+
+    Raises:
+        ValueError: If a user with the same external_id and auth_provider already exists
+    """
+    # Generate external_id if not provided
+    if external_id is None:
+        external_id = f"cli|{uuid.uuid4().hex[:12]}"
+
+    # Check if user already exists
+    result = await db.execute(select(User).where(User.external_id == external_id, User.auth_provider == auth_provider))
+    existing_user = result.scalar_one_or_none()
+    if existing_user:
+        msg = (
+            f"User with external_id '{external_id}' and auth_provider "
+            f"'{auth_provider}' already exists (id: {existing_user.id})"
+        )
+        raise ValueError(msg)
+
+    # Create user
+    user = User(external_id=external_id, auth_provider=auth_provider)
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user
+
+
+async def grant_admin(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    role: AdminRole = AdminRole.ADMIN,
+    granted_by: uuid.UUID | None = None,
+) -> AdminUser:
+    """
+    Grant admin privileges to a user.
+
+    Args:
+        db: Database session
+        user_id: UUID of user to make admin
+        role: Admin role to grant (default: ADMIN)
+        granted_by: User ID who granted admin (optional)
+
+    Returns:
+        Created AdminUser record
+
+    Raises:
+        ValueError: If user doesn't exist or is already an admin
+    """
+    # Check user exists
+    user_result = await db.execute(select(User).where(User.id == user_id))
+    user = user_result.scalar_one_or_none()
+    if not user:
+        msg = f"User with id {user_id} not found"
+        raise ValueError(msg)
+
+    # Check not already admin
+    admin_result = await db.execute(select(AdminUser).where(AdminUser.user_id == user_id))
+    existing_admin = admin_result.scalar_one_or_none()
+    if existing_admin:
+        msg = f"User {user_id} is already an admin with role {existing_admin.role.value}"
+        raise ValueError(msg)
+
+    # Create admin record
+    admin = AdminUser(
+        user_id=user_id,
+        role=role,
+        granted_at=datetime.now(UTC),
+        granted_by=granted_by,
+    )
+    db.add(admin)
+    await db.commit()
+    await db.refresh(admin)
+    return admin
+
+
+async def create_admin_user(
+    db: AsyncSession,
+    external_id: str | None = None,
+    auth_provider: str = "cli",
+    role: AdminRole = AdminRole.ADMIN,
+) -> tuple[User, AdminUser]:
+    """
+    Create a new user and immediately grant admin privileges.
+
+    This is the primary function for creating admin users in local development.
+    It combines user creation and admin grant in a single transaction.
+
+    Args:
+        db: Database session
+        external_id: Optional external ID (e.g., "auth0|123"). If not provided,
+                     generates "cli|<uuid>"
+        auth_provider: Auth provider name (default: "cli" for CLI-created users)
+        role: Admin role to grant (default: ADMIN)
+
+    Returns:
+        Tuple of (User, AdminUser)
+
+    Raises:
+        ValueError: If a user with the same external_id and auth_provider already exists
+    """
+    # Create user
+    user = await create_user(db, external_id=external_id, auth_provider=auth_provider)
+
+    # Grant admin privileges
+    admin = await grant_admin(db, user_id=user.id, role=role, granted_by=None)
+
+    return user, admin
+
+
+async def revoke_admin(db: AsyncSession, user_id: uuid.UUID) -> bool:
+    """
+    Revoke admin privileges from a user.
+
+    Args:
+        db: Database session
+        user_id: UUID of user to remove admin privileges from
+
+    Returns:
+        True if admin was revoked, False if user was not an admin
+
+    Raises:
+        ValueError: If user doesn't exist
+    """
+    # Check user exists
+    result = await db.execute(select(User).where(User.id == user_id))
+    user = result.scalar_one_or_none()
+    if not user:
+        msg = f"User with id {user_id} not found"
+        raise ValueError(msg)
+
+    # Find admin record
+    result = await db.execute(select(AdminUser).where(AdminUser.user_id == user_id))
+    admin = result.scalar_one_or_none()
+    if not admin:
+        return False
+
+    # Delete admin record
+    await db.delete(admin)
+    await db.commit()
+    return True
+
+
+async def list_admin_users(db: AsyncSession) -> list[tuple[User, AdminUser]]:
+    """
+    List all admin users.
+
+    Args:
+        db: Database session
+
+    Returns:
+        List of (User, AdminUser) tuples for all admins
+    """
+    result = await db.execute(
+        select(User, AdminUser).join(AdminUser, User.id == AdminUser.user_id).order_by(AdminUser.granted_at.desc())
+    )
+    return [(row[0], row[1]) for row in result.all()]
+
+
+async def list_users(db: AsyncSession, limit: int = 50, offset: int = 0) -> list[User]:
+    """
+    List all users with pagination.
+
+    Args:
+        db: Database session
+        limit: Maximum number of users to return (default: 50)
+        offset: Number of users to skip (default: 0)
+
+    Returns:
+        List of User objects
+    """
+    result = await db.execute(select(User).order_by(User.created_at.desc()).limit(limit).offset(offset))
+    return list(result.scalars().all())
+
+
+async def get_user_by_id(db: AsyncSession, user_id: uuid.UUID) -> User | None:
+    """
+    Find user by UUID.
+
+    Args:
+        db: Database session
+        user_id: UUID of user to find
+
+    Returns:
+        User object or None if not found
+    """
+    result = await db.execute(select(User).where(User.id == user_id))
+    return result.scalar_one_or_none()
+
+
+async def find_user_by_external_id(
+    db: AsyncSession,
+    external_id: str,
+    auth_provider: str = "auth0",
+) -> User | None:
+    """
+    Find user by external_id (e.g., Auth0 ID).
+
+    Args:
+        db: Database session
+        external_id: External ID to search for (e.g., "auth0|123456")
+        auth_provider: Auth provider name (default: "auth0")
+
+    Returns:
+        User object or None if not found
+    """
+    result = await db.execute(select(User).where(User.external_id == external_id, User.auth_provider == auth_provider))
+    return result.scalar_one_or_none()

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,0 +1,357 @@
+"""Tests for CLI tool.
+
+This module tests the CLI command handlers to ensure proper integration
+with admin_helpers and correct error handling.
+"""
+
+import argparse
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from app.cli import (
+    cmd_create_admin,
+    cmd_create_user,
+    cmd_grant_admin,
+    cmd_list_admins,
+    cmd_list_users,
+    cmd_revoke_admin,
+)
+from app.models.admin import AdminRole
+
+
+@pytest.mark.asyncio
+async def test_cmd_create_admin_success(capsys: pytest.CaptureFixture[str]):
+    """Test create-admin command with default parameters."""
+    args = argparse.Namespace(external_id=None, superadmin=False)
+
+    mock_user = MagicMock(
+        id=uuid.uuid4(),
+        external_id="cli|test123",
+        auth_provider="cli",
+    )
+    mock_admin = MagicMock(
+        role=AdminRole.ADMIN,
+        granted_at="2025-01-01 12:00:00",
+    )
+
+    with patch("app.cli.create_admin_user", new_callable=AsyncMock) as mock_create:
+        mock_create.return_value = (mock_user, mock_admin)
+
+        exit_code = await cmd_create_admin(args)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Created admin user successfully" in captured.out
+    assert str(mock_user.id) in captured.out
+    assert "cli|test123" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_cmd_create_admin_with_custom_external_id(capsys: pytest.CaptureFixture[str]):
+    """Test create-admin command with custom external_id."""
+    args = argparse.Namespace(external_id="auth0|custom", superadmin=False)
+
+    mock_user = MagicMock(
+        id=uuid.uuid4(),
+        external_id="auth0|custom",
+        auth_provider="cli",
+    )
+    mock_admin = MagicMock(
+        role=AdminRole.ADMIN,
+        granted_at="2025-01-01 12:00:00",
+    )
+
+    with patch("app.cli.create_admin_user", new_callable=AsyncMock) as mock_create:
+        mock_create.return_value = (mock_user, mock_admin)
+
+        exit_code = await cmd_create_admin(args)
+
+    assert exit_code == 0
+    mock_create.assert_called_once()
+    call_kwargs = mock_create.call_args[1]
+    assert call_kwargs["external_id"] == "auth0|custom"
+
+
+@pytest.mark.asyncio
+async def test_cmd_create_admin_with_superadmin_role(capsys: pytest.CaptureFixture[str]):
+    """Test create-admin command with superadmin flag."""
+    args = argparse.Namespace(external_id=None, superadmin=True)
+
+    mock_user = MagicMock(id=uuid.uuid4(), external_id="cli|test", auth_provider="cli")
+    mock_admin = MagicMock(role=AdminRole.SUPERADMIN, granted_at="2025-01-01 12:00:00")
+
+    with patch("app.cli.create_admin_user", new_callable=AsyncMock) as mock_create:
+        mock_create.return_value = (mock_user, mock_admin)
+
+        exit_code = await cmd_create_admin(args)
+
+    assert exit_code == 0
+    call_kwargs = mock_create.call_args[1]
+    assert call_kwargs["role"] == AdminRole.SUPERADMIN
+
+
+@pytest.mark.asyncio
+async def test_cmd_create_admin_duplicate_error(capsys: pytest.CaptureFixture[str]):
+    """Test create-admin command with duplicate external_id."""
+    args = argparse.Namespace(external_id="auth0|duplicate", superadmin=False)
+
+    with patch("app.cli.create_admin_user", new_callable=AsyncMock) as mock_create:
+        mock_create.side_effect = ValueError("User already exists")
+
+        exit_code = await cmd_create_admin(args)
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Error" in captured.err
+    assert "User already exists" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_cmd_create_user_success(capsys: pytest.CaptureFixture[str]):
+    """Test create-user command."""
+    args = argparse.Namespace(external_id=None)
+
+    mock_user = MagicMock(
+        id=uuid.uuid4(),
+        external_id="cli|user123",
+        auth_provider="cli",
+        created_at="2025-01-01 12:00:00",
+    )
+
+    with patch("app.cli.create_user", new_callable=AsyncMock) as mock_create:
+        mock_create.return_value = mock_user
+
+        exit_code = await cmd_create_user(args)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Created user successfully" in captured.out
+    assert str(mock_user.id) in captured.out
+
+
+@pytest.mark.asyncio
+async def test_cmd_grant_admin_by_uuid_success(capsys: pytest.CaptureFixture[str]):
+    """Test grant-admin command using UUID."""
+    user_id = uuid.uuid4()
+    args = argparse.Namespace(
+        identifier=str(user_id),
+        external_id=False,
+        provider="auth0",
+        superadmin=False,
+    )
+
+    mock_admin = MagicMock(role=AdminRole.ADMIN, granted_at="2025-01-01 12:00:00")
+    mock_user = MagicMock(id=user_id, external_id="auth0|test", auth_provider="auth0")
+
+    with (
+        patch("app.cli.grant_admin", new_callable=AsyncMock) as mock_grant,
+        patch("app.cli.get_user_by_id", new_callable=AsyncMock) as mock_get,
+    ):
+        mock_grant.return_value = mock_admin
+        mock_get.return_value = mock_user
+
+        exit_code = await cmd_grant_admin(args)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Granted admin privileges successfully" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_cmd_grant_admin_by_external_id_success(capsys: pytest.CaptureFixture[str]):
+    """Test grant-admin command using external_id."""
+    user_id = uuid.uuid4()
+    args = argparse.Namespace(
+        identifier="auth0|test123",
+        external_id=True,
+        provider="auth0",
+        superadmin=False,
+    )
+
+    mock_user = MagicMock(id=user_id, external_id="auth0|test123", auth_provider="auth0")
+    mock_admin = MagicMock(role=AdminRole.ADMIN, granted_at="2025-01-01 12:00:00")
+
+    with (
+        patch("app.cli.find_user_by_external_id", new_callable=AsyncMock) as mock_find,
+        patch("app.cli.grant_admin", new_callable=AsyncMock) as mock_grant,
+        patch("app.cli.get_user_by_id", new_callable=AsyncMock) as mock_get,
+    ):
+        mock_find.return_value = mock_user
+        mock_grant.return_value = mock_admin
+        mock_get.return_value = mock_user
+
+        exit_code = await cmd_grant_admin(args)
+
+    assert exit_code == 0
+
+
+@pytest.mark.asyncio
+async def test_cmd_grant_admin_invalid_uuid(capsys: pytest.CaptureFixture[str]):
+    """Test grant-admin command with invalid UUID."""
+    args = argparse.Namespace(
+        identifier="not-a-uuid",
+        external_id=False,
+        provider="auth0",
+        superadmin=False,
+    )
+
+    exit_code = await cmd_grant_admin(args)
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "Invalid UUID" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_cmd_grant_admin_user_not_found_by_external_id(capsys: pytest.CaptureFixture[str]):
+    """Test grant-admin when user not found by external_id."""
+    args = argparse.Namespace(
+        identifier="auth0|notfound",
+        external_id=True,
+        provider="auth0",
+        superadmin=False,
+    )
+
+    with patch("app.cli.find_user_by_external_id", new_callable=AsyncMock) as mock_find:
+        mock_find.return_value = None
+
+        exit_code = await cmd_grant_admin(args)
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "not found" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_cmd_revoke_admin_success(capsys: pytest.CaptureFixture[str]):
+    """Test revoke-admin command."""
+    user_id = uuid.uuid4()
+    args = argparse.Namespace(
+        identifier=str(user_id),
+        external_id=False,
+        provider="auth0",
+    )
+
+    with patch("app.cli.revoke_admin", new_callable=AsyncMock) as mock_revoke:
+        mock_revoke.return_value = True
+
+        exit_code = await cmd_revoke_admin(args)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Revoked admin privileges" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_cmd_revoke_admin_not_admin(capsys: pytest.CaptureFixture[str]):
+    """Test revoke-admin when user is not an admin."""
+    user_id = uuid.uuid4()
+    args = argparse.Namespace(
+        identifier=str(user_id),
+        external_id=False,
+        provider="auth0",
+    )
+
+    with patch("app.cli.revoke_admin", new_callable=AsyncMock) as mock_revoke:
+        mock_revoke.return_value = False
+
+        exit_code = await cmd_revoke_admin(args)
+
+    assert exit_code == 0  # Still returns 0, but with different message
+    captured = capsys.readouterr()
+    assert "was not an admin" in captured.err
+
+
+@pytest.mark.asyncio
+async def test_cmd_list_admins_empty(capsys: pytest.CaptureFixture[str]):
+    """Test list-admins command with no admins."""
+    args = argparse.Namespace()
+
+    with patch("app.cli.list_admin_users", new_callable=AsyncMock) as mock_list:
+        mock_list.return_value = []
+
+        exit_code = await cmd_list_admins(args)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "No admin users found" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_cmd_list_admins_with_admins(capsys: pytest.CaptureFixture[str]):
+    """Test list-admins command with admins."""
+    args = argparse.Namespace()
+
+    mock_user = MagicMock(
+        id=uuid.uuid4(),
+        external_id="auth0|admin1",
+    )
+    mock_admin = MagicMock(
+        role=AdminRole.ADMIN,
+        granted_at=MagicMock(strftime=lambda fmt: "2025-01-01 12:00:00"),
+    )
+
+    with patch("app.cli.list_admin_users", new_callable=AsyncMock) as mock_list:
+        mock_list.return_value = [(mock_user, mock_admin)]
+
+        exit_code = await cmd_list_admins(args)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Found 1 admin user" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_cmd_list_users_empty(capsys: pytest.CaptureFixture[str]):
+    """Test list-users command with no users."""
+    args = argparse.Namespace(limit=50, offset=0)
+
+    with patch("app.cli.list_users", new_callable=AsyncMock) as mock_list:
+        mock_list.return_value = []
+
+        exit_code = await cmd_list_users(args)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "No users found" in captured.out
+
+
+@pytest.mark.asyncio
+async def test_cmd_list_users_with_users(capsys: pytest.CaptureFixture[str]):
+    """Test list-users command with users."""
+    args = argparse.Namespace(limit=50, offset=0)
+
+    mock_user = MagicMock(
+        id=uuid.uuid4(),
+        external_id="cli|user1",
+        auth_provider="cli",
+        created_at=MagicMock(strftime=lambda fmt: "2025-01-01 12:00:00"),
+    )
+
+    with patch("app.cli.list_users", new_callable=AsyncMock) as mock_list:
+        mock_list.return_value = [mock_user]
+
+        exit_code = await cmd_list_users(args)
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "Showing 1 user(s)" in captured.out
+    assert str(mock_user.id) in captured.out
+
+
+@pytest.mark.asyncio
+async def test_cmd_list_users_with_pagination(capsys: pytest.CaptureFixture[str]):
+    """Test list-users command with custom limit and offset."""
+    args = argparse.Namespace(limit=20, offset=10)
+
+    with patch("app.cli.list_users", new_callable=AsyncMock) as mock_list:
+        mock_list.return_value = []
+
+        exit_code = await cmd_list_users(args)
+
+    assert exit_code == 0
+    mock_list.assert_called_once()
+    call_kwargs = mock_list.call_args[1]
+    assert call_kwargs["limit"] == 20
+    assert call_kwargs["offset"] == 10

--- a/backend/tests/utils/__init__.py
+++ b/backend/tests/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for utility functions."""

--- a/backend/tests/utils/test_admin_helpers.py
+++ b/backend/tests/utils/test_admin_helpers.py
@@ -1,0 +1,451 @@
+"""Tests for admin helper utility functions.
+
+This module tests all functions in app/utils/admin_helpers.py to ensure 100% coverage
+and validate correct behavior for admin user management operations.
+"""
+
+import uuid
+
+import pytest
+from app.models.admin import AdminRole, AdminUser
+from app.models.user import User
+from app.utils.admin_helpers import (
+    create_admin_user,
+    create_user,
+    find_user_by_external_id,
+    get_user_by_id,
+    grant_admin,
+    list_admin_users,
+    list_users,
+    revoke_admin,
+)
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Test create_user function
+
+
+@pytest.mark.asyncio
+async def test_create_user_with_default_values(db_session: AsyncSession):
+    """Test creating a user with default external_id and auth_provider."""
+    user = await create_user(db_session)
+
+    assert user.id is not None
+    assert user.external_id.startswith("cli|")
+    assert user.auth_provider == "cli"
+    assert user.created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_create_user_with_custom_external_id(db_session: AsyncSession):
+    """Test creating a user with custom external_id."""
+    custom_id = "auth0|custom123"
+    user = await create_user(db_session, external_id=custom_id, auth_provider="auth0")
+
+    assert user.external_id == custom_id
+    assert user.auth_provider == "auth0"
+
+
+@pytest.mark.asyncio
+async def test_create_user_duplicate_external_id_raises_error(db_session: AsyncSession):
+    """Test that creating a user with duplicate external_id raises ValueError."""
+    external_id = "auth0|duplicate"
+
+    # Create first user
+    await create_user(db_session, external_id=external_id, auth_provider="auth0")
+
+    # Attempt to create duplicate - should raise ValueError
+    with pytest.raises(ValueError, match=r".*") as exc_info:
+        await create_user(db_session, external_id=external_id, auth_provider="auth0")
+
+    assert "already exists" in str(exc_info.value)
+    assert external_id in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_create_user_same_external_id_different_provider_succeeds(
+    db_session: AsyncSession,
+):
+    """Test that same external_id with different provider creates separate users."""
+    external_id = "user123"
+
+    # Create user with auth0 provider
+    user1 = await create_user(db_session, external_id=external_id, auth_provider="auth0")
+
+    # Create user with cli provider (same external_id, different provider)
+    user2 = await create_user(db_session, external_id=external_id, auth_provider="cli")
+
+    assert user1.id != user2.id
+    assert user1.external_id == user2.external_id
+    assert user1.auth_provider != user2.auth_provider
+
+
+# Test grant_admin function
+
+
+@pytest.mark.asyncio
+async def test_grant_admin_to_existing_user(db_session: AsyncSession, test_user: User):
+    """Test granting admin privileges to an existing user."""
+    admin = await grant_admin(db_session, user_id=test_user.id)
+
+    assert admin.id is not None
+    assert admin.user_id == test_user.id
+    assert admin.role == AdminRole.ADMIN
+    assert admin.granted_at is not None
+    assert admin.granted_by is None
+
+
+@pytest.mark.asyncio
+async def test_grant_admin_with_superadmin_role(db_session: AsyncSession, test_user: User):
+    """Test granting superadmin role."""
+    admin = await grant_admin(db_session, user_id=test_user.id, role=AdminRole.SUPERADMIN)
+
+    assert admin.role == AdminRole.SUPERADMIN
+
+
+@pytest.mark.asyncio
+async def test_grant_admin_with_granted_by(db_session: AsyncSession):
+    """Test granting admin with granted_by field set."""
+    # Create granter user
+    granter = await create_user(db_session, external_id="granter|123")
+
+    # Create grantee user
+    grantee = await create_user(db_session, external_id="grantee|123")
+
+    # Grant admin with granted_by
+    admin = await grant_admin(db_session, user_id=grantee.id, granted_by=granter.id)
+
+    assert admin.granted_by == granter.id
+
+
+@pytest.mark.asyncio
+async def test_grant_admin_to_nonexistent_user_raises_error(db_session: AsyncSession):
+    """Test that granting admin to non-existent user raises ValueError."""
+    fake_id = uuid.uuid4()
+
+    with pytest.raises(ValueError, match=r".*") as exc_info:
+        await grant_admin(db_session, user_id=fake_id)
+
+    assert "not found" in str(exc_info.value)
+    assert str(fake_id) in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_grant_admin_to_existing_admin_raises_error(db_session: AsyncSession, test_user: User):
+    """Test that granting admin to already-admin user raises ValueError."""
+    # Grant admin first time
+    await grant_admin(db_session, user_id=test_user.id)
+
+    # Attempt to grant again - should raise ValueError
+    with pytest.raises(ValueError, match=r".*") as exc_info:
+        await grant_admin(db_session, user_id=test_user.id)
+
+    assert "already an admin" in str(exc_info.value)
+
+
+# Test create_admin_user function
+
+
+@pytest.mark.asyncio
+async def test_create_admin_user_with_defaults(db_session: AsyncSession):
+    """Test creating an admin user with default values."""
+    user, admin = await create_admin_user(db_session)
+
+    assert user.id is not None
+    assert user.external_id.startswith("cli|")
+    assert user.auth_provider == "cli"
+    assert admin.user_id == user.id
+    assert admin.role == AdminRole.ADMIN
+
+
+@pytest.mark.asyncio
+async def test_create_admin_user_with_custom_values(db_session: AsyncSession):
+    """Test creating an admin user with custom external_id and role."""
+    external_id = "auth0|admin123"
+    user, admin = await create_admin_user(
+        db_session,
+        external_id=external_id,
+        auth_provider="auth0",
+        role=AdminRole.SUPERADMIN,
+    )
+
+    assert user.external_id == external_id
+    assert user.auth_provider == "auth0"
+    assert admin.role == AdminRole.SUPERADMIN
+
+
+@pytest.mark.asyncio
+async def test_create_admin_user_duplicate_external_id_raises_error(
+    db_session: AsyncSession,
+):
+    """Test that creating admin user with duplicate external_id raises ValueError."""
+    external_id = "auth0|duplicate_admin"
+
+    # Create first admin user
+    await create_admin_user(db_session, external_id=external_id, auth_provider="auth0")
+
+    # Attempt to create duplicate - should raise ValueError
+    with pytest.raises(ValueError, match=r".*") as exc_info:
+        await create_admin_user(db_session, external_id=external_id, auth_provider="auth0")
+
+    assert "already exists" in str(exc_info.value)
+
+
+# Test revoke_admin function
+
+
+@pytest.mark.asyncio
+async def test_revoke_admin_from_admin_user(db_session: AsyncSession, test_user: User):
+    """Test revoking admin privileges from an admin user."""
+    # Grant admin first
+    await grant_admin(db_session, user_id=test_user.id)
+
+    # Revoke admin
+    was_revoked = await revoke_admin(db_session, user_id=test_user.id)
+
+    assert was_revoked is True
+
+    # Verify admin record is deleted
+    result = await db_session.execute(select(AdminUser).where(AdminUser.user_id == test_user.id))
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_revoke_admin_from_non_admin_user(db_session: AsyncSession, test_user: User):
+    """Test revoking admin from a user who is not an admin."""
+    was_revoked = await revoke_admin(db_session, user_id=test_user.id)
+
+    assert was_revoked is False
+
+
+@pytest.mark.asyncio
+async def test_revoke_admin_from_nonexistent_user_raises_error(db_session: AsyncSession):
+    """Test that revoking admin from non-existent user raises ValueError."""
+    fake_id = uuid.uuid4()
+
+    with pytest.raises(ValueError, match=r".*") as exc_info:
+        await revoke_admin(db_session, user_id=fake_id)
+
+    assert "not found" in str(exc_info.value)
+
+
+# Test list_admin_users function
+
+
+@pytest.mark.asyncio
+async def test_list_admin_users_empty(db_session: AsyncSession):
+    """Test listing admin users when there are none."""
+    admins = await list_admin_users(db_session)
+
+    assert admins == []
+
+
+@pytest.mark.asyncio
+async def test_list_admin_users_single(db_session: AsyncSession):
+    """Test listing admin users with one admin."""
+    user, admin = await create_admin_user(db_session)
+
+    admins = await list_admin_users(db_session)
+
+    assert len(admins) == 1
+    assert admins[0][0].id == user.id
+    assert admins[0][1].id == admin.id
+
+
+@pytest.mark.asyncio
+async def test_list_admin_users_multiple(db_session: AsyncSession):
+    """Test listing multiple admin users."""
+    # Create 3 admin users
+    user1, _admin1 = await create_admin_user(db_session, external_id="admin1")
+    user2, _admin2 = await create_admin_user(db_session, external_id="admin2")
+    user3, _admin3 = await create_admin_user(db_session, external_id="admin3", role=AdminRole.SUPERADMIN)
+
+    admins = await list_admin_users(db_session)
+
+    assert len(admins) == 3
+
+    # Extract user IDs from results
+    admin_user_ids = {admin_tuple[0].id for admin_tuple in admins}
+    assert user1.id in admin_user_ids
+    assert user2.id in admin_user_ids
+    assert user3.id in admin_user_ids
+
+
+@pytest.mark.asyncio
+async def test_list_admin_users_ordered_by_granted_at(db_session: AsyncSession):
+    """Test that admin users are ordered by granted_at descending (newest first)."""
+    # Create admin users sequentially
+    user1, _admin1 = await create_admin_user(db_session, external_id="admin1")
+    user2, _admin2 = await create_admin_user(db_session, external_id="admin2")
+    user3, _admin3 = await create_admin_user(db_session, external_id="admin3")
+
+    admins = await list_admin_users(db_session)
+
+    # Should be ordered newest first
+    assert admins[0][0].id == user3.id
+    assert admins[1][0].id == user2.id
+    assert admins[2][0].id == user1.id
+
+
+# Test list_users function
+
+
+@pytest.mark.asyncio
+async def test_list_users_empty(db_session: AsyncSession):
+    """Test listing users when there are none."""
+    users = await list_users(db_session)
+
+    assert users == []
+
+
+@pytest.mark.asyncio
+async def test_list_users_single(db_session: AsyncSession, test_user: User):
+    """Test listing users with one user."""
+    users = await list_users(db_session)
+
+    assert len(users) == 1
+    assert users[0].id == test_user.id
+
+
+@pytest.mark.asyncio
+async def test_list_users_multiple(db_session: AsyncSession):
+    """Test listing multiple users."""
+    # Create 5 users
+    user1 = await create_user(db_session, external_id="user1")
+    user2 = await create_user(db_session, external_id="user2")
+    user3 = await create_user(db_session, external_id="user3")
+    user4 = await create_user(db_session, external_id="user4")
+    user5 = await create_user(db_session, external_id="user5")
+
+    users = await list_users(db_session)
+
+    assert len(users) == 5
+
+    # Extract user IDs
+    user_ids = {user.id for user in users}
+    assert user1.id in user_ids
+    assert user2.id in user_ids
+    assert user3.id in user_ids
+    assert user4.id in user_ids
+    assert user5.id in user_ids
+
+
+@pytest.mark.asyncio
+async def test_list_users_with_limit(db_session: AsyncSession):
+    """Test listing users with limit parameter."""
+    # Create 10 users
+    for i in range(10):
+        await create_user(db_session, external_id=f"user{i}")
+
+    users = await list_users(db_session, limit=5)
+
+    assert len(users) == 5
+
+
+@pytest.mark.asyncio
+async def test_list_users_with_offset(db_session: AsyncSession):
+    """Test listing users with offset parameter."""
+    # Create 10 users
+    created_users = []
+    for i in range(10):
+        user = await create_user(db_session, external_id=f"user{i}")
+        created_users.append(user)
+
+    # Get first page
+    first_page = await list_users(db_session, limit=5, offset=0)
+    # Get second page
+    second_page = await list_users(db_session, limit=5, offset=5)
+
+    assert len(first_page) == 5
+    assert len(second_page) == 5
+
+    # Ensure no overlap (users are ordered by created_at desc, so newest first)
+    first_page_ids = {user.id for user in first_page}
+    second_page_ids = {user.id for user in second_page}
+    assert len(first_page_ids & second_page_ids) == 0
+
+
+@pytest.mark.asyncio
+async def test_list_users_ordered_by_created_at(db_session: AsyncSession):
+    """Test that users are ordered by created_at descending (newest first)."""
+    # Create users sequentially
+    user1 = await create_user(db_session, external_id="user1")
+    user2 = await create_user(db_session, external_id="user2")
+    user3 = await create_user(db_session, external_id="user3")
+
+    users = await list_users(db_session)
+
+    # Should be ordered newest first
+    assert users[0].id == user3.id
+    assert users[1].id == user2.id
+    assert users[2].id == user1.id
+
+
+# Test get_user_by_id function
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_id_existing_user(db_session: AsyncSession, test_user: User):
+    """Test getting an existing user by ID."""
+    user = await get_user_by_id(db_session, test_user.id)
+
+    assert user is not None
+    assert user.id == test_user.id
+
+
+@pytest.mark.asyncio
+async def test_get_user_by_id_nonexistent_user(db_session: AsyncSession):
+    """Test getting a non-existent user by ID returns None."""
+    fake_id = uuid.uuid4()
+    user = await get_user_by_id(db_session, fake_id)
+
+    assert user is None
+
+
+# Test find_user_by_external_id function
+
+
+@pytest.mark.asyncio
+async def test_find_user_by_external_id_existing_user(db_session: AsyncSession):
+    """Test finding an existing user by external_id."""
+    external_id = "auth0|findme123"
+    created_user = await create_user(db_session, external_id=external_id, auth_provider="auth0")
+
+    user = await find_user_by_external_id(db_session, external_id, auth_provider="auth0")
+
+    assert user is not None
+    assert user.id == created_user.id
+    assert user.external_id == external_id
+
+
+@pytest.mark.asyncio
+async def test_find_user_by_external_id_nonexistent_user(db_session: AsyncSession):
+    """Test finding a non-existent user by external_id returns None."""
+    user = await find_user_by_external_id(db_session, "nonexistent|123", auth_provider="auth0")
+
+    assert user is None
+
+
+@pytest.mark.asyncio
+async def test_find_user_by_external_id_wrong_provider(db_session: AsyncSession):
+    """Test finding a user with correct external_id but wrong provider returns None."""
+    external_id = "user123"
+    await create_user(db_session, external_id=external_id, auth_provider="auth0")
+
+    # Search with wrong provider
+    user = await find_user_by_external_id(db_session, external_id, auth_provider="cli")
+
+    assert user is None
+
+
+@pytest.mark.asyncio
+async def test_find_user_by_external_id_default_auth0_provider(db_session: AsyncSession):
+    """Test that find_user_by_external_id defaults to auth0 provider."""
+    external_id = "auth0|default123"
+    created_user = await create_user(db_session, external_id=external_id, auth_provider="auth0")
+
+    # Call without auth_provider argument (should default to "auth0")
+    user = await find_user_by_external_id(db_session, external_id)
+
+    assert user is not None
+    assert user.id == created_user.id

--- a/docs/adr/10-testing.md
+++ b/docs/adr/10-testing.md
@@ -169,3 +169,27 @@ Use `fresh_db_session` fixture which creates a new database per test with Alembi
 - Much slower tests (~2s per test vs ~0.1s)
 - Should only be used when necessary (not for all tests)
 - Need separate fixture (`fresh_db_session` vs `db_session`)
+
+---
+
+## Admin User Creation CLI Tool
+
+### Status
+Active
+
+### Context
+Testing admin-only functionality requires creating admin users. Manually running SQL commands is error-prone and doesn't follow DRY principles. Test fixtures contain reusable logic that should be available outside tests.
+
+### Decision
+Created CLI tool (`uv run python -m app.cli`) for admin user management with shared utility functions in `backend/app/utils/admin_helpers.py`. Primary command is `create-admin` which creates an admin user in one step. The `admin_user` fixture uses these shared helpers to maintain DRY principles.
+
+### Consequences
+**Easier:**
+- Create admin users with single CLI command (no SQL required)
+- Shared logic between CLI and test fixtures (DRY)
+- Frontend developers can create admin users for testing
+- Type-safe with comprehensive error handling
+
+**More Difficult:**
+- Must remember to use CLI tool instead of manual SQL
+- CLI requires running from backend directory with `uv run`


### PR DESCRIPTION
- Introduced utility functions for admin user management in `backend/app/utils/admin_helpers.py`.
- Implemented functions to create, grant, revoke admin privileges, and list users and admins.
- Created a new CLI tool for managing admin users, allowing for easy creation and management via commands.
- Added comprehensive tests for the new utility functions and CLI commands to ensure correct behavior and coverage.
- Updated documentation to reflect the new CLI tool and its usage for admin user creation.

closes #159

## Summary by Sourcery

Add shared utilities and a CLI for admin user management in local development, update documentation accordingly, and include comprehensive tests to ensure correct behavior

New Features:
- Add utility functions for creating, granting, revoking, and listing admin users in app/utils/admin_helpers.py
- Introduce a CLI tool with commands for create-user, create-admin, grant-admin, revoke-admin, list-users, and list-admins

Enhancements:
- Refactor test fixtures to use shared grant_admin helper for DRY admin user setup

Documentation:
- Update README with CLI usage instructions for admin user management
- Add an ADR detailing the design and rationale of the admin user creation CLI tool

Tests:
- Add unit tests for admin_helpers covering user creation, admin grant/revoke, and listing functions
- Add integration tests for CLI commands to validate admin_helpers integration and error handling