### PR TITLE
feat: implement line disruption state logging and related tests

### DIFF
--- a/backend/alembic/versions/8ed2312f54f3_add_line_disruption_state_logs_table.py
+++ b/backend/alembic/versions/8ed2312f54f3_add_line_disruption_state_logs_table.py
@@ -1,0 +1,77 @@
+"""add_line_disruption_state_logs_table
+
+Revision ID: 8ed2312f54f3
+Revises: dbef0183286a
+Create Date: 2025-11-17 09:06:25.445431
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "8ed2312f54f3"
+down_revision: str | Sequence[str] | None = "dbef0183286a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Create line_disruption_state_logs table
+    op.create_table(
+        "line_disruption_state_logs",
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column(
+            "line_id", sa.String(length=50), nullable=False, comment="TfL line ID (e.g., 'bakerloo', 'victoria')"
+        ),
+        sa.Column(
+            "status_severity_description",
+            sa.String(length=100),
+            nullable=False,
+            comment="Disruption status (e.g., 'Good Service', 'Minor Delays', 'Severe Delays')",
+        ),
+        sa.Column(
+            "reason",
+            sa.String(length=1000),
+            nullable=True,
+            comment="Full disruption reason text (nullable for good service)",
+        ),
+        sa.Column(
+            "state_hash",
+            sa.String(length=64),
+            nullable=False,
+            comment="SHA256 hash of {line_id, status, reason} for deduplication",
+        ),
+        sa.Column(
+            "detected_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            comment="When this state was detected by the alert service",
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # Create indexes
+    op.create_index("ix_line_disruption_state_logs_line_id", "line_disruption_state_logs", ["line_id"])
+    op.create_index("ix_line_disruption_state_logs_state_hash", "line_disruption_state_logs", ["state_hash"])
+    op.create_index("ix_line_disruption_state_logs_detected_at", "line_disruption_state_logs", ["detected_at"])
+    # Composite index for querying recent states for a line
+    op.create_index("ix_line_disruption_logs_line_detected", "line_disruption_state_logs", ["line_id", "detected_at"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Drop indexes
+    op.drop_index("ix_line_disruption_logs_line_detected", table_name="line_disruption_state_logs")
+    op.drop_index("ix_line_disruption_state_logs_detected_at", table_name="line_disruption_state_logs")
+    op.drop_index("ix_line_disruption_state_logs_state_hash", table_name="line_disruption_state_logs")
+    op.drop_index("ix_line_disruption_state_logs_line_id", table_name="line_disruption_state_logs")
+
+    # Drop table
+    op.drop_table("line_disruption_state_logs")

--- a/backend/app/celery/app.py
+++ b/backend/app/celery/app.py
@@ -39,4 +39,10 @@ celery_app.conf.update(
 
 # Import tasks to register them with Celery
 # This must come after celery_app is created so tasks can use the @celery_app.task decorator
-from app.celery import tasks  # noqa: E402, F401
+# Import schedules to configure Celery Beat
+# CRITICAL: This import must remain - it populates celery_app.conf.beat_schedule
+# Removing this import will break all periodic tasks (Issue #167)
+from app.celery import (  # noqa: E402
+    schedules,  # noqa: F401
+    tasks,  # noqa: F401
+)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -13,7 +13,7 @@ from app.models.notification import (
 from app.models.rate_limit import RateLimitAction, RateLimitLog
 from app.models.route import Route, RouteSchedule, RouteSegment
 from app.models.route_index import RouteStationIndex
-from app.models.tfl import Line, Station, StationConnection
+from app.models.tfl import Line, LineDisruptionStateLog, Station, StationConnection
 from app.models.user import (
     EmailAddress,
     PhoneNumber,
@@ -37,6 +37,7 @@ __all__ = [
     "RateLimitAction",
     # TfL models
     "Line",
+    "LineDisruptionStateLog",
     "Station",
     "StationConnection",
     # Route models

--- a/backend/app/services/alert_service.py
+++ b/backend/app/services/alert_service.py
@@ -22,7 +22,7 @@ from app.models.notification import (
 )
 from app.models.route import Route, RouteSchedule
 from app.models.route_index import RouteStationIndex
-from app.models.tfl import Line
+from app.models.tfl import Line, LineDisruptionStateLog
 from app.models.user import EmailAddress, PhoneNumber, User
 from app.schemas.tfl import DisruptionResponse
 from app.services.notification_service import NotificationService
@@ -32,6 +32,36 @@ logger = structlog.get_logger(__name__)
 
 
 # Pure helper functions for testability
+def create_line_state_hash(line_id: str, status: str, reason: str | None) -> str:
+    """
+    Create SHA256 hash of line disruption state for deduplication.
+
+    Pure function for easy testing without database dependencies.
+
+    Args:
+        line_id: TfL line ID (e.g., "bakerloo", "victoria")
+        status: Disruption status (e.g., "Good Service", "Minor Delays")
+        reason: Disruption reason text (nullable for good service)
+
+    Returns:
+        SHA256 hash string (64 characters)
+
+    Example:
+        >>> create_line_state_hash("bakerloo", "Minor Delays", "Signal failure")
+        'abc123...'  # 64-character hex string
+        >>> create_line_state_hash("victoria", "Good Service", None)
+        'def456...'  # Different hash for different state
+    """
+    # Normalize null/empty reason to empty string for consistent hashing
+    normalized_reason = reason or ""
+
+    # Create hash input string
+    hash_input = f"{line_id}|{status}|{normalized_reason}"
+
+    # Return SHA256 hex digest
+    return hashlib.sha256(hash_input.encode("utf-8")).hexdigest()
+
+
 def extract_line_station_pairs(disruption: DisruptionResponse) -> list[tuple[str, str]]:
     """
     Extract (line_id, station_naptan) tuples from disruption data.
@@ -156,6 +186,105 @@ class AlertService:
         self.db = db
         self.redis_client = redis_client
 
+    async def _log_line_disruption_state_changes(
+        self,
+        disruptions: list[DisruptionResponse],
+    ) -> int:
+        """
+        Log line disruption state changes to database for troubleshooting and analytics.
+
+        Only logs when state changes (different hash from last logged state for that line).
+        Uses pure function create_line_state_hash() for testability.
+
+        Args:
+            disruptions: List of current disruptions from TfL API
+
+        Returns:
+            Number of state changes logged (new log entries created)
+
+        Example:
+            >>> # First call with disruption
+            >>> await service._log_line_disruption_state_changes([disruption])
+            1  # Logged because first state
+            >>> # Second call with same disruption
+            >>> await service._log_line_disruption_state_changes([disruption])
+            0  # Not logged because hash unchanged
+            >>> # Third call with different disruption status
+            >>> await service._log_line_disruption_state_changes([updated_disruption])
+            1  # Logged because hash changed
+        """
+        try:
+            logged_count = 0
+
+            # Get all lines to log "Good Service" for lines with no disruptions
+            # This is optional - we can skip it to reduce write volume
+            # For now, only log lines that have disruptions (YAGNI principle)
+
+            for disruption in disruptions:
+                line_id = disruption.line_id
+                status = disruption.status_severity_description
+                # Combine all reasons into single text if multiple exist
+                reason = disruption.reason or None
+
+                # Calculate state hash
+                state_hash = create_line_state_hash(line_id, status, reason)
+
+                # Check if last logged state for this line has the same hash
+                # Query: SELECT state_hash FROM line_disruption_state_logs
+                # WHERE line_id = ? ORDER BY detected_at DESC LIMIT 1
+                result = await self.db.execute(
+                    select(LineDisruptionStateLog.state_hash)
+                    .where(LineDisruptionStateLog.line_id == line_id)
+                    .order_by(LineDisruptionStateLog.detected_at.desc())
+                    .limit(1)
+                )
+                last_state_row = result.first()
+                last_state_hash = last_state_row[0] if last_state_row else None
+
+                # Only log if state changed (or no previous state exists)
+                if state_hash != last_state_hash:
+                    # Create new log entry
+                    new_log = LineDisruptionStateLog(
+                        line_id=line_id,
+                        status_severity_description=status,
+                        reason=reason,
+                        state_hash=state_hash,
+                        detected_at=datetime.now(UTC),
+                    )
+                    self.db.add(new_log)
+                    logged_count += 1
+
+                    logger.info(
+                        "line_disruption_state_changed",
+                        line_id=line_id,
+                        status=status,
+                        previous_hash=last_state_hash,
+                        new_hash=state_hash,
+                    )
+                else:
+                    logger.debug(
+                        "line_disruption_state_unchanged",
+                        line_id=line_id,
+                        status=status,
+                        state_hash=state_hash,
+                    )
+
+            # Commit all new log entries
+            if logged_count > 0:
+                await self.db.commit()
+                logger.info("line_disruption_states_logged", count=logged_count)
+
+            return logged_count
+
+        except Exception as e:
+            logger.error(
+                "log_line_disruption_states_failed",
+                error=str(e),
+                exc_info=e,
+            )
+            # Don't raise - logging failures shouldn't block alert processing
+            return 0
+
     async def process_all_routes(self) -> dict[str, Any]:
         """
         Main entry point for processing all active routes.
@@ -177,6 +306,25 @@ class AlertService:
         try:
             routes = await self._get_active_routes()
             logger.info("active_routes_fetched", count=len(routes))
+
+            # Fetch all line disruptions once and log state changes
+            # Uses cache automatically, so subsequent per-route calls will be fast
+            # Errors here are non-fatal - per-route processing will still work
+            try:
+                tfl_service = TfLService(db=self.db)
+                all_disruptions = await tfl_service.fetch_line_disruptions(use_cache=True)
+                logger.info("all_disruptions_fetched", count=len(all_disruptions))
+
+                # Log line disruption state changes (for troubleshooting and analytics)
+                await self._log_line_disruption_state_changes(all_disruptions)
+            except Exception as e:
+                logger.error(
+                    "disruption_logging_failed",
+                    error=str(e),
+                    exc_info=e,
+                )
+                # Don't track as error - per-route processing will handle its own disruptions
+                # This is just for centralized logging
 
             for route in routes:
                 try:

--- a/backend/tests/test_alert_service.py
+++ b/backend/tests/test_alert_service.py
@@ -20,10 +20,15 @@ from app.models.notification import (
 )
 from app.models.route import Route, RouteSchedule, RouteSegment
 from app.models.route_index import RouteStationIndex
-from app.models.tfl import Line, Station
+from app.models.tfl import Line, LineDisruptionStateLog, Station
 from app.models.user import EmailAddress, PhoneNumber, User
 from app.schemas.tfl import AffectedRouteInfo, DisruptionResponse
-from app.services.alert_service import AlertService, extract_line_station_pairs, get_redis_client
+from app.services.alert_service import (
+    AlertService,
+    create_line_state_hash,
+    extract_line_station_pairs,
+    get_redis_client,
+)
 from freezegun import freeze_time
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -2632,3 +2637,289 @@ class TestPerformance:
         assert elapsed_ms < index_perf_threshold, (
             f"Index query took {elapsed_ms:.2f}ms (expected < {index_perf_threshold}ms)"
         )
+
+
+class TestLineDisruptionStateLogging:
+    """Tests for line disruption state logging functionality."""
+
+    def test_create_line_state_hash_pure_function(self):
+        """Test that create_line_state_hash produces consistent hashes."""
+        # Same inputs should produce same hash
+        hash1 = create_line_state_hash("bakerloo", "Minor Delays", "Signal failure")
+        hash2 = create_line_state_hash("bakerloo", "Minor Delays", "Signal failure")
+        assert hash1 == hash2
+
+        # Different inputs should produce different hashes
+        hash3 = create_line_state_hash("bakerloo", "Severe Delays", "Signal failure")
+        assert hash1 != hash3
+
+        hash4 = create_line_state_hash("victoria", "Minor Delays", "Signal failure")
+        assert hash1 != hash4
+
+        hash5 = create_line_state_hash("bakerloo", "Minor Delays", "Track fault")
+        assert hash1 != hash5
+
+        # Hash should be 64 characters (SHA256 hex digest)
+        assert len(hash1) == 64
+        assert all(c in "0123456789abcdef" for c in hash1)
+
+    def test_create_line_state_hash_null_reason(self):
+        """Test that create_line_state_hash handles null reasons consistently."""
+        # None and empty string should produce same hash
+        hash_none = create_line_state_hash("victoria", "Good Service", None)
+        hash_empty = create_line_state_hash("victoria", "Good Service", "")
+        assert hash_none == hash_empty
+
+        # Good Service with no reason should differ from disruption with reason
+        hash_with_reason = create_line_state_hash("victoria", "Good Service", "Testing")
+        assert hash_none != hash_with_reason
+
+    async def test_log_line_disruption_state_changes_first_state(
+        self,
+        db_session: AsyncSession,
+        mock_redis: AsyncMock,
+    ):
+        """Test that first disruption state is always logged."""
+        alert_service = AlertService(db=db_session, redis_client=mock_redis)
+
+        # Create disruption
+        disruption = DisruptionResponse(
+            line_id="bakerloo",
+            line_name="Bakerloo",
+            status_severity=10,
+            status_severity_description="Minor Delays",
+            reason="Signal failure at Baker Street",
+        )
+
+        # Log state change
+        logged_count = await alert_service._log_line_disruption_state_changes([disruption])
+
+        # Should log because no previous state
+        assert logged_count == 1
+
+        # Verify database entry
+        result = await db_session.execute(select(LineDisruptionStateLog))
+        logs = result.scalars().all()
+        assert len(logs) == 1
+        assert logs[0].line_id == "bakerloo"
+        assert logs[0].status_severity_description == "Minor Delays"
+        assert logs[0].reason == "Signal failure at Baker Street"
+        assert logs[0].state_hash is not None
+        assert logs[0].detected_at is not None
+
+    async def test_log_line_disruption_state_changes_no_change(
+        self,
+        db_session: AsyncSession,
+        mock_redis: AsyncMock,
+    ):
+        """Test that unchanged disruption state is not logged again."""
+        alert_service = AlertService(db=db_session, redis_client=mock_redis)
+
+        # Create disruption
+        disruption = DisruptionResponse(
+            line_id="central",
+            line_name="Central",
+            status_severity=10,
+            status_severity_description="Minor Delays",
+            reason="Train cancellation",
+        )
+
+        # Log first state
+        logged_count1 = await alert_service._log_line_disruption_state_changes([disruption])
+        assert logged_count1 == 1
+
+        # Log same state again
+        logged_count2 = await alert_service._log_line_disruption_state_changes([disruption])
+        assert logged_count2 == 0  # Should not log duplicate
+
+        # Verify only one database entry
+        result = await db_session.execute(
+            select(LineDisruptionStateLog).where(LineDisruptionStateLog.line_id == "central")
+        )
+        logs = result.scalars().all()
+        assert len(logs) == 1
+
+    async def test_log_line_disruption_state_changes_state_changed(
+        self,
+        db_session: AsyncSession,
+        mock_redis: AsyncMock,
+    ):
+        """Test that changed disruption state is logged."""
+        alert_service = AlertService(db=db_session, redis_client=mock_redis)
+
+        # Create initial disruption
+        disruption1 = DisruptionResponse(
+            line_id="piccadilly",
+            line_name="Piccadilly",
+            status_severity=10,
+            status_severity_description="Minor Delays",
+            reason="Passenger incident",
+        )
+
+        # Log first state
+        logged_count1 = await alert_service._log_line_disruption_state_changes([disruption1])
+        assert logged_count1 == 1
+
+        # Create changed disruption (same line, different status)
+        disruption2 = DisruptionResponse(
+            line_id="piccadilly",
+            line_name="Piccadilly",
+            status_severity=20,
+            status_severity_description="Severe Delays",
+            reason="Passenger incident",
+        )
+
+        # Log changed state
+        logged_count2 = await alert_service._log_line_disruption_state_changes([disruption2])
+        assert logged_count2 == 1  # Should log because state changed
+
+        # Verify two database entries
+        result = await db_session.execute(
+            select(LineDisruptionStateLog)
+            .where(LineDisruptionStateLog.line_id == "piccadilly")
+            .order_by(LineDisruptionStateLog.detected_at)
+        )
+        logs = result.scalars().all()
+        assert len(logs) == 2
+        assert logs[0].status_severity_description == "Minor Delays"
+        assert logs[1].status_severity_description == "Severe Delays"
+
+    async def test_log_line_disruption_state_changes_reason_changed(
+        self,
+        db_session: AsyncSession,
+        mock_redis: AsyncMock,
+    ):
+        """Test that changed disruption reason is logged even if status is same."""
+        alert_service = AlertService(db=db_session, redis_client=mock_redis)
+
+        # Create initial disruption
+        disruption1 = DisruptionResponse(
+            line_id="district",
+            line_name="District",
+            status_severity=10,
+            status_severity_description="Minor Delays",
+            reason="Signal failure at Earl's Court",
+        )
+
+        # Log first state
+        logged_count1 = await alert_service._log_line_disruption_state_changes([disruption1])
+        assert logged_count1 == 1
+
+        # Create disruption with same status but different reason
+        disruption2 = DisruptionResponse(
+            line_id="district",
+            line_name="District",
+            status_severity=10,
+            status_severity_description="Minor Delays",
+            reason="Signal failure at Tower Hill",
+        )
+
+        # Log changed state
+        logged_count2 = await alert_service._log_line_disruption_state_changes([disruption2])
+        assert logged_count2 == 1  # Should log because reason changed
+
+        # Verify two database entries with different reasons
+        result = await db_session.execute(
+            select(LineDisruptionStateLog)
+            .where(LineDisruptionStateLog.line_id == "district")
+            .order_by(LineDisruptionStateLog.detected_at)
+        )
+        logs = result.scalars().all()
+        assert len(logs) == 2
+        assert logs[0].reason == "Signal failure at Earl's Court"
+        assert logs[1].reason == "Signal failure at Tower Hill"
+
+    async def test_log_line_disruption_state_changes_multiple_lines(
+        self,
+        db_session: AsyncSession,
+        mock_redis: AsyncMock,
+    ):
+        """Test that multiple line disruptions are logged correctly."""
+        alert_service = AlertService(db=db_session, redis_client=mock_redis)
+
+        # Create disruptions for multiple lines
+        disruptions = [
+            DisruptionResponse(
+                line_id="northern",
+                line_name="Northern",
+                status_severity=10,
+                status_severity_description="Minor Delays",
+                reason="Train cancellation",
+            ),
+            DisruptionResponse(
+                line_id="jubilee",
+                line_name="Jubilee",
+                status_severity=20,
+                status_severity_description="Severe Delays",
+                reason="Signal failure",
+            ),
+            DisruptionResponse(
+                line_id="metropolitan",
+                line_name="Metropolitan",
+                status_severity=6,
+                status_severity_description="Good Service",
+                reason=None,
+            ),
+        ]
+
+        # Log all states
+        logged_count = await alert_service._log_line_disruption_state_changes(disruptions)
+        assert logged_count == 3
+
+        # Verify database entries
+        result = await db_session.execute(select(LineDisruptionStateLog).order_by(LineDisruptionStateLog.line_id))
+        logs = result.scalars().all()
+        assert len(logs) == 3
+        assert {log.line_id for log in logs} == {"northern", "jubilee", "metropolitan"}
+
+    async def test_log_line_disruption_state_changes_null_reason(
+        self,
+        db_session: AsyncSession,
+        mock_redis: AsyncMock,
+    ):
+        """Test that null reason is handled correctly."""
+        alert_service = AlertService(db=db_session, redis_client=mock_redis)
+
+        # Create disruption with no reason (Good Service)
+        disruption = DisruptionResponse(
+            line_id="circle",
+            line_name="Circle",
+            status_severity=6,
+            status_severity_description="Good Service",
+            reason=None,
+        )
+
+        # Log state
+        logged_count = await alert_service._log_line_disruption_state_changes([disruption])
+        assert logged_count == 1
+
+        # Verify database entry with null reason
+        result = await db_session.execute(
+            select(LineDisruptionStateLog).where(LineDisruptionStateLog.line_id == "circle")
+        )
+        log = result.scalar_one()
+        assert log.line_id == "circle"
+        assert log.status_severity_description == "Good Service"
+        assert log.reason is None
+
+    async def test_log_line_disruption_state_changes_error_handling(
+        self,
+        db_session: AsyncSession,
+        mock_redis: AsyncMock,
+    ):
+        """Test that logging errors don't crash the alert processing."""
+        alert_service = AlertService(db=db_session, redis_client=mock_redis)
+
+        disruption = DisruptionResponse(
+            line_id="hammersmith-city",
+            line_name="Hammersmith & City",
+            status_severity=10,
+            status_severity_description="Minor Delays",
+            reason="Test error",
+        )
+
+        # Mock db.execute to raise an exception
+        with patch.object(db_session, "execute", side_effect=Exception("Database error")):
+            # Should not raise, should return 0
+            logged_count = await alert_service._log_line_disruption_state_changes([disruption])
+            assert logged_count == 0

--- a/backend/tests/test_celery_schedules.py
+++ b/backend/tests/test_celery_schedules.py
@@ -1,0 +1,125 @@
+"""Tests for Celery Beat schedule configuration.
+
+Regression tests to ensure schedules module remains imported and configured.
+These tests prevent Issue #167 from recurring.
+"""
+
+from app.celery import schedules
+from app.celery.app import celery_app
+
+from celery.schedules import schedule
+
+
+class TestCelerySchedulesImport:
+    """Test that schedules module is properly imported and configured."""
+
+    def test_schedules_module_is_imported(self):
+        """Test that schedules module exists in app.celery namespace.
+
+        Regression test for Issue #167: schedules.py was not imported,
+        causing beat_schedule to remain empty.
+        """
+        # Verify schedules module can be imported
+        assert schedules is not None
+        assert hasattr(schedules, "celery_app")
+
+    def test_beat_schedule_is_populated(self):
+        """Test that beat_schedule configuration is not empty.
+
+        If schedules.py is not imported, beat_schedule will be an empty dict.
+        This test catches that regression.
+        """
+        assert celery_app.conf.beat_schedule is not None
+        assert isinstance(celery_app.conf.beat_schedule, dict)
+        assert len(celery_app.conf.beat_schedule) > 0, "beat_schedule is empty - schedules module may not be imported"
+
+    def test_check_disruptions_and_alert_task_exists(self):
+        """Test that the check-disruptions-and-alert task is registered.
+
+        This is the primary periodic task that drives the notification system.
+        """
+        assert "check-disruptions-and-alert" in celery_app.conf.beat_schedule
+        task_config = celery_app.conf.beat_schedule["check-disruptions-and-alert"]
+
+        # Verify it's a dict with expected structure
+        assert isinstance(task_config, dict)
+        assert "task" in task_config
+        assert "schedule" in task_config
+        assert "options" in task_config
+
+
+class TestScheduleConfiguration:
+    """Test the configuration details of scheduled tasks."""
+
+    def test_check_disruptions_schedule_interval(self):
+        """Test that check-disruptions task runs every 30 seconds."""
+        task_config = celery_app.conf.beat_schedule["check-disruptions-and-alert"]
+
+        # Verify schedule is a celery.schedules.schedule object
+        assert isinstance(task_config["schedule"], schedule)
+
+        # Verify interval is 30 seconds
+        # schedule.run_every is a timedelta object
+        assert task_config["schedule"].run_every.total_seconds() == 30.0
+
+    def test_check_disruptions_task_name(self):
+        """Test that task points to correct Python path."""
+        task_config = celery_app.conf.beat_schedule["check-disruptions-and-alert"]
+
+        assert task_config["task"] == "app.celery.tasks.check_disruptions_and_alert"
+
+    def test_check_disruptions_task_expires(self):
+        """Test that task expires after 60 seconds if not picked up."""
+        task_config = celery_app.conf.beat_schedule["check-disruptions-and-alert"]
+
+        assert "options" in task_config
+        assert "expires" in task_config["options"]
+        assert task_config["options"]["expires"] == 60
+
+    def test_beat_schedule_structure_integrity(self):
+        """Test that all registered tasks have required configuration keys."""
+        for task_name, task_config in celery_app.conf.beat_schedule.items():
+            # Every scheduled task must have these keys
+            assert "task" in task_config, f"{task_name} missing 'task' key"
+            assert "schedule" in task_config, f"{task_name} missing 'schedule' key"
+
+            # Verify values are not None or empty
+            assert task_config["task"], f"{task_name} has empty 'task' value"
+            assert task_config["schedule"], f"{task_name} has empty 'schedule' value"
+
+            # Verify task name is a valid Python path (has at least one dot)
+            assert "." in task_config["task"], f"{task_name} task path '{task_config['task']}' invalid"
+
+
+class TestCeleryAppConfiguration:
+    """Test that Celery app is properly configured."""
+
+    def test_celery_app_exists(self):
+        """Test that celery_app instance is created."""
+        assert celery_app is not None
+        assert hasattr(celery_app, "conf")
+
+    def test_broker_url_configured(self):
+        """Test that Redis broker URL is configured."""
+        assert celery_app.conf.broker_url is not None
+        assert len(celery_app.conf.broker_url) > 0
+        # Should be redis:// URL
+        assert celery_app.conf.broker_url.startswith("redis://")
+
+    def test_result_backend_configured(self):
+        """Test that Redis result backend is configured."""
+        assert celery_app.conf.result_backend is not None
+        assert len(celery_app.conf.result_backend) > 0
+        # Should be redis:// URL
+        assert celery_app.conf.result_backend.startswith("redis://")
+
+    def test_task_time_limits_configured(self):
+        """Test that task time limits are set correctly."""
+        # Hard limit: 5 minutes (300 seconds)
+        assert celery_app.conf.task_time_limit == 300
+
+        # Soft limit: 4 minutes (240 seconds)
+        assert celery_app.conf.task_soft_time_limit == 240
+
+        # Soft limit should be less than hard limit
+        assert celery_app.conf.task_soft_time_limit < celery_app.conf.task_time_limit


### PR DESCRIPTION
## Summary by Sourcery

Introduce persistent logging of TfL line disruption state changes to enable historical visibility and analytics by adding a new database table, a pure hashing utility, a service method to detect and record state changes, and integrating it into the route processing pipeline.

New Features:
- Add LineDisruptionStateLog model and corresponding Alembic migration to store line disruption state changes
- Implement create_line_state_hash() pure function for SHA256-based deduplication of disruption states
- Add AlertService._log_line_disruption_state_changes() and integrate it into process_all_routes() to log state changes

Build:
- Add Alembic migration to create line_disruption_state_logs table with indexes

Documentation:
- Update ADR to document the line disruption state logging design, rationale, and consequences

Tests:
- Add unit tests for create_line_state_hash() and comprehensive tests covering various logging scenarios (first state, unchanged, status/ reason changes, multiple lines, error handling)
- Add Celery Beat schedule tests to ensure periodic task configuration is imported and correctly scheduled