### PR TITLE
Refactor route-related tests to use UserRoute and UserRouteSegment models

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import get_current_user
 from app.core.database import get_db
-from app.models.route import Route, RouteSchedule, RouteSegment
+from app.models.route import UserRoute, UserRouteSchedule, UserRouteSegment
 from app.models.user import User
 from app.schemas.routes import (
     CreateRouteRequest,
@@ -70,7 +70,7 @@ async def create_route(
     request: CreateRouteRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-) -> Route:
+) -> UserRoute:
     """
     Create a new route.
 
@@ -78,7 +78,7 @@ async def create_route(
     Use the segments and schedules endpoints to add them after creation.
 
     Args:
-        request: Route creation request
+        request: UserRoute creation request
         current_user: Authenticated user
         db: Database session
 
@@ -97,12 +97,12 @@ async def get_route(
     route_id: UUID,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-) -> Route:
+) -> UserRoute:
     """
     Get a route by ID with all segments and schedules.
 
     Args:
-        route_id: Route UUID
+        route_id: UserRoute UUID
         current_user: Authenticated user
         db: Database session
 
@@ -122,14 +122,14 @@ async def update_route(
     request: UpdateRouteRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-) -> Route:
+) -> UserRoute:
     """
     Update route metadata (name, description, active status).
 
     Only updates fields that are provided in the request.
 
     Args:
-        route_id: Route UUID
+        route_id: UserRoute UUID
         request: Update request
         current_user: Authenticated user
         db: Database session
@@ -159,7 +159,7 @@ async def delete_route(
     This also deletes all associated segments and schedules (CASCADE).
 
     Args:
-        route_id: Route UUID
+        route_id: UserRoute UUID
         current_user: Authenticated user
         db: Database session
 
@@ -179,7 +179,7 @@ async def upsert_segments(
     request: UpsertSegmentsRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-) -> list[RouteSegment]:
+) -> list[UserRouteSegment]:
     """
     Replace all segments for a route.
 
@@ -187,7 +187,7 @@ async def upsert_segments(
     Segments must be ordered with consecutive sequences starting from 0.
 
     Args:
-        route_id: Route UUID
+        route_id: UserRoute UUID
         request: Segments to set
         current_user: Authenticated user
         db: Database session
@@ -209,7 +209,7 @@ async def update_segment(
     request: UpdateSegmentRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-) -> RouteSegment:
+) -> UserRouteSegment:
     """
     Update a single segment.
 
@@ -217,7 +217,7 @@ async def update_segment(
     the update is rolled back.
 
     Args:
-        route_id: Route UUID
+        route_id: UserRoute UUID
         sequence: Segment sequence number (0-based)
         request: Update request
         current_user: Authenticated user
@@ -246,7 +246,7 @@ async def delete_segment(
     Cannot delete if it would leave fewer than 2 segments.
 
     Args:
-        route_id: Route UUID
+        route_id: UserRoute UUID
         sequence: Segment sequence number (0-based)
         current_user: Authenticated user
         db: Database session
@@ -267,14 +267,14 @@ async def create_schedule(
     request: CreateScheduleRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-) -> RouteSchedule:
+) -> UserRouteSchedule:
     """
     Create a schedule for a route.
 
     A route can have multiple schedules (e.g., different times for weekdays vs weekends).
 
     Args:
-        route_id: Route UUID
+        route_id: UserRoute UUID
         request: Schedule creation request
         current_user: Authenticated user
         db: Database session
@@ -296,14 +296,14 @@ async def update_schedule(
     request: UpdateScheduleRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-) -> RouteSchedule:
+) -> UserRouteSchedule:
     """
     Update a schedule.
 
     Only updates fields that are provided in the request.
 
     Args:
-        route_id: Route UUID
+        route_id: UserRoute UUID
         schedule_id: Schedule UUID
         request: Update request
         current_user: Authenticated user
@@ -330,7 +330,7 @@ async def delete_schedule(
     Delete a schedule.
 
     Args:
-        route_id: Route UUID
+        route_id: UserRoute UUID
         schedule_id: Schedule UUID
         current_user: Authenticated user
         db: Database session

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -11,7 +11,7 @@ from app.models.notification import (
     NotificationStatus,
 )
 from app.models.rate_limit import RateLimitAction, RateLimitLog
-from app.models.route import Route, RouteSchedule, RouteSegment
+from app.models.route import UserRoute, UserRouteSchedule, UserRouteSegment
 from app.models.route_index import RouteStationIndex
 from app.models.tfl import Line, LineDisruptionStateLog, Station, StationConnection
 from app.models.user import (
@@ -41,9 +41,9 @@ __all__ = [
     "Station",
     "StationConnection",
     # Route models
-    "Route",
-    "RouteSegment",
-    "RouteSchedule",
+    "UserRoute",
+    "UserRouteSegment",
+    "UserRouteSchedule",
     "RouteStationIndex",
     # Notification models
     "NotificationPreference",

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -19,7 +19,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from app.models.base import BaseModel
 
 if TYPE_CHECKING:  # Avoid circular imports -> route.py imports from app.helpers.station_resolution (line 22)
-    from app.models.route import Route
+    from app.models.route import UserRoute
     from app.models.user import User
 
 
@@ -71,7 +71,7 @@ class NotificationPreference(BaseModel):
     )
 
     # Relationships
-    route: Mapped["Route"] = relationship(back_populates="notification_preferences")
+    route: Mapped["UserRoute"] = relationship(back_populates="notification_preferences")
 
     # Ensure one and only one target is set
     __table_args__ = (
@@ -135,7 +135,7 @@ class NotificationLog(BaseModel):
 
     # Relationships
     user: Mapped["User"] = relationship()
-    route: Mapped["Route"] = relationship()
+    route: Mapped["UserRoute"] = relationship()
 
     # Composite index for recent notifications by user
     __table_args__ = (

--- a/backend/app/models/route.py
+++ b/backend/app/models/route.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
     from app.models.route_index import RouteStationIndex
 
 
-class Route(BaseModel):
+class UserRoute(BaseModel):
     """User's commute route."""
 
     __tablename__ = "user_routes"
@@ -62,12 +62,12 @@ class Route(BaseModel):
 
     # Relationships
     user: Mapped["User"] = relationship()
-    segments: Mapped[list["RouteSegment"]] = relationship(
+    segments: Mapped[list["UserRouteSegment"]] = relationship(
         back_populates="route",
         cascade="all, delete-orphan",
-        order_by="RouteSegment.sequence",
+        order_by="UserRouteSegment.sequence",
     )
-    schedules: Mapped[list["RouteSchedule"]] = relationship(
+    schedules: Mapped[list["UserRouteSchedule"]] = relationship(
         back_populates="route",
         cascade="all, delete-orphan",
     )
@@ -82,10 +82,10 @@ class Route(BaseModel):
 
     def __repr__(self) -> str:
         """String representation of the route."""
-        return f"<Route(id={self.id}, name={self.name}, active={self.active})>"
+        return f"<UserRoute(id={self.id}, name={self.name}, active={self.active})>"
 
 
-class RouteSegment(BaseModel):
+class UserRouteSegment(BaseModel):
     """A segment of a route (station + line combination in sequence)."""
 
     __tablename__ = "user_route_segments"
@@ -112,7 +112,7 @@ class RouteSegment(BaseModel):
     )
 
     # Relationships
-    route: Mapped[Route] = relationship(back_populates="segments")
+    route: Mapped[UserRoute] = relationship(back_populates="segments")
     station: Mapped["Station"] = relationship()
     line: Mapped["Line"] = relationship()
 
@@ -141,10 +141,10 @@ class RouteSegment(BaseModel):
 
     def __repr__(self) -> str:
         """String representation of the route segment."""
-        return f"<RouteSegment(id={self.id}, route={self.route_id}, seq={self.sequence})>"
+        return f"<UserRouteSegment(id={self.id}, route={self.route_id}, seq={self.sequence})>"
 
 
-class RouteSchedule(BaseModel):
+class UserRouteSchedule(BaseModel):
     """Schedule for when a route should be monitored for disruptions."""
 
     __tablename__ = "user_route_schedules"
@@ -170,8 +170,8 @@ class RouteSchedule(BaseModel):
     )
 
     # Relationships
-    route: Mapped[Route] = relationship(back_populates="schedules")
+    route: Mapped[UserRoute] = relationship(back_populates="schedules")
 
     def __repr__(self) -> str:
         """String representation of the route schedule."""
-        return f"<RouteSchedule(id={self.id}, route={self.route_id}, days={self.days_of_week})>"
+        return f"<UserRouteSchedule(id={self.id}, route={self.route_id}, days={self.days_of_week})>"

--- a/backend/app/models/route_index.py
+++ b/backend/app/models/route_index.py
@@ -8,7 +8,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import BaseModel
-from app.models.route import Route
+from app.models.route import UserRoute
 
 
 class RouteStationIndex(BaseModel):
@@ -57,7 +57,7 @@ class RouteStationIndex(BaseModel):
     )
 
     # Relationships
-    route: Mapped[Route] = relationship(back_populates="station_indexes")
+    route: Mapped[UserRoute] = relationship(back_populates="station_indexes")
 
     __table_args__ = (
         # Primary lookup: "Which routes pass through station X on line Y?"

--- a/backend/app/services/alert_service.py
+++ b/backend/app/services/alert_service.py
@@ -20,7 +20,7 @@ from app.models.notification import (
     NotificationPreference,
     NotificationStatus,
 )
-from app.models.route import Route, RouteSchedule
+from app.models.route import UserRoute, UserRouteSchedule
 from app.models.route_index import RouteStationIndex
 from app.models.tfl import Line, LineDisruptionStateLog
 from app.models.user import EmailAddress, PhoneNumber, User
@@ -83,7 +83,7 @@ def extract_line_station_pairs(disruption: DisruptionResponse) -> list[tuple[str
         ...     status_severity=10,
         ...     status_severity_description="Minor Delays",
         ...     affected_routes=[
-        ...         AffectedRouteInfo(
+        ...         AffectedUserRouteInfo(
         ...             name="Cockfosters → Heathrow T5",
         ...             direction="outbound",
         ...             affected_stations=["940GZZLURSQ", "940GZZLUHBN"]
@@ -437,25 +437,25 @@ class AlertService:
             stats["errors"] += 1
             return stats
 
-    async def _get_active_routes(self) -> list[Route]:
+    async def _get_active_routes(self) -> list[UserRoute]:
         """
         Get all active routes with their relationships.
 
         Returns:
-            List of active Route objects with segments, schedules, preferences, and user loaded
+            List of active UserRoute objects with segments, schedules, preferences, and user loaded
         """
         try:
             result = await self.db.execute(
-                select(Route)
+                select(UserRoute)
                 .where(
-                    Route.active == True,  # noqa: E712
-                    Route.deleted_at.is_(None),
+                    UserRoute.active == True,  # noqa: E712
+                    UserRoute.deleted_at.is_(None),
                 )
                 .options(
-                    selectinload(Route.segments),
-                    selectinload(Route.schedules),
-                    selectinload(Route.notification_preferences),
-                    selectinload(Route.user).selectinload(User.email_addresses),
+                    selectinload(UserRoute.segments),
+                    selectinload(UserRoute.schedules),
+                    selectinload(UserRoute.notification_preferences),
+                    selectinload(UserRoute.user).selectinload(User.email_addresses),
                 )
             )
             return list(result.scalars().all())
@@ -466,16 +466,16 @@ class AlertService:
 
     async def _get_active_schedule(
         self,
-        route: Route,
-        schedules: list[RouteSchedule] | None = None,
-    ) -> RouteSchedule | None:
+        route: UserRoute,
+        schedules: list[UserRouteSchedule] | None = None,
+    ) -> UserRouteSchedule | None:
         """
         Check if the route is currently in any active schedule window.
 
         Converts UTC now to route's timezone and checks against schedule windows.
 
         Args:
-            route: Route to check schedules for
+            route: UserRoute to check schedules for
             schedules: Optional list of schedules. If None, uses route.schedules
                        (but requires schedules to be eagerly loaded)
 
@@ -571,7 +571,7 @@ class AlertService:
         Get (line_tfl_id, station_naptan) pairs for a specific route from the index.
 
         Args:
-            route_id: Route ID to get index pairs for
+            route_id: UserRoute ID to get index pairs for
 
         Returns:
             Set of (line_tfl_id, station_naptan) tuples for this route
@@ -650,11 +650,11 @@ class AlertService:
 
         # Query all routes that have segments on this line
         result = await self.db.execute(
-            select(Route.id)
+            select(UserRoute.id)
             .where(
-                Route.segments.any(line_id=line_db_id),
-                Route.active.is_(True),
-                Route.deleted_at.is_(None),
+                UserRoute.segments.any(line_id=line_db_id),
+                UserRoute.active.is_(True),
+                UserRoute.deleted_at.is_(None),
             )
             .distinct()
         )
@@ -668,7 +668,7 @@ class AlertService:
 
         return affected_route_ids
 
-    async def _get_route_disruptions(self, route: Route) -> tuple[list[DisruptionResponse], bool]:
+    async def _get_route_disruptions(self, route: UserRoute) -> tuple[list[DisruptionResponse], bool]:
         """
         Get current disruptions affecting this route using inverted index.
 
@@ -676,7 +676,7 @@ class AlertService:
         Falls back to line-level matching only when TfL doesn't provide station data.
 
         Args:
-            route: Route to get disruptions for
+            route: UserRoute to get disruptions for
 
         Returns:
             Tuple of (disruptions, error_occurred)
@@ -739,9 +739,9 @@ class AlertService:
 
     async def _should_send_alert(
         self,
-        route: Route,
+        route: UserRoute,
         user_id: UUID,
-        schedule: RouteSchedule,
+        schedule: UserRouteSchedule,
         disruptions: list[DisruptionResponse],
     ) -> bool:
         """
@@ -751,7 +751,7 @@ class AlertService:
         Compares current disruptions with stored state to detect changes.
 
         Args:
-            route: Route to check
+            route: UserRoute to check
             user_id: User ID for deduplication key
             schedule: Active schedule
             disruptions: Current disruptions
@@ -829,7 +829,7 @@ class AlertService:
 
         Args:
             pref: Notification preference
-            route_id: Route ID for logging
+            route_id: UserRoute ID for logging
 
         Returns:
             Contact string (email or phone) if verified, None otherwise
@@ -890,12 +890,12 @@ class AlertService:
         )
         return None
 
-    def _get_user_display_name(self, route: Route) -> str | None:
+    def _get_user_display_name(self, route: UserRoute) -> str | None:
         """
         Get user display name from their primary email address.
 
         Args:
-            route: Route with user relationship loaded
+            route: UserRoute with user relationship loaded
 
         Returns:
             User's email or None
@@ -924,7 +924,7 @@ class AlertService:
 
         Args:
             user_id: User ID
-            route_id: Route ID
+            route_id: UserRoute ID
             method: Notification method
             status: Notification status
             error_message: Optional error message
@@ -943,7 +943,7 @@ class AlertService:
         self,
         pref: NotificationPreference,
         contact_info: str,
-        route: Route,
+        route: UserRoute,
         disruptions: list[DisruptionResponse],
     ) -> tuple[bool, str | None]:
         """
@@ -952,7 +952,7 @@ class AlertService:
         Args:
             pref: Notification preference
             contact_info: Contact string (email or phone)
-            route: Route being alerted
+            route: UserRoute being alerted
             disruptions: List of disruptions
 
         Returns:
@@ -1001,15 +1001,15 @@ class AlertService:
 
     async def _send_alerts_for_route(
         self,
-        route: Route,
-        schedule: RouteSchedule,
+        route: UserRoute,
+        schedule: UserRouteSchedule,
         disruptions: list[DisruptionResponse],
     ) -> int:
         """
         Send alerts for a route to all configured notification preferences.
 
         Args:
-            route: Route to send alerts for
+            route: UserRoute to send alerts for
             schedule: Active schedule
             disruptions: Disruptions to notify about
 
@@ -1105,9 +1105,9 @@ class AlertService:
 
     async def _store_alert_state(
         self,
-        route: Route,
+        route: UserRoute,
         user_id: UUID,
-        schedule: RouteSchedule,
+        schedule: UserRouteSchedule,
         disruptions: list[DisruptionResponse],
     ) -> None:
         """
@@ -1117,7 +1117,7 @@ class AlertService:
         prevents spam; between windows, expired keys allow fresh alerts.
 
         Args:
-            route: Route the alert was sent for
+            route: UserRoute the alert was sent for
             user_id: User ID for deduplication key
             schedule: Active schedule
             disruptions: Disruptions that were alerted

--- a/backend/app/services/alert_service.py
+++ b/backend/app/services/alert_service.py
@@ -83,7 +83,7 @@ def extract_line_station_pairs(disruption: DisruptionResponse) -> list[tuple[str
         ...     status_severity=10,
         ...     status_severity_description="Minor Delays",
         ...     affected_routes=[
-        ...         AffectedUserRouteInfo(
+        ...         AffectedRouteInfo(
         ...             name="Cockfosters → Heathrow T5",
         ...             direction="outbound",
         ...             affected_stations=["940GZZLURSQ", "940GZZLUHBN"]

--- a/backend/app/services/notification_preference_service.py
+++ b/backend/app/services/notification_preference_service.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.models.notification import NotificationMethod, NotificationPreference
-from app.models.route import Route
+from app.models.route import UserRoute
 from app.models.user import EmailAddress, PhoneNumber
 
 
@@ -116,7 +116,7 @@ class NotificationPreferenceService:
         Check for duplicate preferences.
 
         Args:
-            route_id: Route UUID
+            route_id: UserRoute UUID
             method: Notification method
             email_id: Email address ID (if email method)
             phone_id: Phone number ID (if SMS method)
@@ -169,10 +169,10 @@ class NotificationPreferenceService:
         # Join with route to validate ownership
         query = (
             select(NotificationPreference)
-            .join(Route, NotificationPreference.route_id == Route.id)
+            .join(UserRoute, NotificationPreference.route_id == UserRoute.id)
             .where(
                 NotificationPreference.id == preference_id,
-                Route.user_id == user_id,
+                UserRoute.user_id == user_id,
             )
         )
 
@@ -195,7 +195,7 @@ class NotificationPreferenceService:
         List all notification preferences for a route.
 
         Args:
-            route_id: Route UUID
+            route_id: UserRoute UUID
             user_id: User UUID (for ownership check)
 
         Returns:
@@ -206,16 +206,16 @@ class NotificationPreferenceService:
         """
         # First validate route ownership
         route_result = await self.db.execute(
-            select(Route).where(
-                Route.id == route_id,
-                Route.user_id == user_id,
+            select(UserRoute).where(
+                UserRoute.id == route_id,
+                UserRoute.user_id == user_id,
             )
         )
 
         if not route_result.scalar_one_or_none():
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail="Route not found.",
+                detail="UserRoute not found.",
             )
 
         # Get preferences
@@ -239,7 +239,7 @@ class NotificationPreferenceService:
         Create a new notification preference.
 
         Args:
-            route_id: Route UUID
+            route_id: UserRoute UUID
             user_id: User UUID (for ownership validation)
             method: Notification method (email or sms)
             target_email_id: Email address ID (required if method is email)
@@ -253,16 +253,16 @@ class NotificationPreferenceService:
         """
         # Validate route ownership
         route_result = await self.db.execute(
-            select(Route).where(
-                Route.id == route_id,
-                Route.user_id == user_id,
+            select(UserRoute).where(
+                UserRoute.id == route_id,
+                UserRoute.user_id == user_id,
             )
         )
 
         if not route_result.scalar_one_or_none():
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail="Route not found.",
+                detail="UserRoute not found.",
             )
 
         # Validate exactly one target is provided

--- a/backend/app/services/route_index_service.py
+++ b/backend/app/services/route_index_service.py
@@ -9,14 +9,14 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
-from app.models.route import Route, RouteSegment
+from app.models.route import UserRoute, UserRouteSegment
 from app.models.route_index import RouteStationIndex
 from app.models.tfl import Line, Station
 
 logger = structlog.get_logger(__name__)
 
 
-class RebuildRoutesResult(TypedDict):
+class RebuildUserRoutesResult(TypedDict):
     """Result from rebuild_routes operation."""
 
     rebuilt_count: int
@@ -82,7 +82,7 @@ class RouteIndexService:
             # Load route with segments and related data
             route = await self._load_route_with_segments(route_id)
             if not route:
-                msg = f"Route {route_id} not found"
+                msg = f"UserRoute {route_id} not found"
                 logger.error("route_not_found", route_id=str(route_id))
                 raise ValueError(msg)
 
@@ -125,7 +125,7 @@ class RouteIndexService:
         route_id: UUID | None = None,
         *,
         auto_commit: bool = True,
-    ) -> RebuildRoutesResult:
+    ) -> RebuildUserRoutesResult:
         """
         Rebuild route station indexes for single route or all routes.
 
@@ -156,7 +156,7 @@ class RouteIndexService:
                     rebuilt_count = 1
                 except Exception as exc:
                     failed_count = 1
-                    errors.append(f"Route {route_id}: {exc!s}")
+                    errors.append(f"UserRoute {route_id}: {exc!s}")
                     logger.error(
                         "rebuild_single_route_failed",
                         route_id=str(route_id),
@@ -164,7 +164,7 @@ class RouteIndexService:
                     )
             else:
                 # Rebuild all routes
-                result = await self.db.execute(select(Route))
+                result = await self.db.execute(select(UserRoute))
                 routes = result.scalars().all()
 
                 for route in routes:
@@ -173,7 +173,7 @@ class RouteIndexService:
                         rebuilt_count += 1
                     except Exception as exc:
                         failed_count += 1
-                        errors.append(f"Route {route.id}: {exc!s}")
+                        errors.append(f"UserRoute {route.id}: {exc!s}")
                         logger.error(
                             "rebuild_route_failed",
                             route_id=str(route.id),
@@ -201,7 +201,7 @@ class RouteIndexService:
             )
             raise
 
-    async def _load_route_with_segments(self, route_id: UUID) -> Route | None:
+    async def _load_route_with_segments(self, route_id: UUID) -> UserRoute | None:
         """
         Load route with segments, stations, and lines eagerly loaded.
 
@@ -209,18 +209,18 @@ class RouteIndexService:
             route_id: UUID of route to load
 
         Returns:
-            Route instance or None if not found
+            UserRoute instance or None if not found
         """
         # Note: Segments MUST be ordered by sequence for _process_segments to work correctly.
-        # The ordering is enforced by the Route.segments relationship default (see route.py:68).
+        # The ordering is enforced by the UserRoute.segments relationship default (see route.py:68).
         # This is critical - if segments are unordered, _process_segments would create incorrect
         # index entries linking non-adjacent stations.
         result = await self.db.execute(
-            select(Route)
-            .where(Route.id == route_id)
+            select(UserRoute)
+            .where(UserRoute.id == route_id)
             .options(
-                selectinload(Route.segments).selectinload(RouteSegment.station),
-                selectinload(Route.segments).selectinload(RouteSegment.line),
+                selectinload(UserRoute.segments).selectinload(UserRouteSegment.station),
+                selectinload(UserRoute.segments).selectinload(UserRouteSegment.line),
             )
         )
         return result.scalar_one_or_none()
@@ -302,7 +302,7 @@ class RouteIndexService:
         )
         raise ValueError(msg)
 
-    async def _process_segments(self, route: Route) -> tuple[int, int]:
+    async def _process_segments(self, route: UserRoute) -> tuple[int, int]:
         """
         Process route segments and create index entries.
 
@@ -310,7 +310,7 @@ class RouteIndexService:
         and creates index entries for each station.
 
         Args:
-            route: Route instance with segments loaded
+            route: UserRoute instance with segments loaded
 
         Returns:
             Tuple of (entries_created, pairs_processed) where:

--- a/backend/app/services/route_index_service.py
+++ b/backend/app/services/route_index_service.py
@@ -16,7 +16,7 @@ from app.models.tfl import Line, Station
 logger = structlog.get_logger(__name__)
 
 
-class RebuildUserRoutesResult(TypedDict):
+class RebuildRoutesResult(TypedDict):
     """Result from rebuild_routes operation."""
 
     rebuilt_count: int
@@ -125,7 +125,7 @@ class RouteIndexService:
         route_id: UUID | None = None,
         *,
         auto_commit: bool = True,
-    ) -> RebuildUserRoutesResult:
+    ) -> RebuildRoutesResult:
         """
         Rebuild route station indexes for single route or all routes.
 

--- a/backend/refactoring-notes.md
+++ b/backend/refactoring-notes.md
@@ -145,11 +145,28 @@ Each phase must achieve:
 
 ## Learnings Log
 
-### Phase 4: [Agent to fill in]
+### Phase 4: Model Class Renames (COMPLETE)
 - **What worked**:
+  - Using Edit tool with `replace_all=true` for consistent patterns (e.g., `Route(` → `UserRoute(`)
+  - Systematically updating imports first, then type hints, then usages
+  - ast-grep for verification of complete replacement
+  - Mypy caught all type-related issues immediately
+
 - **What didn't**:
+  - Initial approach of doing blanket `replace_all` for `Route` accidentally renamed service classes (RouteService → UserRouteService) and schema names which shouldn't have been changed in Phase 4
+  - `replace_all` on already-replaced imports created double-replacements (UserRoute → UserUserRoute)
+  - Missed references like `select(Route)` and `Route.` that weren't caught by `Route(` pattern
+  - Had to manually fix test files with multiple patterns (`-> Route:`, `route: Route`, `Route.`, `select(Route)`)
+
 - **Gotchas**:
-- **Time taken**:
+  - **Service class names should NOT be renamed in Phase 4** (that's Phase 5) - had to revert RouteService and RouteIndexService
+  - **Schema names should NOT be renamed in Phase 4** (that's Phase 7) - had to revert CreateUserRouteRequest back to CreateRouteRequest
+  - **RouteStationIndex should NOT be renamed** - that's Phase 6
+  - Type annotations in function signatures need separate replacements: `-> Route:`, `route: Route`
+  - SQLAlchemy queries need updates: `select(Route)`, `Route.id`, etc.
+  - Must read files before using Edit tool (encountered multiple "file not read" errors)
+
+- **Time taken**: ~2 hours (including fixing double-replacements and missed patterns)
 
 ### Phase 5: [Agent to fill in]
 - **What worked**:

--- a/backend/tests/test_admin_alerts.py
+++ b/backend/tests/test_admin_alerts.py
@@ -11,7 +11,7 @@ from app.core.config import settings
 from app.core.database import get_db
 from app.main import app
 from app.models.notification import NotificationLog, NotificationMethod, NotificationStatus
-from app.models.route import Route
+from app.models.route import UserRoute
 from app.models.user import User
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -490,7 +490,7 @@ async def test_recent_logs_with_data(
 ) -> None:
     """Test recent logs returns notification logs."""
     # Create a test route
-    route = Route(
+    route = UserRoute(
         user_id=test_user.id,
         name="Test Route",
         active=True,
@@ -552,7 +552,7 @@ async def test_recent_logs_pagination(
 ) -> None:
     """Test pagination of recent logs."""
     # Create a test route
-    route = Route(
+    route = UserRoute(
         user_id=test_user.id,
         name="Test Route",
         active=True,
@@ -612,7 +612,7 @@ async def test_recent_logs_filter_by_status(
 ) -> None:
     """Test filtering logs by status."""
     # Create a test route
-    route = Route(
+    route = UserRoute(
         user_id=test_user.id,
         name="Test Route",
         active=True,
@@ -672,7 +672,7 @@ async def test_recent_logs_ordering(
 ) -> None:
     """Test that logs are ordered by sent_at descending (most recent first)."""
     # Create a test route
-    route = Route(
+    route = UserRoute(
         user_id=test_user.id,
         name="Test Route",
         active=True,

--- a/backend/tests/test_admin_dashboard.py
+++ b/backend/tests/test_admin_dashboard.py
@@ -14,7 +14,7 @@ from app.models.notification import (
     NotificationMethod,
     NotificationStatus,
 )
-from app.models.route import Route
+from app.models.route import UserRoute
 from app.models.user import (
     EmailAddress,
     PhoneNumber,
@@ -645,7 +645,7 @@ async def test_anonymise_user_success(
         verified=True,
         is_primary=True,
     )
-    route = Route(user_id=user.id, name="Test Route", active=True, timezone="Europe/London")
+    route = UserRoute(user_id=user.id, name="Test Route", active=True, timezone="Europe/London")
     db_session.add_all([email, phone, route])
     await db_session.flush()  # Flush to get email.id
 
@@ -810,13 +810,13 @@ async def test_engagement_metrics_with_data(
     db_session.add_all([email, phone])
 
     # Add routes
-    route1 = Route(
+    route1 = UserRoute(
         user_id=another_user.id,
         name="Active Route",
         active=True,
         timezone="Europe/London",
     )
-    route2 = Route(
+    route2 = UserRoute(
         user_id=another_user.id,
         name="Inactive Route",
         active=False,
@@ -878,7 +878,7 @@ async def test_engagement_metrics_notification_methods(
 ) -> None:
     """Test notification stats are correctly grouped by method."""
     # Create a route
-    route = Route(
+    route = UserRoute(
         user_id=another_user.id,
         name="Test Route",
         active=True,

--- a/backend/tests/test_admin_route_index.py
+++ b/backend/tests/test_admin_route_index.py
@@ -10,7 +10,7 @@ import pytest
 from app.core.config import settings
 from app.core.database import get_db
 from app.main import app
-from app.models.route import Route, RouteSegment
+from app.models.route import UserRoute, UserRouteSegment
 from app.models.route_index import RouteStationIndex
 from app.models.tfl import Line, Station
 from app.models.user import User
@@ -245,13 +245,13 @@ class TestAdminRebuildIndexesIntegration:
         await db_session.flush()
 
         # Create route with segments
-        route = Route(user_id=user.id, name="Integration Test Route", active=True)
+        route = UserRoute(user_id=user.id, name="Integration Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
         segments = [
-            RouteSegment(route_id=route.id, sequence=1, station_id=station_a.id, line_id=line.id),
-            RouteSegment(route_id=route.id, sequence=2, station_id=station_b.id, line_id=None),
+            UserRouteSegment(route_id=route.id, sequence=1, station_id=station_a.id, line_id=line.id),
+            UserRouteSegment(route_id=route.id, sequence=2, station_id=station_b.id, line_id=None),
         ]
         db_session.add_all(segments)
         await db_session.commit()
@@ -339,20 +339,20 @@ class TestAdminRebuildIndexesIntegration:
         await db_session.flush()
 
         # Create multiple routes
-        route1 = Route(user_id=user.id, name="Route 1", active=True)
-        route2 = Route(user_id=user.id, name="Route 2", active=True)
+        route1 = UserRoute(user_id=user.id, name="Route 1", active=True)
+        route2 = UserRoute(user_id=user.id, name="Route 2", active=True)
         db_session.add_all([route1, route2])
         await db_session.flush()
 
         # Route 1: X → Y
         segments1 = [
-            RouteSegment(route_id=route1.id, sequence=1, station_id=station_x.id, line_id=line.id),
-            RouteSegment(route_id=route1.id, sequence=2, station_id=station_y.id, line_id=None),
+            UserRouteSegment(route_id=route1.id, sequence=1, station_id=station_x.id, line_id=line.id),
+            UserRouteSegment(route_id=route1.id, sequence=2, station_id=station_y.id, line_id=None),
         ]
         # Route 2: Y → Z
         segments2 = [
-            RouteSegment(route_id=route2.id, sequence=1, station_id=station_y.id, line_id=line.id),
-            RouteSegment(route_id=route2.id, sequence=2, station_id=station_z.id, line_id=None),
+            UserRouteSegment(route_id=route2.id, sequence=1, station_id=station_y.id, line_id=line.id),
+            UserRouteSegment(route_id=route2.id, sequence=2, station_id=station_z.id, line_id=None),
         ]
         db_session.add_all(segments1 + segments2)
         await db_session.commit()

--- a/backend/tests/test_notification_preference_service.py
+++ b/backend/tests/test_notification_preference_service.py
@@ -2,7 +2,7 @@
 
 import pytest
 from app.models.notification import NotificationMethod
-from app.models.route import Route
+from app.models.route import UserRoute
 from app.models.user import EmailAddress, PhoneNumber, User
 from app.services.notification_preference_service import NotificationPreferenceService
 from fastapi import HTTPException, status
@@ -15,9 +15,9 @@ class TestNotificationPreferenceServiceDirect:
     """Test cases for service-level validation bypassing Pydantic."""
 
     @pytest.fixture
-    async def test_route(self, db_session: AsyncSession, test_user: User) -> Route:
+    async def test_route(self, db_session: AsyncSession, test_user: User) -> UserRoute:
         """Create a test route."""
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Test Route",
             active=True,
@@ -68,7 +68,7 @@ class TestNotificationPreferenceServiceDirect:
         self,
         db_session: AsyncSession,
         test_user: User,
-        test_route: Route,
+        test_route: UserRoute,
     ) -> None:
         """Test creating preference with no targets (bypassing Pydantic)."""
         service = NotificationPreferenceService(db_session)
@@ -90,7 +90,7 @@ class TestNotificationPreferenceServiceDirect:
         self,
         db_session: AsyncSession,
         test_user: User,
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
         verified_phone: PhoneNumber,
     ) -> None:
@@ -124,7 +124,7 @@ class TestNotificationPreferenceServiceDirect:
         self,
         db_session: AsyncSession,
         test_user: User,
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
     ) -> None:
         """Test changing method without providing matching target."""
@@ -158,7 +158,7 @@ class TestNotificationPreferenceServiceDirect:
         self,
         db_session: AsyncSession,
         test_user: User,
-        test_route: Route,
+        test_route: UserRoute,
         verified_phone: PhoneNumber,
     ) -> None:
         """Test changing from SMS to EMAIL method without providing email target."""

--- a/backend/tests/test_notification_preferences_api.py
+++ b/backend/tests/test_notification_preferences_api.py
@@ -8,7 +8,7 @@ from app.core.config import settings
 from app.core.database import get_db
 from app.main import app
 from app.models.notification import NotificationMethod, NotificationPreference
-from app.models.route import Route
+from app.models.route import UserRoute
 from app.models.user import EmailAddress, PhoneNumber, User
 from fastapi import status
 from httpx import AsyncClient
@@ -32,9 +32,9 @@ class TestNotificationPreferencesAPI:
         app.dependency_overrides.clear()
 
     @pytest.fixture
-    async def test_route(self, db_session: AsyncSession, test_user: User) -> Route:
+    async def test_route(self, db_session: AsyncSession, test_user: User) -> UserRoute:
         """Create a test route for the test user."""
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Test Commute",
             description="Test route",
@@ -50,9 +50,9 @@ class TestNotificationPreferencesAPI:
         self,
         db_session: AsyncSession,
         another_user: User,
-    ) -> Route:
+    ) -> UserRoute:
         """Create a test route for another user."""
-        route = Route(
+        route = UserRoute(
             user_id=another_user.id,
             name="Other User Commute",
             active=True,
@@ -159,7 +159,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
     ) -> None:
         """Test listing preferences when none exist."""
         response = await async_client.get(
@@ -175,7 +175,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
         db_session: AsyncSession,
     ) -> None:
@@ -222,7 +222,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        other_user_route: Route,
+        other_user_route: UserRoute,
     ) -> None:
         """Test listing preferences for another user's route."""
         response = await async_client.get(
@@ -236,7 +236,7 @@ class TestNotificationPreferencesAPI:
     async def test_list_preferences_requires_auth(
         self,
         async_client: AsyncClient,
-        test_route: Route,
+        test_route: UserRoute,
     ) -> None:
         """Test that listing requires authentication."""
         response = await async_client.get(
@@ -255,7 +255,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
     ) -> None:
         """Test successfully creating an email notification preference."""
@@ -280,7 +280,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_phone: PhoneNumber,
     ) -> None:
         """Test successfully creating an SMS notification preference."""
@@ -304,7 +304,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
     ) -> None:
         """Test creating preference without target fails validation."""
         response = await async_client.post(
@@ -322,7 +322,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
         verified_phone: PhoneNumber,
     ) -> None:
@@ -344,7 +344,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_phone: PhoneNumber,
     ) -> None:
         """Test that email method requires email target."""
@@ -365,7 +365,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
     ) -> None:
         """Test that SMS method requires phone target."""
@@ -386,7 +386,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         unverified_email: EmailAddress,
     ) -> None:
         """Test creating preference with unverified email fails."""
@@ -407,7 +407,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         unverified_phone: PhoneNumber,
     ) -> None:
         """Test creating preference with unverified phone fails."""
@@ -428,7 +428,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
     ) -> None:
         """Test creating preference with non-existent email."""
         fake_id = uuid.uuid4()
@@ -449,7 +449,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
     ) -> None:
         """Test creating preference with non-existent phone."""
         fake_id = uuid.uuid4()
@@ -470,7 +470,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         other_user_email: EmailAddress,
     ) -> None:
         """Test creating preference with another user's email fails."""
@@ -490,7 +490,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
         db_session: AsyncSession,
     ) -> None:
@@ -522,7 +522,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         test_user: User,
         db_session: AsyncSession,
     ) -> None:
@@ -597,7 +597,7 @@ class TestNotificationPreferencesAPI:
     async def test_create_preference_requires_auth(
         self,
         async_client: AsyncClient,
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
     ) -> None:
         """Test that creating preference requires authentication."""
@@ -621,7 +621,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_phone: PhoneNumber,
         db_session: AsyncSession,
     ) -> None:
@@ -665,7 +665,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
         test_user: User,
         db_session: AsyncSession,
@@ -710,7 +710,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
         verified_phone: PhoneNumber,
         db_session: AsyncSession,
@@ -743,7 +743,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
         verified_phone: PhoneNumber,
         db_session: AsyncSession,
@@ -780,7 +780,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
         unverified_email: EmailAddress,
         db_session: AsyncSession,
@@ -813,7 +813,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         test_user: User,
         db_session: AsyncSession,
     ) -> None:
@@ -866,7 +866,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
     ) -> None:
         """Test updating non-existent preference."""
@@ -886,7 +886,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        other_user_route: Route,
+        other_user_route: UserRoute,
         other_user_email: EmailAddress,
         db_session: AsyncSession,
     ) -> None:
@@ -916,7 +916,7 @@ class TestNotificationPreferencesAPI:
     async def test_update_preference_requires_auth(
         self,
         async_client: AsyncClient,
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
         db_session: AsyncSession,
     ) -> None:
@@ -948,7 +948,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_phone: PhoneNumber,
         db_session: AsyncSession,
     ) -> None:
@@ -980,7 +980,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
         db_session: AsyncSession,
     ) -> None:
@@ -1012,7 +1012,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_phone: PhoneNumber,
         unverified_phone: PhoneNumber,
         db_session: AsyncSession,
@@ -1045,7 +1045,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_phone: PhoneNumber,
         db_session: AsyncSession,
     ) -> None:
@@ -1076,7 +1076,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
         db_session: AsyncSession,
     ) -> None:
@@ -1109,7 +1109,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
         db_session: AsyncSession,
     ) -> None:
@@ -1143,7 +1143,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        test_route: Route,
+        test_route: UserRoute,
     ) -> None:
         """Test deleting non-existent preference."""
         fake_id = uuid.uuid4()
@@ -1159,7 +1159,7 @@ class TestNotificationPreferencesAPI:
         self,
         async_client: AsyncClient,
         auth_headers_for_user: dict[str, str],
-        other_user_route: Route,
+        other_user_route: UserRoute,
         other_user_email: EmailAddress,
         db_session: AsyncSession,
     ) -> None:
@@ -1185,7 +1185,7 @@ class TestNotificationPreferencesAPI:
     async def test_delete_preference_requires_auth(
         self,
         async_client: AsyncClient,
-        test_route: Route,
+        test_route: UserRoute,
         verified_email: EmailAddress,
         db_session: AsyncSession,
     ) -> None:
@@ -1220,8 +1220,8 @@ class TestNotificationPreferencesAPI:
     ) -> None:
         """Test updating with mismatched route_id in URL."""
         # Create two routes
-        route1 = Route(user_id=test_user.id, name="Route 1", active=True)
-        route2 = Route(user_id=test_user.id, name="Route 2", active=True)
+        route1 = UserRoute(user_id=test_user.id, name="Route 1", active=True)
+        route2 = UserRoute(user_id=test_user.id, name="Route 2", active=True)
         db_session.add_all([route1, route2])
         await db_session.commit()
         await db_session.refresh(route1)
@@ -1260,8 +1260,8 @@ class TestNotificationPreferencesAPI:
     ) -> None:
         """Test deleting with mismatched route_id in URL."""
         # Create two routes
-        route1 = Route(user_id=test_user.id, name="Route 1", active=True)
-        route2 = Route(user_id=test_user.id, name="Route 2", active=True)
+        route1 = UserRoute(user_id=test_user.id, name="Route 1", active=True)
+        route2 = UserRoute(user_id=test_user.id, name="Route 2", active=True)
         db_session.add_all([route1, route2])
         await db_session.commit()
         await db_session.refresh(route1)

--- a/backend/tests/test_route_index_service.py
+++ b/backend/tests/test_route_index_service.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import UTC, datetime
 
 import pytest
-from app.models.route import Route, RouteSegment
+from app.models.route import UserRoute, UserRouteSegment
 from app.models.route_index import RouteStationIndex
 from app.models.tfl import Line, Station
 from app.models.user import User
@@ -97,7 +97,7 @@ class TestRouteIndexService:
         await db_session.flush()
 
         # Create route with 2 segments
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Test Route",
             active=True,
@@ -105,13 +105,13 @@ class TestRouteIndexService:
         db_session.add(route)
         await db_session.flush()
 
-        segment1 = RouteSegment(
+        segment1 = UserRouteSegment(
             route_id=route.id,
             sequence=1,
             station_id=station1.id,
             line_id=line.id,
         )
-        segment2 = RouteSegment(
+        segment2 = UserRouteSegment(
             route_id=route.id,
             sequence=2,
             station_id=station2.id,
@@ -175,7 +175,7 @@ class TestRouteIndexService:
         await db_session.flush()
 
         # Create route: parallel-north → parallel-south
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="North to South Route",
             active=True,
@@ -183,13 +183,13 @@ class TestRouteIndexService:
         db_session.add(route)
         await db_session.flush()
 
-        segment1 = RouteSegment(
+        segment1 = UserRouteSegment(
             route_id=route.id,
             sequence=1,
             station_id=station_north.id,
             line_id=line.id,
         )
-        segment2 = RouteSegment(
+        segment2 = UserRouteSegment(
             route_id=route.id,
             sequence=2,
             station_id=station_south.id,
@@ -255,7 +255,7 @@ class TestRouteIndexService:
         await db_session.flush()
 
         # Create route: west-fork → fork-south-end (via junction)
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="West Branch Route",
             active=True,
@@ -263,13 +263,13 @@ class TestRouteIndexService:
         db_session.add(route)
         await db_session.flush()
 
-        segment1 = RouteSegment(
+        segment1 = UserRouteSegment(
             route_id=route.id,
             sequence=1,
             station_id=station_west_fork.id,
             line_id=line.id,
         )
-        segment2 = RouteSegment(
+        segment2 = UserRouteSegment(
             route_id=route.id,
             sequence=2,
             station_id=station_south.id,
@@ -317,7 +317,7 @@ class TestRouteIndexService:
         await db_session.flush()
 
         # Create route with 4 segments across 2 lines
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Multi-Line Route",
             active=True,
@@ -326,10 +326,10 @@ class TestRouteIndexService:
         await db_session.flush()
 
         segments = [
-            RouteSegment(route_id=route.id, sequence=1, station_id=station1.id, line_id=line1.id),
-            RouteSegment(route_id=route.id, sequence=2, station_id=station2.id, line_id=None),  # Interchange
-            RouteSegment(route_id=route.id, sequence=3, station_id=station3.id, line_id=line2.id),
-            RouteSegment(route_id=route.id, sequence=4, station_id=station4.id, line_id=None),  # Destination
+            UserRouteSegment(route_id=route.id, sequence=1, station_id=station1.id, line_id=line1.id),
+            UserRouteSegment(route_id=route.id, sequence=2, station_id=station2.id, line_id=None),  # Interchange
+            UserRouteSegment(route_id=route.id, sequence=3, station_id=station3.id, line_id=line2.id),
+            UserRouteSegment(route_id=route.id, sequence=4, station_id=station4.id, line_id=None),  # Destination
         ]
         db_session.add_all(segments)
         await db_session.commit()
@@ -384,7 +384,7 @@ class TestRouteIndexService:
     ) -> None:
         """Test building index for route with < 2 segments returns zero entries."""
         # Create route with only 1 segment
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Single Segment Route",
             active=True,
@@ -397,7 +397,7 @@ class TestRouteIndexService:
         db_session.add_all([station, line])
         await db_session.flush()
 
-        segment = RouteSegment(
+        segment = UserRouteSegment(
             route_id=route.id,
             sequence=1,
             station_id=station.id,
@@ -434,7 +434,7 @@ class TestRouteIndexService:
         await db_session.flush()
 
         # Create route
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Test Route",
             active=True,
@@ -442,13 +442,13 @@ class TestRouteIndexService:
         db_session.add(route)
         await db_session.flush()
 
-        segment1 = RouteSegment(
+        segment1 = UserRouteSegment(
             route_id=route.id,
             sequence=1,
             station_id=station1.id,
             line_id=line.id,
         )
-        segment2 = RouteSegment(
+        segment2 = UserRouteSegment(
             route_id=route.id,
             sequence=2,
             station_id=station2.id,
@@ -493,7 +493,7 @@ class TestRouteIndexService:
         await db_session.flush()
 
         # Create route
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Test Route",
             active=True,
@@ -501,13 +501,13 @@ class TestRouteIndexService:
         db_session.add(route)
         await db_session.flush()
 
-        segment1 = RouteSegment(
+        segment1 = UserRouteSegment(
             route_id=route.id,
             sequence=1,
             station_id=station1.id,
             line_id=line.id,
         )
-        segment2 = RouteSegment(
+        segment2 = UserRouteSegment(
             route_id=route.id,
             sequence=2,
             station_id=station2.id,
@@ -540,7 +540,7 @@ class TestRouteIndexService:
         await db_session.flush()
 
         # Create route
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Test Route",
             active=True,
@@ -548,13 +548,13 @@ class TestRouteIndexService:
         db_session.add(route)
         await db_session.flush()
 
-        segment1 = RouteSegment(
+        segment1 = UserRouteSegment(
             route_id=route.id,
             sequence=1,
             station_id=station1.id,
             line_id=line.id,
         )
-        segment2 = RouteSegment(
+        segment2 = UserRouteSegment(
             route_id=route.id,
             sequence=2,
             station_id=station2.id,
@@ -585,7 +585,7 @@ class TestRouteIndexService:
             await service.build_route_station_index(fake_route_id)
 
         # Session should still be usable after rollback
-        result = await db_session.execute(select(Route))
+        result = await db_session.execute(select(UserRoute))
         routes = result.scalars().all()
         assert isinstance(routes, list)  # Session still works
 
@@ -605,7 +605,7 @@ class TestRouteIndexService:
         await db_session.flush()
 
         # Create route
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Test Route",
             active=True,
@@ -613,13 +613,13 @@ class TestRouteIndexService:
         db_session.add(route)
         await db_session.flush()
 
-        segment1 = RouteSegment(
+        segment1 = UserRouteSegment(
             route_id=route.id,
             sequence=1,
             station_id=station1.id,
             line_id=line.id,
         )
-        segment2 = RouteSegment(
+        segment2 = UserRouteSegment(
             route_id=route.id,
             sequence=2,
             station_id=station2.id,
@@ -656,13 +656,13 @@ class TestRouteIndexService:
         await db_session.flush()
 
         # Create route with 2 segments
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
         segments = [
-            RouteSegment(route_id=route.id, sequence=1, station_id=station1.id, line_id=line.id),
-            RouteSegment(route_id=route.id, sequence=2, station_id=station2.id, line_id=None),
+            UserRouteSegment(route_id=route.id, sequence=1, station_id=station1.id, line_id=line.id),
+            UserRouteSegment(route_id=route.id, sequence=2, station_id=station2.id, line_id=None),
         ]
         db_session.add_all(segments)
         await db_session.commit()
@@ -738,24 +738,24 @@ class TestRouteIndexService:
         # Segment 0→1: parallel-north → hubnorth-overground on parallelline
         # Resolution: hubnorth-overground (not on parallelline) should resolve to
         # parallel-north (in same hub, on parallelline)
-        route = Route(user_id=test_user.id, name="Hub Interchange Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Hub Interchange Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
         segments = [
-            RouteSegment(
+            UserRouteSegment(
                 route_id=route.id,
                 sequence=1,
                 station_id=parallel_north.id,
                 line_id=parallelline.id,
             ),
-            RouteSegment(
+            UserRouteSegment(
                 route_id=route.id,
                 sequence=2,
                 station_id=hubnorth_overground.id,
                 line_id=asymmetricline.id,
             ),
-            RouteSegment(
+            UserRouteSegment(
                 route_id=route.id,
                 sequence=3,
                 station_id=asym_regular_1.id,
@@ -800,18 +800,18 @@ class TestRouteIndexService:
 
         # Create route with a segment where both stations are in hubs
         # This won't actually connect in our test network, but tests the resolution logic
-        route = Route(user_id=test_user.id, name="Two Hubs Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Two Hubs Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
         segments = [
-            RouteSegment(
+            UserRouteSegment(
                 route_id=route.id,
                 sequence=1,
                 station_id=fork_mid_1.id,
                 line_id=forkedline.id,
             ),
-            RouteSegment(
+            UserRouteSegment(
                 route_id=route.id,
                 sequence=2,
                 station_id=fork_south_end.id,
@@ -845,18 +845,18 @@ class TestRouteIndexService:
         await db_session.flush()
 
         # Create route using station that's already on the line (no resolution needed)
-        route = Route(user_id=test_user.id, name="Direct Hub Station", active=True)
+        route = UserRoute(user_id=test_user.id, name="Direct Hub Station", active=True)
         db_session.add(route)
         await db_session.flush()
 
         segments = [
-            RouteSegment(
+            UserRouteSegment(
                 route_id=route.id,
                 sequence=1,
                 station_id=parallel_north.id,
                 line_id=parallelline.id,
             ),
-            RouteSegment(
+            UserRouteSegment(
                 route_id=route.id,
                 sequence=2,
                 station_id=parallel_split.id,
@@ -901,18 +901,18 @@ class TestRouteIndexService:
         await db_session.flush()
 
         # Create route using the fake hub station
-        route = Route(user_id=test_user.id, name="Broken Hub Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Broken Hub Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
         segments = [
-            RouteSegment(
+            UserRouteSegment(
                 route_id=route.id,
                 sequence=1,
                 station_id=fake_hub_station.id,
                 line_id=parallelline.id,
             ),
-            RouteSegment(
+            UserRouteSegment(
                 route_id=route.id,
                 sequence=2,
                 station_id=parallel_split.id,
@@ -942,18 +942,18 @@ class TestRouteIndexService:
         db_session.add_all([forkedline, fork_junction, fork_mid_2])
         await db_session.flush()
 
-        route = Route(user_id=test_user.id, name="Non-Hub Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Non-Hub Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
         segments = [
-            RouteSegment(
+            UserRouteSegment(
                 route_id=route.id,
                 sequence=1,
                 station_id=fork_junction.id,
                 line_id=forkedline.id,
             ),
-            RouteSegment(
+            UserRouteSegment(
                 route_id=route.id,
                 sequence=2,
                 station_id=fork_mid_2.id,
@@ -990,13 +990,13 @@ class TestRebuildRoutes:
         await db_session.flush()
 
         # Create route
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
         segments = [
-            RouteSegment(route_id=route.id, sequence=1, station_id=station1.id, line_id=line.id),
-            RouteSegment(route_id=route.id, sequence=2, station_id=station2.id, line_id=None),
+            UserRouteSegment(route_id=route.id, sequence=1, station_id=station1.id, line_id=line.id),
+            UserRouteSegment(route_id=route.id, sequence=2, station_id=station2.id, line_id=None),
         ]
         db_session.add_all(segments)
         await db_session.commit()
@@ -1049,13 +1049,13 @@ class TestRebuildRoutes:
         # Create 3 routes
         routes = []
         for i in range(3):
-            route = Route(user_id=test_user.id, name=f"Route {i}", active=True)
+            route = UserRoute(user_id=test_user.id, name=f"Route {i}", active=True)
             db_session.add(route)
             await db_session.flush()
 
             segments = [
-                RouteSegment(route_id=route.id, sequence=1, station_id=station1.id, line_id=line.id),
-                RouteSegment(route_id=route.id, sequence=2, station_id=station2.id, line_id=None),
+                UserRouteSegment(route_id=route.id, sequence=1, station_id=station1.id, line_id=line.id),
+                UserRouteSegment(route_id=route.id, sequence=2, station_id=station2.id, line_id=None),
             ]
             db_session.add_all(segments)
             routes.append(route)
@@ -1096,13 +1096,13 @@ class TestRebuildRoutes:
         # Create 2 valid routes
         valid_routes = []
         for i in range(2):
-            route = Route(user_id=test_user.id, name=f"Valid Route {i}", active=True)
+            route = UserRoute(user_id=test_user.id, name=f"Valid Route {i}", active=True)
             db_session.add(route)
             await db_session.flush()
 
             segments = [
-                RouteSegment(route_id=route.id, sequence=1, station_id=station1.id, line_id=line.id),
-                RouteSegment(route_id=route.id, sequence=2, station_id=station2.id, line_id=None),
+                UserRouteSegment(route_id=route.id, sequence=1, station_id=station1.id, line_id=line.id),
+                UserRouteSegment(route_id=route.id, sequence=2, station_id=station2.id, line_id=None),
             ]
             db_session.add_all(segments)
             valid_routes.append(route)
@@ -1153,7 +1153,7 @@ class TestRebuildRoutes:
     ) -> None:
         """Test that rebuild_routes handles different exception types consistently."""
         # Create route with insufficient segments (will cause warning but not exception)
-        route = Route(user_id=test_user.id, name="Insufficient Segments", active=True)
+        route = UserRoute(user_id=test_user.id, name="Insufficient Segments", active=True)
         db_session.add(route)
         await db_session.flush()
 
@@ -1163,7 +1163,7 @@ class TestRebuildRoutes:
         db_session.add_all([line, station])
         await db_session.flush()
 
-        segment = RouteSegment(route_id=route.id, sequence=1, station_id=station.id, line_id=line.id)
+        segment = UserRouteSegment(route_id=route.id, sequence=1, station_id=station.id, line_id=line.id)
         db_session.add(segment)
         await db_session.commit()
 
@@ -1206,14 +1206,14 @@ class TestRebuildRoutes:
         await db_session.flush()
 
         # Create route
-        route = Route(user_id=test_user.id, name="Empty Variant Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Empty Variant Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
         # Add segments using this line
         segments = [
-            RouteSegment(route_id=route.id, sequence=1, station_id=station1.id, line_id=line.id),
-            RouteSegment(route_id=route.id, sequence=2, station_id=station2.id, line_id=None),
+            UserRouteSegment(route_id=route.id, sequence=1, station_id=station1.id, line_id=line.id),
+            UserRouteSegment(route_id=route.id, sequence=2, station_id=station2.id, line_id=None),
         ]
         db_session.add_all(segments)
         await db_session.commit()

--- a/backend/tests/test_route_service.py
+++ b/backend/tests/test_route_service.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from app.models.route import Route
+from app.models.route import UserRoute
 from app.models.tfl import Line, Station
 from app.models.user import User
 from app.schemas.routes import SegmentRequest
@@ -23,7 +23,7 @@ class TestRouteServiceUpsertSegments:
     ) -> None:
         """Test that database errors trigger rollback in upsert_segments."""
         # Create test data
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
 
         line = Line(tfl_id="victoria", name="Victoria", last_updated=datetime.now(UTC))

--- a/backend/tests/test_routes_api.py
+++ b/backend/tests/test_routes_api.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from app.core.database import get_db
 from app.main import app
-from app.models.route import Route, RouteSchedule, RouteSegment
+from app.models.route import UserRoute, UserRouteSchedule, UserRouteSegment
 from app.models.tfl import Line, Station
 from app.models.user import User
 from fastapi import HTTPException, status
@@ -157,8 +157,8 @@ class TestRoutesAPI:
     ) -> None:
         """Test listing all routes for a user."""
         # Create test routes
-        route1 = Route(user_id=test_user.id, name="Route 1", active=True, timezone="Europe/London")
-        route2 = Route(user_id=test_user.id, name="Route 2", active=False, timezone="Europe/London")
+        route1 = UserRoute(user_id=test_user.id, name="Route 1", active=True, timezone="Europe/London")
+        route2 = UserRoute(user_id=test_user.id, name="Route 2", active=False, timezone="Europe/London")
         db_session.add_all([route1, route2])
         await db_session.commit()
 
@@ -199,8 +199,8 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test that users can only see their own routes."""
-        route1 = Route(user_id=test_user.id, name="My Route", active=True)
-        route2 = Route(user_id=another_user.id, name="Other Route", active=True)
+        route1 = UserRoute(user_id=test_user.id, name="My Route", active=True)
+        route2 = UserRoute(user_id=another_user.id, name="Other Route", active=True)
         db_session.add_all([route1, route2])
         await db_session.commit()
 
@@ -223,7 +223,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test getting a single route by ID."""
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Test Route",
             description="Test description",
@@ -268,7 +268,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test that users cannot access other users' routes."""
-        route = Route(user_id=another_user.id, name="Other Route", active=True)
+        route = UserRoute(user_id=another_user.id, name="Other Route", active=True)
         db_session.add(route)
         await db_session.commit()
         await db_session.refresh(route)
@@ -289,7 +289,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test updating a route."""
-        route = Route(user_id=test_user.id, name="Old Name", active=True)
+        route = UserRoute(user_id=test_user.id, name="Old Name", active=True)
         db_session.add(route)
         await db_session.commit()
         await db_session.refresh(route)
@@ -319,7 +319,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test partial update of a route."""
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Old Name",
             description="Old description",
@@ -350,7 +350,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test deleting a route."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.commit()
         route_id = route.id
@@ -363,7 +363,7 @@ class TestRoutesAPI:
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
         # Verify route was deleted
-        result = await db_session.execute(select(Route).where(Route.id == route_id))
+        result = await db_session.execute(select(UserRoute).where(UserRoute.id == route_id))
         assert result.scalar_one_or_none() is None
 
     # ==================== Timezone Tests ====================
@@ -434,7 +434,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test updating a route's timezone."""
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Test Route",
             active=True,
@@ -463,7 +463,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test updating a route with invalid timezone fails validation."""
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Test Route",
             active=True,
@@ -492,7 +492,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test that getting a route returns timezone field."""
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Test Route",
             active=True,
@@ -520,7 +520,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test that listing routes includes timezone field."""
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Test Route",
             active=True,
@@ -548,7 +548,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test that updating route with timezone=None preserves existing timezone."""
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Test Route",
             active=True,
@@ -579,7 +579,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test that updating route with explicit timezone: null preserves existing timezone."""
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Test Route",
             active=True,
@@ -620,7 +620,7 @@ class TestRoutesAPI:
         # Mock validation to pass
         mock_validate.return_value = None
 
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.commit()
         await db_session.refresh(route)
@@ -670,7 +670,7 @@ class TestRoutesAPI:
             detail="Route validation failed: No connection between stations",
         )
 
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.commit()
         await db_session.refresh(route)
@@ -709,7 +709,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test that non-consecutive sequences are rejected."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.commit()
         await db_session.refresh(route)
@@ -752,11 +752,11 @@ class TestRoutesAPI:
         # Mock validation to pass
         mock_validate.return_value = None
 
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
-        segment = RouteSegment(
+        segment = UserRouteSegment(
             route_id=route.id,
             sequence=0,
             station_id=test_station1.id,
@@ -787,13 +787,13 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test deleting a segment and resequencing."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
         # Create 3 segments
         segments = [
-            RouteSegment(
+            UserRouteSegment(
                 route_id=route.id,
                 sequence=i,
                 station_id=test_station1.id if i % 2 == 0 else test_station2.id,
@@ -813,7 +813,7 @@ class TestRoutesAPI:
 
         # Verify segment was deleted and others resequenced
         result = await db_session.execute(
-            select(RouteSegment).where(RouteSegment.route_id == route.id).order_by(RouteSegment.sequence)
+            select(UserRouteSegment).where(UserRouteSegment.route_id == route.id).order_by(UserRouteSegment.sequence)
         )
         remaining = list(result.scalars().all())
         assert len(remaining) == 2
@@ -832,13 +832,13 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test that deletion is prevented if it would leave <2 segments."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
         # Create exactly 2 segments (minimum)
         segments = [
-            RouteSegment(
+            UserRouteSegment(
                 route_id=route.id,
                 sequence=i,
                 station_id=test_station1.id if i == 0 else test_station2.id,
@@ -875,7 +875,7 @@ class TestRoutesAPI:
         # Mock validation to pass
         mock_validate.return_value = None
 
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.commit()
         await db_session.refresh(route)
@@ -922,7 +922,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test creating a schedule for a route."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.commit()
         await db_session.refresh(route)
@@ -952,7 +952,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test that invalid day codes are rejected."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.commit()
         await db_session.refresh(route)
@@ -978,7 +978,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test that end_time must be after start_time."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.commit()
         await db_session.refresh(route)
@@ -1004,11 +1004,11 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test service-layer validation when partially updating time (only one field)."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
-        schedule = RouteSchedule(
+        schedule = UserRouteSchedule(
             route_id=route.id,
             days_of_week=["MON"],
             start_time=time(8, 0),
@@ -1038,11 +1038,11 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test updating a schedule."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
-        schedule = RouteSchedule(
+        schedule = UserRouteSchedule(
             route_id=route.id,
             days_of_week=["MON", "TUE"],
             start_time=time(8, 0),
@@ -1071,11 +1071,11 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test deleting a schedule."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
-        schedule = RouteSchedule(
+        schedule = UserRouteSchedule(
             route_id=route.id,
             days_of_week=["MON"],
             start_time=time(8, 0),
@@ -1093,7 +1093,7 @@ class TestRoutesAPI:
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
         # Verify deletion
-        result = await db_session.execute(select(RouteSchedule).where(RouteSchedule.id == schedule_id))
+        result = await db_session.execute(select(UserRouteSchedule).where(UserRouteSchedule.id == schedule_id))
         assert result.scalar_one_or_none() is None
 
     @pytest.mark.asyncio
@@ -1106,11 +1106,11 @@ class TestRoutesAPI:
     ) -> None:
         """Test that users cannot modify other users' schedules."""
         # Create route and schedule for another user
-        route = Route(user_id=another_user.id, name="Other Route", active=True)
+        route = UserRoute(user_id=another_user.id, name="Other Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
-        schedule = RouteSchedule(
+        schedule = UserRouteSchedule(
             route_id=route.id,
             days_of_week=["MON"],
             start_time=time(8, 0),
@@ -1141,7 +1141,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test updating a non-existent segment."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.commit()
         await db_session.refresh(route)
@@ -1167,13 +1167,13 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test deleting a non-existent segment."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
         # Add 3 segments so we can test deletion without hitting minimum constraint
         segments = [
-            RouteSegment(
+            UserRouteSegment(
                 route_id=route.id,
                 sequence=i,
                 station_id=test_station1.id if i % 2 == 0 else test_station2.id,
@@ -1201,7 +1201,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test updating/deleting a non-existent schedule."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.commit()
         await db_session.refresh(route)
@@ -1234,7 +1234,7 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test updating only the description field of a route."""
-        route = Route(
+        route = UserRoute(
             user_id=test_user.id,
             name="Original Name",
             description="Original description",
@@ -1282,11 +1282,11 @@ class TestRoutesAPI:
         await db_session.commit()
         await db_session.refresh(line2)
 
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
-        segment = RouteSegment(
+        segment = UserRouteSegment(
             route_id=route.id,
             sequence=0,
             station_id=test_station1.id,
@@ -1315,11 +1315,11 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test updating only the start_time field of a schedule."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
-        schedule = RouteSchedule(
+        schedule = UserRouteSchedule(
             route_id=route.id,
             days_of_week=["MON"],
             start_time=time(8, 0),
@@ -1361,7 +1361,7 @@ class TestRoutesAPI:
             detail="Route validation failed: Station not on line (segment index: 1)",
         )
 
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.commit()
         await db_session.refresh(route)
@@ -1410,11 +1410,11 @@ class TestRoutesAPI:
             detail="Route validation failed: Invalid route configuration",
         )
 
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
-        segment = RouteSegment(
+        segment = UserRouteSegment(
             route_id=route.id,
             sequence=0,
             station_id=test_station1.id,
@@ -1441,11 +1441,11 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test updating schedule without providing days_of_week (None case)."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
-        schedule = RouteSchedule(
+        schedule = UserRouteSchedule(
             route_id=route.id,
             days_of_week=["MON", "TUE"],
             start_time=time(8, 0),
@@ -1484,7 +1484,7 @@ class TestRoutesAPI:
         # Mock TfL service to return validation failure with index
         mock_validate_route.return_value = (False, "Station not on line", 1)
 
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.commit()
         await db_session.refresh(route)
@@ -1531,7 +1531,7 @@ class TestRoutesAPI:
         # Mock TfL service to return validation failure without index
         mock_validate_route.return_value = (False, "Invalid route configuration", None)
 
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.commit()
         await db_session.refresh(route)
@@ -1579,11 +1579,11 @@ class TestRoutesAPI:
         # Mock TfL service to return success
         mock_validate_route.return_value = (True, "", None)
 
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
-        segment = RouteSegment(
+        segment = UserRouteSegment(
             route_id=route.id,
             sequence=0,
             station_id=test_station1.id,
@@ -1611,11 +1611,11 @@ class TestRoutesAPI:
         db_session: AsyncSession,
     ) -> None:
         """Test updating schedule with explicit days_of_week: None to trigger validator line 153."""
-        route = Route(user_id=test_user.id, name="Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
         db_session.add(route)
         await db_session.flush()
 
-        schedule = RouteSchedule(
+        schedule = UserRouteSchedule(
             route_id=route.id,
             days_of_week=["MON", "TUE"],
             start_time=time(8, 0),
@@ -1672,7 +1672,7 @@ class TestRouteSegmentsWithHubCodes:
         - Destination on elizabethline
         """
         # Create route
-        route = Route(user_id=test_user.id, name="Cross-Mode Hub Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Cross-Mode Hub Route", active=True)
         db_session.add(route)
         await db_session.commit()
 
@@ -1708,7 +1708,7 @@ class TestRouteSegmentsWithHubCodes:
         test_railway_network: RailwayNetworkFixture,
     ) -> None:
         """Test creating route with mix of hub codes and regular station IDs."""
-        route = Route(user_id=test_user.id, name="Mixed Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Mixed Route", active=True)
         db_session.add(route)
         await db_session.commit()
 
@@ -1758,7 +1758,7 @@ class TestRouteSegmentsWithHubCodes:
         db_session.add_all([line3, other_station])
         await db_session.commit()
 
-        route = Route(user_id=test_user.id, name="Invalid Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Invalid Route", active=True)
         db_session.add(route)
         await db_session.commit()
 
@@ -1788,7 +1788,7 @@ class TestRouteSegmentsWithHubCodes:
         test_railway_network: RailwayNetworkFixture,
     ) -> None:
         """Test updating an existing segment to use a hub code."""
-        route = Route(user_id=test_user.id, name="Update Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Update Test Route", active=True)
         db_session.add(route)
         await db_session.commit()
 
@@ -1828,7 +1828,7 @@ class TestRouteSegmentsWithHubCodes:
         test_railway_network: RailwayNetworkFixture,
     ) -> None:
         """Test GET route returns hub codes (canonicalize on read)."""
-        route = Route(user_id=test_user.id, name="Canonical Test Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Canonical Test Route", active=True)
         db_session.add(route)
         await db_session.commit()
 
@@ -1869,7 +1869,7 @@ class TestRouteSegmentsWithHubCodes:
         test_railway_network: RailwayNetworkFixture,
     ) -> None:
         """Test that existing routes using station IDs continue to work."""
-        route = Route(user_id=test_user.id, name="Backward Compat Route", active=True)
+        route = UserRoute(user_id=test_user.id, name="Backward Compat Route", active=True)
         db_session.add(route)
         await db_session.commit()
 


### PR DESCRIPTION
Closes #175 by

- Updated test_route_index_service.py to replace Route and RouteSegment with UserRoute and UserRouteSegment.
- Modified test_route_service.py to utilize UserRoute instead of Route.
- Changed test_routes_api.py to implement UserRoute and UserRouteSegment in all relevant tests.