### PR TITLE
refactor(services): rename RouteService to UserRouteService (#178)

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -32,8 +32,8 @@ from app.schemas.admin import (
 from app.schemas.tfl import BuildGraphResponse
 from app.services.admin_service import AdminService
 from app.services.alert_service import AlertService, get_redis_client
-from app.services.route_index_service import RouteIndexService
 from app.services.tfl_service import TfLService
+from app.services.user_route_index_service import UserRouteIndexService
 
 router = APIRouter(prefix="/admin", tags=["admin"])
 logger = structlog.get_logger(__name__)
@@ -544,7 +544,7 @@ async def rebuild_route_indexes(
     Raises:
         HTTPException: 403 if not admin
     """
-    index_service = RouteIndexService(db)
+    index_service = UserRouteIndexService(db)
 
     try:
         # Use shared rebuild_routes method for consistent behavior

--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -21,7 +21,7 @@ from app.schemas.routes import (
     UpdateSegmentRequest,
     UpsertSegmentsRequest,
 )
-from app.services.route_service import RouteService
+from app.services.user_route_service import UserRouteService
 
 router = APIRouter(prefix="/routes", tags=["routes"])
 
@@ -47,7 +47,7 @@ async def list_routes(
     Returns:
         List of routes with counts
     """
-    service = RouteService(db)
+    service = UserRouteService(db)
     routes = await service.list_routes(current_user.id)
 
     # Build response with counts using Pydantic models
@@ -85,7 +85,7 @@ async def create_route(
     Returns:
         Created route
     """
-    service = RouteService(db)
+    service = UserRouteService(db)
     route = await service.create_route(current_user.id, request)
 
     # Reload with full relationships for response serialization
@@ -112,7 +112,7 @@ async def get_route(
     Raises:
         HTTPException: 404 if route not found or doesn't belong to user
     """
-    service = RouteService(db)
+    service = UserRouteService(db)
     return await service.get_route_by_id(route_id, current_user.id, load_relationships=True)
 
 
@@ -140,7 +140,7 @@ async def update_route(
     Raises:
         HTTPException: 404 if route not found or doesn't belong to user
     """
-    service = RouteService(db)
+    service = UserRouteService(db)
     await service.update_route(route_id, current_user.id, request)
 
     # Reload with full relationships for response serialization
@@ -166,7 +166,7 @@ async def delete_route(
     Raises:
         HTTPException: 404 if route not found or doesn't belong to user
     """
-    service = RouteService(db)
+    service = UserRouteService(db)
     await service.delete_route(route_id, current_user.id)
 
 
@@ -198,7 +198,7 @@ async def upsert_segments(
     Raises:
         HTTPException: 404 if route not found, 400 if validation fails
     """
-    service = RouteService(db)
+    service = UserRouteService(db)
     return await service.upsert_segments(route_id, current_user.id, request.segments)
 
 
@@ -229,7 +229,7 @@ async def update_segment(
     Raises:
         HTTPException: 404 if route or segment not found, 400 if validation fails
     """
-    service = RouteService(db)
+    service = UserRouteService(db)
     return await service.update_segment(route_id, current_user.id, sequence, request)
 
 
@@ -254,7 +254,7 @@ async def delete_segment(
     Raises:
         HTTPException: 404 if route or segment not found, 400 if would leave <2 segments
     """
-    service = RouteService(db)
+    service = UserRouteService(db)
     await service.delete_segment(route_id, current_user.id, sequence)
 
 
@@ -285,7 +285,7 @@ async def create_schedule(
     Raises:
         HTTPException: 404 if route not found
     """
-    service = RouteService(db)
+    service = UserRouteService(db)
     return await service.create_schedule(route_id, current_user.id, request)
 
 
@@ -315,7 +315,7 @@ async def update_schedule(
     Raises:
         HTTPException: 404 if route or schedule not found, 400 if time validation fails
     """
-    service = RouteService(db)
+    service = UserRouteService(db)
     return await service.update_schedule(route_id, schedule_id, current_user.id, request)
 
 
@@ -338,5 +338,5 @@ async def delete_schedule(
     Raises:
         HTTPException: 404 if route or schedule not found
     """
-    service = RouteService(db)
+    service = UserRouteService(db)
     await service.delete_schedule(route_id, schedule_id, current_user.id)

--- a/backend/app/celery/tasks.py
+++ b/backend/app/celery/tasks.py
@@ -18,7 +18,7 @@ from app.celery.database import get_worker_session, reset_worker_engine
 from app.models.route_index import RouteStationIndex
 from app.models.tfl import Line
 from app.services.alert_service import AlertService, get_redis_client
-from app.services.route_index_service import RouteIndexService
+from app.services.user_route_index_service import UserRouteIndexService
 
 logger = structlog.get_logger(__name__)
 
@@ -286,7 +286,7 @@ async def _rebuild_indexes_async(route_id_str: str | None = None) -> RebuildInde
     try:
         # Create database session for this task
         session = get_worker_session()
-        index_service = RouteIndexService(session)
+        index_service = UserRouteIndexService(session)
 
         # Parse route_id if provided
         route_id = UUID(route_id_str) if route_id_str else None

--- a/backend/app/services/user_route_index_service.py
+++ b/backend/app/services/user_route_index_service.py
@@ -24,7 +24,7 @@ class RebuildRoutesResult(TypedDict):
     errors: list[str]
 
 
-class RouteIndexService:
+class UserRouteIndexService:
     """
     Service for building inverted indexes mapping (line, station) → routes.
 

--- a/backend/app/services/user_route_service.py
+++ b/backend/app/services/user_route_service.py
@@ -19,14 +19,14 @@ from app.schemas.routes import (
     UpdateSegmentRequest,
 )
 from app.schemas.tfl import RouteSegmentRequest
-from app.services.route_index_service import RouteIndexService
 from app.services.tfl_service import TfLService
+from app.services.user_route_index_service import UserRouteIndexService
 
 # Constants
 MIN_ROUTE_SEGMENTS = 2
 
 
-class RouteService:
+class UserRouteService:
     """Service for managing user routes."""
 
     def __init__(self, db: AsyncSession) -> None:
@@ -242,7 +242,7 @@ class RouteService:
             await self.db.flush()  # Flush to make segments available for index building
 
             # Build route station index (part of same transaction)
-            index_service = RouteIndexService(self.db)
+            index_service = UserRouteIndexService(self.db)
             await index_service.build_route_station_index(route_id, auto_commit=False)
 
             await self.db.commit()
@@ -315,7 +315,7 @@ class RouteService:
         await self.db.flush()  # Flush to make changes available for index building
 
         # Rebuild route station index (part of same transaction)
-        index_service = RouteIndexService(self.db)
+        index_service = UserRouteIndexService(self.db)
         await index_service.build_route_station_index(route_id, auto_commit=False)
 
         await self.db.commit()
@@ -379,7 +379,7 @@ class RouteService:
         await self.db.flush()  # Flush to make changes available for index building
 
         # Rebuild route station index (part of same transaction)
-        index_service = RouteIndexService(self.db)
+        index_service = UserRouteIndexService(self.db)
         await index_service.build_route_station_index(route_id, auto_commit=False)
 
         await self.db.commit()

--- a/backend/refactoring-notes.md
+++ b/backend/refactoring-notes.md
@@ -168,11 +168,32 @@ Each phase must achieve:
 
 - **Time taken**: ~2 hours (including fixing double-replacements and missed patterns)
 
-### Phase 5: [Agent to fill in]
+### Phase 5: Service Class Renames (COMPLETE)
 - **What worked**:
+  - Using `git mv` to rename files preserved git history
+  - Edit tool with `replace_all=true` was very effective for consistent patterns like `RouteService(` and `RouteIndexService(`
+  - Systematic approach: rename files → update class definitions → update imports → update instantiations → update patch decorators → rename test files
+  - ast-grep verification at the end confirmed zero old references remained
+  - Patch decorator updates in test files were straightforward with replace_all
+
 - **What didn't**:
+  - Some minor comments in test files were missed initially but caught during verification
+  - Test class names (e.g., `class TestRouteIndexService:`) weren't caught by initial instantiation patterns
+
 - **Gotchas**:
-- **Time taken**:
+  - **File imports must be updated before instantiations** - otherwise you get import errors
+  - **Patch decorators use string paths** - must update both module name (`route_service` → `user_route_service`) AND class name
+  - **Test class names** need manual updating (not caught by `ServiceName(` pattern)
+  - **Cross-imports** between services (user_route_service imports UserRouteIndexService) need updating
+  - **Comments and docstrings** also need updates, not just code
+  - **Ruff auto-fixes import ordering** - pre-commit will reorder imports after updates
+
+- **Key patterns used**:
+  - `replace_all=true` for: `RouteService(`, `RouteIndexService(`, patch decorator paths
+  - Individual replacements for: imports, class definitions, docstrings, test class names
+  - ast-grep verification: `ast-grep --pattern 'class RouteService' app/ tests/` (should return nothing)
+
+- **Time taken**: ~45 minutes (including quality checks)
 
 ### Phase 6: [Agent to fill in]
 - **What worked**:

--- a/backend/tests/test_admin_route_index.py
+++ b/backend/tests/test_admin_route_index.py
@@ -66,7 +66,7 @@ class TestAdminRebuildIndexesEndpoint:
         # Mock the service method to avoid needing full database setup
         mock_result = {"rebuilt_count": 1, "failed_count": 0, "errors": []}
 
-        with patch("app.api.admin.RouteIndexService") as mock_service_class:
+        with patch("app.api.admin.UserRouteIndexService") as mock_service_class:
             mock_service = AsyncMock()
             mock_service.rebuild_routes = AsyncMock(return_value=mock_result)
             mock_service_class.return_value = mock_service
@@ -96,7 +96,7 @@ class TestAdminRebuildIndexesEndpoint:
         """Test rebuilding indexes for all routes successfully."""
         mock_result = {"rebuilt_count": 5, "failed_count": 0, "errors": []}
 
-        with patch("app.api.admin.RouteIndexService") as mock_service_class:
+        with patch("app.api.admin.UserRouteIndexService") as mock_service_class:
             mock_service = AsyncMock()
             mock_service.rebuild_routes = AsyncMock(return_value=mock_result)
             mock_service_class.return_value = mock_service
@@ -131,7 +131,7 @@ class TestAdminRebuildIndexesEndpoint:
             "errors": [f"Route {route_id}: Route not found"],
         }
 
-        with patch("app.api.admin.RouteIndexService") as mock_service_class:
+        with patch("app.api.admin.UserRouteIndexService") as mock_service_class:
             mock_service = AsyncMock()
             mock_service.rebuild_routes = AsyncMock(return_value=mock_result)
             mock_service_class.return_value = mock_service
@@ -171,7 +171,7 @@ class TestAdminRebuildIndexesEndpoint:
         auth_headers_for_user: dict[str, str],
     ) -> None:
         """Test that service exceptions are properly converted to HTTP errors."""
-        with patch("app.api.admin.RouteIndexService") as mock_service_class:
+        with patch("app.api.admin.UserRouteIndexService") as mock_service_class:
             mock_service = AsyncMock()
             mock_service.rebuild_routes = AsyncMock(side_effect=Exception("Database error"))
             mock_service_class.return_value = mock_service

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -416,7 +416,7 @@ def test_rebuild_indexes_task_registered() -> None:
 
 @pytest.mark.asyncio
 @patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
-@patch("app.celery.tasks.RouteIndexService")
+@patch("app.celery.tasks.UserRouteIndexService")
 @patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_success_single_route(
     mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: AsyncMock
@@ -427,7 +427,7 @@ async def test_rebuild_indexes_async_success_single_route(
     mock_session.close = AsyncMock()
     mock_session_factory.return_value = mock_session
 
-    # Mock RouteIndexService
+    # Mock UserRouteIndexService
     mock_service_instance = AsyncMock()
     mock_service_instance.rebuild_routes = AsyncMock(
         return_value={
@@ -448,7 +448,7 @@ async def test_rebuild_indexes_async_success_single_route(
     assert result["failed_count"] == 0
     assert result["errors"] == []
 
-    # Verify RouteIndexService was instantiated correctly
+    # Verify UserRouteIndexService was instantiated correctly
     mock_service_class.assert_called_once_with(mock_session)
 
     # Verify rebuild_routes was called with correct UUID
@@ -460,7 +460,7 @@ async def test_rebuild_indexes_async_success_single_route(
 
 @pytest.mark.asyncio
 @patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
-@patch("app.celery.tasks.RouteIndexService")
+@patch("app.celery.tasks.UserRouteIndexService")
 @patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_success_all_routes(
     mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: AsyncMock
@@ -471,7 +471,7 @@ async def test_rebuild_indexes_async_success_all_routes(
     mock_session.close = AsyncMock()
     mock_session_factory.return_value = mock_session
 
-    # Mock RouteIndexService
+    # Mock UserRouteIndexService
     mock_service_instance = AsyncMock()
     mock_service_instance.rebuild_routes = AsyncMock(
         return_value={
@@ -500,7 +500,7 @@ async def test_rebuild_indexes_async_success_all_routes(
 
 @pytest.mark.asyncio
 @patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
-@patch("app.celery.tasks.RouteIndexService")
+@patch("app.celery.tasks.UserRouteIndexService")
 @patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_partial_failure(
     mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: AsyncMock
@@ -511,7 +511,7 @@ async def test_rebuild_indexes_async_partial_failure(
     mock_session.close = AsyncMock()
     mock_session_factory.return_value = mock_session
 
-    # Mock RouteIndexService with partial failure
+    # Mock UserRouteIndexService with partial failure
     mock_service_instance = AsyncMock()
     mock_service_instance.rebuild_routes = AsyncMock(
         return_value={
@@ -554,7 +554,7 @@ async def test_rebuild_indexes_async_invalid_uuid(
 
 @pytest.mark.asyncio
 @patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
-@patch("app.celery.tasks.RouteIndexService")
+@patch("app.celery.tasks.UserRouteIndexService")
 @patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_closes_session_on_success(
     mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: AsyncMock
@@ -565,7 +565,7 @@ async def test_rebuild_indexes_async_closes_session_on_success(
     mock_session.close = AsyncMock()
     mock_session_factory.return_value = mock_session
 
-    # Mock RouteIndexService
+    # Mock UserRouteIndexService
     mock_service_instance = AsyncMock()
     mock_service_instance.rebuild_routes = AsyncMock(
         return_value={
@@ -585,7 +585,7 @@ async def test_rebuild_indexes_async_closes_session_on_success(
 
 @pytest.mark.asyncio
 @patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
-@patch("app.celery.tasks.RouteIndexService")
+@patch("app.celery.tasks.UserRouteIndexService")
 @patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_closes_session_on_error(
     mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: AsyncMock
@@ -596,7 +596,7 @@ async def test_rebuild_indexes_async_closes_session_on_error(
     mock_session.close = AsyncMock()
     mock_session_factory.return_value = mock_session
 
-    # Mock RouteIndexService to raise error
+    # Mock UserRouteIndexService to raise error
     mock_service_instance = AsyncMock()
     mock_service_instance.rebuild_routes = AsyncMock(side_effect=RuntimeError("Database error"))
     mock_service_class.return_value = mock_service_instance
@@ -611,18 +611,18 @@ async def test_rebuild_indexes_async_closes_session_on_error(
 
 @pytest.mark.asyncio
 @patch("app.celery.tasks.reset_worker_engine", new_callable=AsyncMock)
-@patch("app.celery.tasks.RouteIndexService")
+@patch("app.celery.tasks.UserRouteIndexService")
 @patch("app.celery.tasks.get_worker_session")
 async def test_rebuild_indexes_async_closes_session_when_service_fails(
     mock_session_factory: MagicMock, mock_service_class: MagicMock, mock_reset_engine: AsyncMock
 ) -> None:
-    """Test that session is closed even when RouteIndexService instantiation fails."""
+    """Test that session is closed even when UserRouteIndexService instantiation fails."""
     # Mock database session
     mock_session = AsyncMock()
     mock_session.close = AsyncMock()
     mock_session_factory.return_value = mock_session
 
-    # Mock RouteIndexService to raise error on instantiation
+    # Mock UserRouteIndexService to raise error on instantiation
     mock_service_class.side_effect = RuntimeError("Service init failed")
 
     # Execute async function and catch exception

--- a/backend/tests/test_routes_api.py
+++ b/backend/tests/test_routes_api.py
@@ -604,7 +604,7 @@ class TestRoutesAPI:
     # ==================== Segment Tests ====================
 
     @pytest.mark.asyncio
-    @patch("app.services.route_service.RouteService._validate_segments")
+    @patch("app.services.user_route_service.UserRouteService._validate_segments")
     async def test_upsert_segments_success(
         self,
         mock_validate: AsyncMock,
@@ -651,7 +651,7 @@ class TestRoutesAPI:
         assert data[1]["sequence"] == 1
 
     @pytest.mark.asyncio
-    @patch("app.services.route_service.RouteService._validate_segments")
+    @patch("app.services.user_route_service.UserRouteService._validate_segments")
     async def test_upsert_segments_validation_failure(
         self,
         mock_validate: AsyncMock,
@@ -736,7 +736,7 @@ class TestRoutesAPI:
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
 
     @pytest.mark.asyncio
-    @patch("app.services.route_service.RouteService._validate_route_segments")
+    @patch("app.services.user_route_service.UserRouteService._validate_route_segments")
     async def test_update_segment(
         self,
         mock_validate: AsyncMock,
@@ -858,7 +858,7 @@ class TestRoutesAPI:
         assert "at least 2 segments" in response.json()["detail"]
 
     @pytest.mark.asyncio
-    @patch("app.services.route_service.RouteService._validate_segments")
+    @patch("app.services.user_route_service.UserRouteService._validate_segments")
     async def test_upsert_segments_with_null_destination_line(
         self,
         mock_validate: AsyncMock,
@@ -1257,7 +1257,7 @@ class TestRoutesAPI:
         assert data["active"] is True  # Unchanged
 
     @pytest.mark.asyncio
-    @patch("app.services.route_service.RouteService._validate_route_segments")
+    @patch("app.services.user_route_service.UserRouteService._validate_route_segments")
     async def test_update_segment_line_id(
         self,
         mock_validate: AsyncMock,
@@ -1342,7 +1342,7 @@ class TestRoutesAPI:
         assert data["days_of_week"] == ["MON"]  # Unchanged
 
     @pytest.mark.asyncio
-    @patch("app.services.route_service.RouteService._validate_segments")
+    @patch("app.services.user_route_service.UserRouteService._validate_segments")
     async def test_upsert_segments_validation_with_index(
         self,
         mock_validate: AsyncMock,
@@ -1391,7 +1391,7 @@ class TestRoutesAPI:
         assert "segment index: 1" in detail.lower()
 
     @pytest.mark.asyncio
-    @patch("app.services.route_service.RouteService._validate_route_segments")
+    @patch("app.services.user_route_service.UserRouteService._validate_route_segments")
     async def test_update_segment_validation_failure(
         self,
         mock_validate: AsyncMock,

--- a/backend/tests/test_user_route_index_service.py
+++ b/backend/tests/test_user_route_index_service.py
@@ -1,4 +1,4 @@
-"""Tests for RouteIndexService."""
+"""Tests for UserRouteIndexService."""
 
 import uuid
 from datetime import UTC, datetime
@@ -8,8 +8,8 @@ from app.models.route import UserRoute, UserRouteSegment
 from app.models.route_index import RouteStationIndex
 from app.models.tfl import Line, Station
 from app.models.user import User
-from app.services.route_index_service import (
-    RouteIndexService,
+from app.services.user_route_index_service import (
+    UserRouteIndexService,
     deduplicate_preserving_order,
     find_stations_between,
 )
@@ -78,8 +78,8 @@ class TestPureFunctions:
 # =============================================================================
 
 
-class TestRouteIndexService:
-    """Tests for RouteIndexService."""
+class TestUserRouteIndexService:
+    """Tests for UserRouteIndexService."""
 
     @pytest.mark.asyncio
     async def test_build_index_simple_two_stop_line(
@@ -121,7 +121,7 @@ class TestRouteIndexService:
         await db_session.commit()
 
         # Build index
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.build_route_station_index(route.id)
 
         # Verify result statistics
@@ -199,7 +199,7 @@ class TestRouteIndexService:
         await db_session.commit()
 
         # Build index
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.build_route_station_index(route.id)
 
         # Verify result statistics
@@ -279,7 +279,7 @@ class TestRouteIndexService:
         await db_session.commit()
 
         # Build index
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         await service.build_route_station_index(route.id)
 
         # Verify index entries
@@ -335,7 +335,7 @@ class TestRouteIndexService:
         await db_session.commit()
 
         # Build index
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.build_route_station_index(route.id)
 
         # Verify result statistics
@@ -370,7 +370,7 @@ class TestRouteIndexService:
         db_session: AsyncSession,
     ) -> None:
         """Test building index for non-existent route raises ValueError."""
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         fake_route_id = uuid.uuid4()
 
         with pytest.raises(ValueError, match=r"Route .* not found"):
@@ -407,7 +407,7 @@ class TestRouteIndexService:
         await db_session.commit()
 
         # Build index
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.build_route_station_index(route.id)
 
         # Should return zero entries
@@ -458,7 +458,7 @@ class TestRouteIndexService:
         await db_session.commit()
 
         # Build index first time
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result1 = await service.build_route_station_index(route.id)
         assert result1["entries_created"] == 2
 
@@ -517,7 +517,7 @@ class TestRouteIndexService:
         await db_session.commit()
 
         # Build index - should log warning but not fail
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.build_route_station_index(route.id)
 
         # Should return zero entries (failed to expand)
@@ -564,7 +564,7 @@ class TestRouteIndexService:
         await db_session.commit()
 
         # Build index - should log warning but not fail
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.build_route_station_index(route.id)
 
         # Should return zero entries (failed to expand)
@@ -578,7 +578,7 @@ class TestRouteIndexService:
     ) -> None:
         """Test that database transaction is rolled back on error."""
         # Try to build index for non-existent route
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         fake_route_id = uuid.uuid4()
 
         with pytest.raises(ValueError, match=r"Route .* not found"):
@@ -629,7 +629,7 @@ class TestRouteIndexService:
         await db_session.commit()
 
         # Build index
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         await service.build_route_station_index(route.id)
 
         # Verify line_data_version matches line.last_updated
@@ -668,7 +668,7 @@ class TestRouteIndexService:
         await db_session.commit()
 
         # Build index with auto_commit=False
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.build_route_station_index(route.id, auto_commit=False)
 
         # Verify result (but no commit yet)
@@ -694,7 +694,7 @@ class TestRouteIndexService:
         fake_route_id = uuid.uuid4()
 
         # Build index with auto_commit=False (will fail with route not found)
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
 
         # This should raise ValueError for route not found
         with pytest.raises(ValueError, match=f"Route {fake_route_id} not found"):
@@ -766,7 +766,7 @@ class TestRouteIndexService:
         await db_session.commit()
 
         # Build index
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.build_route_station_index(route.id)
 
         # Should succeed - hub resolution allows index building
@@ -822,7 +822,7 @@ class TestRouteIndexService:
         await db_session.commit()
 
         # Build index - both stations should be resolved (fork_mid_1 is already on forkedline)
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.build_route_station_index(route.id)
 
         # Should succeed
@@ -867,7 +867,7 @@ class TestRouteIndexService:
         await db_session.commit()
 
         # Build index - should use parallel_north directly (it's already on parallelline)
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.build_route_station_index(route.id)
 
         # Should succeed without needing hub resolution
@@ -923,7 +923,7 @@ class TestRouteIndexService:
         await db_session.commit()
 
         # Build index - should raise ValueError
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         with pytest.raises(ValueError, match="no station in that hub serves line"):
             await service.build_route_station_index(route.id)
 
@@ -964,7 +964,7 @@ class TestRouteIndexService:
         await db_session.commit()
 
         # Build index - should work normally without hub resolution
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.build_route_station_index(route.id)
 
         assert result["segments_processed"] == 1
@@ -1002,7 +1002,7 @@ class TestRebuildRoutes:
         await db_session.commit()
 
         # Rebuild single route
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.rebuild_routes(route.id)
 
         # Verify result
@@ -1020,7 +1020,7 @@ class TestRebuildRoutes:
         db_session: AsyncSession,
     ) -> None:
         """Test rebuilding index for non-existent route."""
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         fake_route_id = uuid.uuid4()
 
         result = await service.rebuild_routes(fake_route_id)
@@ -1063,7 +1063,7 @@ class TestRebuildRoutes:
         await db_session.commit()
 
         # Rebuild all routes
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.rebuild_routes()  # None = all routes
 
         # Verify result
@@ -1111,7 +1111,7 @@ class TestRebuildRoutes:
 
         # Rebuild using service, but pass IDs including a non-existent one
         # We'll call rebuild_routes multiple times to simulate the loop behavior
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
 
         # First rebuild the two valid routes
         result1 = await service.rebuild_routes(valid_routes[0].id)
@@ -1137,7 +1137,7 @@ class TestRebuildRoutes:
         db_session: AsyncSession,
     ) -> None:
         """Test rebuilding when no routes exist."""
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.rebuild_routes()
 
         # Should succeed with no routes processed
@@ -1168,7 +1168,7 @@ class TestRebuildRoutes:
         await db_session.commit()
 
         # This should succeed but create no entries (insufficient segments)
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.rebuild_routes(route.id)
 
         # Should succeed (not fail) because insufficient segments just logs warning
@@ -1219,7 +1219,7 @@ class TestRebuildRoutes:
         await db_session.commit()
 
         # Build index - should handle empty variant gracefully
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.build_route_station_index(route.id)
 
         # Should complete but create no entries (no valid variants)
@@ -1237,7 +1237,7 @@ class TestRebuildRoutes:
         fake_route_id = uuid.uuid4()
 
         # Rebuild single route - should catch exception and return failure
-        service = RouteIndexService(db_session)
+        service = UserRouteIndexService(db_session)
         result = await service.rebuild_routes(fake_route_id)
 
         # Should fail gracefully - exception caught and recorded

--- a/backend/tests/test_user_route_service.py
+++ b/backend/tests/test_user_route_service.py
@@ -1,4 +1,4 @@
-"""Unit tests for RouteService."""
+"""Unit tests for UserRouteService."""
 
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
@@ -8,11 +8,11 @@ from app.models.route import UserRoute
 from app.models.tfl import Line, Station
 from app.models.user import User
 from app.schemas.routes import SegmentRequest
-from app.services.route_service import RouteService
+from app.services.user_route_service import UserRouteService
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
-class TestRouteServiceUpsertSegments:
+class TestUserRouteServiceUpsertSegments:
     """Tests for upsert_segments exception handling."""
 
     @pytest.mark.asyncio
@@ -51,7 +51,7 @@ class TestRouteServiceUpsertSegments:
         await db_session.refresh(line)
 
         # Create service
-        service = RouteService(db_session)
+        service = UserRouteService(db_session)
 
         # Create segments
         segments = [


### PR DESCRIPTION
Phase 5 of Route → UserRoute refactoring.

Changes:
- Rename RouteService → UserRouteService
- Rename RouteIndexService → UserRouteIndexService
- Rename service files:
  - route_service.py → user_route_service.py
  - route_index_service.py → user_route_index_service.py
- Rename test files:
  - test_route_service.py → test_user_route_service.py
  - test_route_index_service.py → test_user_route_index_service.py
- Update all imports across 5 files
- Update all instantiations (~40 occurrences)
- Update patch decorators in 3 test files (17 patches)
- Update docstrings, comments, and test class names

Quality checks:
✅ Type safety: mypy passes (55 files, 0 issues)
✅ All tests pass: 1057/1057 (0 failures)
✅ Coverage: 95.87% (exceeds 95% requirement)
✅ Pre-commit: all hooks passed
✅ ast-grep: zero old references remain

Learnings documented in refactoring-notes.md for Phase 6.

closes #178