### PR TITLE
refactor(schemas): rename Route* schemas to UserRoute* (#180)

### DIFF
--- a/backend/app/api/routes.py
+++ b/backend/app/api/routes.py
@@ -10,16 +10,16 @@ from app.core.database import get_db
 from app.models.user import User
 from app.models.user_route import UserRoute, UserRouteSchedule, UserRouteSegment
 from app.schemas.routes import (
-    CreateRouteRequest,
-    CreateScheduleRequest,
-    RouteListItemResponse,
-    RouteResponse,
-    ScheduleResponse,
-    SegmentResponse,
-    UpdateRouteRequest,
-    UpdateScheduleRequest,
-    UpdateSegmentRequest,
-    UpsertSegmentsRequest,
+    CreateUserRouteRequest,
+    CreateUserRouteScheduleRequest,
+    UpdateUserRouteRequest,
+    UpdateUserRouteScheduleRequest,
+    UpdateUserRouteSegmentRequest,
+    UpsertUserRouteSegmentsRequest,
+    UserRouteListItemResponse,
+    UserRouteResponse,
+    UserRouteScheduleResponse,
+    UserRouteSegmentResponse,
 )
 from app.services.user_route_service import UserRouteService
 
@@ -29,11 +29,11 @@ router = APIRouter(prefix="/routes", tags=["routes"])
 # ==================== Route Endpoints ====================
 
 
-@router.get("", response_model=list[RouteListItemResponse])
+@router.get("", response_model=list[UserRouteListItemResponse])
 async def list_routes(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
-) -> list[RouteListItemResponse]:
+) -> list[UserRouteListItemResponse]:
     """
     List all routes for the authenticated user.
 
@@ -52,7 +52,7 @@ async def list_routes(
 
     # Build response with counts using Pydantic models
     return [
-        RouteListItemResponse(
+        UserRouteListItemResponse(
             id=route.id,
             name=route.name,
             description=route.description,
@@ -65,9 +65,9 @@ async def list_routes(
     ]
 
 
-@router.post("", response_model=RouteResponse, status_code=status.HTTP_201_CREATED)
+@router.post("", response_model=UserRouteResponse, status_code=status.HTTP_201_CREATED)
 async def create_route(
-    request: CreateRouteRequest,
+    request: CreateUserRouteRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> UserRoute:
@@ -92,7 +92,7 @@ async def create_route(
     return await service.get_route_by_id(route.id, current_user.id, load_relationships=True)
 
 
-@router.get("/{route_id}", response_model=RouteResponse)
+@router.get("/{route_id}", response_model=UserRouteResponse)
 async def get_route(
     route_id: UUID,
     current_user: User = Depends(get_current_user),
@@ -116,10 +116,10 @@ async def get_route(
     return await service.get_route_by_id(route_id, current_user.id, load_relationships=True)
 
 
-@router.patch("/{route_id}", response_model=RouteResponse)
+@router.patch("/{route_id}", response_model=UserRouteResponse)
 async def update_route(
     route_id: UUID,
-    request: UpdateRouteRequest,
+    request: UpdateUserRouteRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> UserRoute:
@@ -173,10 +173,10 @@ async def delete_route(
 # ==================== Segment Endpoints ====================
 
 
-@router.put("/{route_id}/segments", response_model=list[SegmentResponse])
+@router.put("/{route_id}/segments", response_model=list[UserRouteSegmentResponse])
 async def upsert_segments(
     route_id: UUID,
-    request: UpsertSegmentsRequest,
+    request: UpsertUserRouteSegmentsRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> list[UserRouteSegment]:
@@ -202,11 +202,11 @@ async def upsert_segments(
     return await service.upsert_segments(route_id, current_user.id, request.segments)
 
 
-@router.patch("/{route_id}/segments/{sequence}", response_model=SegmentResponse)
+@router.patch("/{route_id}/segments/{sequence}", response_model=UserRouteSegmentResponse)
 async def update_segment(
     route_id: UUID,
     sequence: int,
-    request: UpdateSegmentRequest,
+    request: UpdateUserRouteSegmentRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> UserRouteSegment:
@@ -261,10 +261,10 @@ async def delete_segment(
 # ==================== Schedule Endpoints ====================
 
 
-@router.post("/{route_id}/schedules", response_model=ScheduleResponse, status_code=status.HTTP_201_CREATED)
+@router.post("/{route_id}/schedules", response_model=UserRouteScheduleResponse, status_code=status.HTTP_201_CREATED)
 async def create_schedule(
     route_id: UUID,
-    request: CreateScheduleRequest,
+    request: CreateUserRouteScheduleRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> UserRouteSchedule:
@@ -289,11 +289,11 @@ async def create_schedule(
     return await service.create_schedule(route_id, current_user.id, request)
 
 
-@router.patch("/{route_id}/schedules/{schedule_id}", response_model=ScheduleResponse)
+@router.patch("/{route_id}/schedules/{schedule_id}", response_model=UserRouteScheduleResponse)
 async def update_schedule(
     route_id: UUID,
     schedule_id: UUID,
-    request: UpdateScheduleRequest,
+    request: UpdateUserRouteScheduleRequest,
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> UserRouteSchedule:

--- a/backend/app/schemas/routes.py
+++ b/backend/app/schemas/routes.py
@@ -91,7 +91,7 @@ def _validate_timezone(tz: str | None) -> str | None:
 # ==================== Request Schemas ====================
 
 
-class CreateRouteRequest(BaseModel):
+class CreateUserRouteRequest(BaseModel):
     """Request to create a new route."""
 
     name: str = Field(..., min_length=1, max_length=255, description="Route name")
@@ -115,7 +115,7 @@ class CreateRouteRequest(BaseModel):
         return result
 
 
-class UpdateRouteRequest(BaseModel):
+class UpdateUserRouteRequest(BaseModel):
     """Request to update a route's metadata."""
 
     name: str | None = Field(None, min_length=1, max_length=255)
@@ -130,7 +130,7 @@ class UpdateRouteRequest(BaseModel):
         return _validate_timezone(tz)
 
 
-class SegmentRequest(BaseModel):
+class UserRouteSegmentRequest(BaseModel):
     """Single segment in a route (station + line + sequence)."""
 
     sequence: int = Field(..., ge=0, description="Order of this segment in the route (0-based)")
@@ -146,10 +146,10 @@ class SegmentRequest(BaseModel):
     )
 
 
-class UpsertSegmentsRequest(BaseModel):
+class UpsertUserRouteSegmentsRequest(BaseModel):
     """Request to replace all segments in a route."""
 
-    segments: list[SegmentRequest] = Field(
+    segments: list[UserRouteSegmentRequest] = Field(
         ...,
         min_length=2,
         description="Ordered list of segments. Must have at least 2 (start and end).",
@@ -157,7 +157,7 @@ class UpsertSegmentsRequest(BaseModel):
 
     @field_validator("segments")
     @classmethod
-    def validate_sequences(cls, segments: list[SegmentRequest]) -> list[SegmentRequest]:
+    def validate_sequences(cls, segments: list[UserRouteSegmentRequest]) -> list[UserRouteSegmentRequest]:
         """
         Validate that sequences are consecutive starting from 0.
 
@@ -180,14 +180,14 @@ class UpsertSegmentsRequest(BaseModel):
         return segments
 
 
-class UpdateSegmentRequest(BaseModel):
+class UpdateUserRouteSegmentRequest(BaseModel):
     """Request to update a single segment."""
 
     station_tfl_id: str | None = None
     line_tfl_id: str | None = None
 
 
-class CreateScheduleRequest(BaseModel):
+class CreateUserRouteScheduleRequest(BaseModel):
     """Request to create a schedule for a route."""
 
     days_of_week: list[str] = Field(
@@ -211,7 +211,7 @@ class CreateScheduleRequest(BaseModel):
         return _validate_day_codes(days)
 
     @model_validator(mode="after")
-    def validate_time_range(self) -> "CreateScheduleRequest":
+    def validate_time_range(self) -> "CreateUserRouteScheduleRequest":
         """
         Validate that end_time is after start_time using shared helper.
 
@@ -225,7 +225,7 @@ class CreateScheduleRequest(BaseModel):
         return self
 
 
-class UpdateScheduleRequest(BaseModel):
+class UpdateUserRouteScheduleRequest(BaseModel):
     """Request to update a schedule."""
 
     days_of_week: list[str] | None = None
@@ -241,7 +241,7 @@ class UpdateScheduleRequest(BaseModel):
         return _validate_day_codes(days)
 
     @model_validator(mode="after")
-    def validate_time_range(self) -> "UpdateScheduleRequest":
+    def validate_time_range(self) -> "UpdateUserRouteScheduleRequest":
         """
         Validate that end_time is after start_time if both are provided using shared helper.
 
@@ -262,7 +262,7 @@ class UpdateScheduleRequest(BaseModel):
 # ==================== Response Schemas ====================
 
 
-class SegmentResponse(BaseModel):
+class UserRouteSegmentResponse(BaseModel):
     """Response schema for a route segment."""
 
     model_config = ConfigDict(from_attributes=True)
@@ -273,7 +273,7 @@ class SegmentResponse(BaseModel):
     line_tfl_id: str | None
 
 
-class ScheduleResponse(BaseModel):
+class UserRouteScheduleResponse(BaseModel):
     """Response schema for a route schedule."""
 
     model_config = ConfigDict(from_attributes=True)
@@ -284,7 +284,7 @@ class ScheduleResponse(BaseModel):
     end_time: time
 
 
-class RouteResponse(BaseModel):
+class UserRouteResponse(BaseModel):
     """Full response schema for a route with segments and schedules."""
 
     model_config = ConfigDict(from_attributes=True)
@@ -294,11 +294,11 @@ class RouteResponse(BaseModel):
     description: str | None
     active: bool
     timezone: str
-    segments: list[SegmentResponse]
-    schedules: list[ScheduleResponse]
+    segments: list[UserRouteSegmentResponse]
+    schedules: list[UserRouteScheduleResponse]
 
 
-class RouteListItemResponse(BaseModel):
+class UserRouteListItemResponse(BaseModel):
     """Simplified response schema for route listings."""
 
     model_config = ConfigDict(from_attributes=True)

--- a/backend/app/services/user_route_service.py
+++ b/backend/app/services/user_route_service.py
@@ -11,12 +11,12 @@ from sqlalchemy.orm import selectinload
 from app.models.tfl import Line, Station
 from app.models.user_route import UserRoute, UserRouteSchedule, UserRouteSegment
 from app.schemas.routes import (
-    CreateRouteRequest,
-    CreateScheduleRequest,
-    SegmentRequest,
-    UpdateRouteRequest,
-    UpdateScheduleRequest,
-    UpdateSegmentRequest,
+    CreateUserRouteRequest,
+    CreateUserRouteScheduleRequest,
+    UpdateUserRouteRequest,
+    UpdateUserRouteScheduleRequest,
+    UpdateUserRouteSegmentRequest,
+    UserRouteSegmentRequest,
 )
 from app.schemas.tfl import RouteSegmentRequest
 from app.services.tfl_service import TfLService
@@ -107,7 +107,7 @@ class UserRouteService:
     async def create_route(
         self,
         user_id: uuid.UUID,
-        request: CreateRouteRequest,
+        request: CreateUserRouteRequest,
     ) -> UserRoute:
         """
         Create a new route.
@@ -137,7 +137,7 @@ class UserRouteService:
         self,
         route_id: uuid.UUID,
         user_id: uuid.UUID,
-        request: UpdateRouteRequest,
+        request: UpdateUserRouteRequest,
     ) -> UserRoute:
         """
         Update route metadata.
@@ -190,7 +190,7 @@ class UserRouteService:
         self,
         route_id: uuid.UUID,
         user_id: uuid.UUID,
-        segments: list[SegmentRequest],
+        segments: list[UserRouteSegmentRequest],
     ) -> list[UserRouteSegment]:
         """
         Replace all segments for a route with validation.
@@ -264,7 +264,7 @@ class UserRouteService:
         route_id: uuid.UUID,
         user_id: uuid.UUID,
         sequence: int,
-        request: UpdateSegmentRequest,
+        request: UpdateUserRouteSegmentRequest,
     ) -> UserRouteSegment:
         """
         Update a single segment and validate the entire route.
@@ -388,7 +388,7 @@ class UserRouteService:
         self,
         route_id: uuid.UUID,
         user_id: uuid.UUID,
-        request: CreateScheduleRequest,
+        request: CreateUserRouteScheduleRequest,
     ) -> UserRouteSchedule:
         """
         Create a schedule for a route.
@@ -425,7 +425,7 @@ class UserRouteService:
         route_id: uuid.UUID,
         schedule_id: uuid.UUID,
         user_id: uuid.UUID,
-        request: UpdateScheduleRequest,
+        request: UpdateUserRouteScheduleRequest,
     ) -> UserRouteSchedule:
         """
         Update a schedule.
@@ -524,7 +524,7 @@ class UserRouteService:
 
     # ==================== Private Helper Methods ====================
 
-    async def _validate_segments(self, segments: list[SegmentRequest]) -> None:
+    async def _validate_segments(self, segments: list[UserRouteSegmentRequest]) -> None:
         """
         Validate route segments using TfL service.
 
@@ -597,7 +597,7 @@ class UserRouteService:
                 )
 
             segment_requests.append(
-                SegmentRequest(
+                UserRouteSegmentRequest(
                     sequence=seg.sequence,
                     station_tfl_id=station.tfl_id,
                     line_tfl_id=line.tfl_id if line is not None else None,

--- a/backend/tests/test_routes_api.py
+++ b/backend/tests/test_routes_api.py
@@ -589,7 +589,7 @@ class TestRoutesAPI:
         await db_session.commit()
         await db_session.refresh(route)
 
-        # Update with explicit None should preserve existing value (per UpdateRouteRequest logic)
+        # Update with explicit None should preserve existing value (per UpdateUserRouteRequest logic)
         response = await async_client.patch(
             f"/api/v1/routes/{route.id}",
             json={"name": "Updated Name", "timezone": None},

--- a/backend/tests/test_schemas_routes.py
+++ b/backend/tests/test_schemas_routes.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 from app.schemas.routes import (
-    CreateRouteRequest,
+    CreateUserRouteRequest,
     _validate_day_codes,
     _validate_time_range,
     _validate_timezone,
@@ -133,8 +133,8 @@ class TestValidateTimezone:
                 _validate_timezone("Europe/London")
 
 
-class TestCreateRouteRequest:
-    """Tests for CreateRouteRequest schema."""
+class TestCreateUserRouteRequest:
+    """Tests for CreateUserRouteRequest schema."""
 
     def test_validate_timezone_none_handling(self) -> None:
         """Test that validator handles unexpected None from _validate_timezone."""
@@ -144,4 +144,4 @@ class TestCreateRouteRequest:
 
             # Should raise ValueError when None is returned
             with pytest.raises(ValueError, match="Invalid timezone"):
-                CreateRouteRequest(name="Test Route", timezone="Europe/London")
+                CreateUserRouteRequest(name="Test Route", timezone="Europe/London")

--- a/backend/tests/test_user_route_service.py
+++ b/backend/tests/test_user_route_service.py
@@ -7,7 +7,7 @@ import pytest
 from app.models.tfl import Line, Station
 from app.models.user import User
 from app.models.user_route import UserRoute
-from app.schemas.routes import SegmentRequest
+from app.schemas.routes import UserRouteSegmentRequest
 from app.services.user_route_service import UserRouteService
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -55,8 +55,8 @@ class TestUserRouteServiceUpsertSegments:
 
         # Create segments
         segments = [
-            SegmentRequest(sequence=0, station_tfl_id=station1.tfl_id, line_tfl_id=line.tfl_id),
-            SegmentRequest(sequence=1, station_tfl_id=station2.tfl_id, line_tfl_id=line.tfl_id),
+            UserRouteSegmentRequest(sequence=0, station_tfl_id=station1.tfl_id, line_tfl_id=line.tfl_id),
+            UserRouteSegmentRequest(sequence=1, station_tfl_id=station2.tfl_id, line_tfl_id=line.tfl_id),
         ]
 
         # Mock validation to pass, commit to fail, and rollback to verify it's called


### PR DESCRIPTION
Rename all 11 schema classes in app/schemas/routes.py from Route* to UserRoute* patterns for consistency with models and services.

Request Schemas (7):
- CreateRouteRequest → CreateUserRouteRequest
- UpdateRouteRequest → UpdateUserRouteRequest
- SegmentRequest → UserRouteSegmentRequest
- UpsertSegmentsRequest → UpsertUserRouteSegmentsRequest
- UpdateSegmentRequest → UpdateUserRouteSegmentRequest
- CreateScheduleRequest → CreateUserRouteScheduleRequest
- UpdateScheduleRequest → UpdateUserRouteScheduleRequest

Response Schemas (4):
- SegmentResponse → UserRouteSegmentResponse
- ScheduleResponse → UserRouteScheduleResponse
- RouteResponse → UserRouteResponse
- RouteListItemResponse → UserRouteListItemResponse

Files Modified:
- app/schemas/routes.py: All 11 schema class definitions
- app/api/routes.py: Import statement and type hints (endpoint paths unchanged)
- app/services/user_route_service.py: Import statement and function signatures
- tests/test_schemas_routes.py: Import and test class name
- tests/test_user_route_service.py: Import and instantiations
- tests/test_routes_api.py: Comment update
- refactoring-notes.md: Phase 7 learnings documented

Verification:
- ast-grep: No old schema names remain
- mypy: All type checks pass (55 files)
- pytest: All 1057 tests passing
- coverage: 95.87% maintained
- pre-commit: All hooks pass
- OpenAPI: New schema names present in docs
- API paths: Unchanged (/routes endpoints preserved - no breaking changes)
resolves #180