### PR TITLE
Refactor Celery worker resource management for persistent event loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   backend:
     name: Backend CI
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
 
@@ -78,6 +79,7 @@ jobs:
   frontend:
     name: Frontend CI
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
 

--- a/backend/app/celery/tasks.py
+++ b/backend/app/celery/tasks.py
@@ -14,37 +14,27 @@ from sqlalchemy import distinct, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.celery.app import celery_app
-from app.celery.database import get_worker_session, reset_worker_engine
+from app.celery.database import get_worker_redis_client, get_worker_session
 from app.models.tfl import Line
 from app.models.user_route_index import UserRouteStationIndex
-from app.services.alert_service import AlertService, get_redis_client
+from app.services.alert_service import AlertService
 from app.services.user_route_index_service import UserRouteIndexService
 
 logger = structlog.get_logger(__name__)
 
 
-def run_in_isolated_loop[T](
+def run_in_worker_loop[T](
     coro_func: Callable[..., Awaitable[T]],
     *args: Any,  # noqa: ANN401 - Pass-through args to async function
     **kwargs: Any,  # noqa: ANN401 - Pass-through kwargs to async function
 ) -> T:
     """
-    Run an async function in a fresh, isolated event loop.
+    Run an async function in the worker's persistent event loop.
 
-    This function creates a new event loop, calls the async function within it,
-    and ensures proper cleanup. This is necessary for Celery workers using fork
-    pool to avoid event loop state contamination between task executions.
-
-    The pattern explicitly:
-    1. Creates a new event loop
-    2. Sets it as the current event loop
-    3. Calls the async function to create the coroutine
-    4. Runs the coroutine
-    5. Closes the loop
-    6. Sets event loop to None (cleanup)
-
-    This ensures each task execution has a completely isolated event loop,
-    preventing "Future attached to a different loop" errors.
+    This function uses the event loop created during worker initialization
+    (in worker_process_init signal handler) rather than creating a new loop
+    per task. This allows database connections and Redis clients to be
+    properly pooled and reused across tasks.
 
     Args:
         coro_func: An async function (not coroutine) to execute
@@ -54,24 +44,9 @@ def run_in_isolated_loop[T](
     Returns:
         The return value of the async function
     """
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        # Create the coroutine INSIDE the fresh event loop
-        coro = coro_func(*args, **kwargs)
-        return loop.run_until_complete(coro)
-    finally:
-        try:
-            # Cancel any pending tasks
-            pending = asyncio.all_tasks(loop)
-            for task in pending:
-                task.cancel()
-            # Run loop once more to let tasks clean up
-            if pending:
-                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
-        finally:
-            loop.close()
-            asyncio.set_event_loop(None)
+    loop = asyncio.get_event_loop()  # Get worker's persistent loop
+    coro = coro_func(*args, **kwargs)
+    return loop.run_until_complete(coro)
 
 
 # Protocol for Celery task request
@@ -158,10 +133,10 @@ def check_disruptions_and_alert(self: BoundTask) -> DisruptionCheckResult:
         Retry: If the task should be retried due to transient failure
     """
     try:
-        # run_in_isolated_loop() creates a fresh event loop for this task.
-        # This is necessary for Celery workers using fork pool to avoid
-        # event loop state contamination between task executions.
-        result = run_in_isolated_loop(_check_disruptions_async)
+        # run_in_worker_loop() uses the worker's persistent event loop.
+        # This allows database and Redis connections to be pooled and
+        # reused across tasks in the same worker process.
+        result = run_in_worker_loop(_check_disruptions_async)
         logger.info(
             "check_disruptions_task_completed",
             result=result,
@@ -185,20 +160,16 @@ async def _check_disruptions_async() -> DisruptionCheckResult:
 
     This function contains all the async database and API operations needed
     to check for disruptions and send alerts. It properly manages the database
-    session lifecycle and Redis connection.
+    session lifecycle. The Redis client is shared across tasks via get_worker_redis_client().
 
     Returns:
         DisruptionCheckResult: Execution statistics including routes_checked, alerts_sent, and errors
     """
-    # Reset engine to bind asyncio primitives to this task's event loop
-    await reset_worker_engine()
-
     session = None
-    redis_client = None
     try:
-        # Create database session and Redis client for this task
+        # Get database session and shared Redis client
         session = get_worker_session()
-        redis_client = await get_redis_client()
+        redis_client = get_worker_redis_client()
 
         # Create AlertService instance and process all routes
         alert_service = AlertService(db=session, redis_client=redis_client)
@@ -212,9 +183,7 @@ async def _check_disruptions_async() -> DisruptionCheckResult:
         )
 
     finally:
-        # Ensure resources are properly closed
-        if redis_client is not None:
-            await redis_client.aclose()
+        # Close session only - Redis client lifecycle managed by worker shutdown
         if session is not None:
             await session.close()
 
@@ -246,10 +215,10 @@ def rebuild_route_indexes_task(
         Retry: If the task should be retried due to transient failure
     """
     try:
-        # run_in_isolated_loop() creates a fresh event loop and calls the async function.
-        # This is necessary for Celery workers using fork pool to avoid
-        # event loop state contamination between task executions.
-        result = run_in_isolated_loop(_rebuild_indexes_async, route_id)
+        # run_in_worker_loop() uses the worker's persistent event loop.
+        # This allows database connections to be pooled and reused
+        # across tasks in the same worker process.
+        result = run_in_worker_loop(_rebuild_indexes_async, route_id)
         logger.info(
             "rebuild_indexes_task_completed",
             route_id=route_id,
@@ -279,9 +248,6 @@ async def _rebuild_indexes_async(route_id_str: str | None = None) -> RebuildInde
     Returns:
         RebuildIndexesResult: Execution statistics including rebuilt_count, failed_count, and errors
     """
-    # Reset engine to bind asyncio primitives to this task's event loop
-    await reset_worker_engine()
-
     session = None
     try:
         # Create database session for this task
@@ -377,10 +343,10 @@ def detect_and_rebuild_stale_routes(self: BoundTask) -> DetectStaleRoutesResult:
         Retry: If the task should be retried due to transient failure
     """
     try:
-        # run_in_isolated_loop() creates a fresh event loop for this task.
-        # This is necessary for Celery workers using fork pool to avoid
-        # event loop state contamination between task executions.
-        result = run_in_isolated_loop(_detect_stale_routes_async)
+        # run_in_worker_loop() uses the worker's persistent event loop.
+        # This allows database connections to be pooled and reused
+        # across tasks in the same worker process.
+        result = run_in_worker_loop(_detect_stale_routes_async)
         logger.info(
             "detect_stale_routes_task_completed",
             result=result,
@@ -413,9 +379,6 @@ async def _detect_stale_routes_async() -> DetectStaleRoutesResult:
             - triggered_count: Number of rebuild tasks successfully triggered
             - errors: List of any errors encountered
     """
-    # Reset engine to bind asyncio primitives to this task's event loop
-    await reset_worker_engine()
-
     session = None
     errors: list[str] = []
     triggered_count = 0

--- a/backend/tests/test_celery_database.py
+++ b/backend/tests/test_celery_database.py
@@ -1,32 +1,39 @@
-"""Tests for Celery database utilities."""
+"""Tests for Celery database utilities.
 
-import pytest
-from app.celery.database import get_worker_session, get_worker_session_context
+These tests verify the session creation functions work correctly.
+They use the worker's event loop to avoid conflicts with pytest-asyncio.
+"""
+
+from app.celery.database import (
+    get_worker_loop,
+    get_worker_session,
+    get_worker_session_context,
+    init_worker_resources,
+)
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
-@pytest.mark.asyncio
-async def test_get_worker_session_context_yields_session() -> None:
-    """Test get_worker_session_context async generator properly closes session."""
+def test_get_worker_session_context_is_async_generator() -> None:
+    """Test get_worker_session_context returns an async generator."""
+    # Ensure worker is initialized
+    init_worker_resources()
 
-    session_obj = None
-    async for session in get_worker_session_context():
-        session_obj = session
-        assert session_obj is not None
-        # Test that session gets closed in finally block
-        break
-
-    # Session should be closed after exiting async generator
-    assert session_obj is not None
+    # Verify it's an async generator
+    result = get_worker_session_context()
+    assert hasattr(result, "__anext__")
+    assert hasattr(result, "__aiter__")
 
 
-@pytest.mark.asyncio
-async def test_get_worker_session_returns_session() -> None:
+def test_get_worker_session_returns_async_session() -> None:
     """Test get_worker_session returns an AsyncSession instance."""
+    # Ensure worker is initialized
+    init_worker_resources()
+
     session = get_worker_session()
     try:
         assert session is not None
-        # Verify we can use the session
         assert isinstance(session, AsyncSession)
     finally:
-        await session.close()
+        # Close synchronously since we're not in async context
+        loop = get_worker_loop()
+        loop.run_until_complete(session.close())

--- a/backend/tests/test_celery_database_integration.py
+++ b/backend/tests/test_celery_database_integration.py
@@ -3,50 +3,95 @@
 Tests the worker_process_init signal handler and lazy engine initialization
 that prevent asyncpg event loop conflicts in forked worker processes.
 
-See Issue #147 and ADR 08 "Worker Pool Fork Safety" for context.
+See Issue #147, #190, #195 and ADR 08 "Worker Pool Fork Safety" for context.
 """
 
+import asyncio
+import inspect
+
 import pytest
-from app.celery.database import _get_worker_engine, get_worker_session, init_worker_db
+from app.celery.database import (
+    RedisClientProtocol,
+    _get_worker_engine,
+    cleanup_worker_resources,
+    get_worker_redis_client,
+    get_worker_session,
+    init_worker_resources,
+)
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 
-def test_init_worker_db_exists_and_callable() -> None:
+def test_init_worker_resources_exists_and_callable() -> None:
     """
-    Test that init_worker_db function exists and can be called.
+    Test that init_worker_resources function exists and can be called.
 
     This verifies the signal handler is properly defined and executes without errors.
     """
-    assert callable(init_worker_db)
+    assert callable(init_worker_resources)
     # Should run without error in test environment
-    init_worker_db()
+    init_worker_resources()
 
 
-def test_init_worker_db_accepts_kwargs() -> None:
+def test_init_worker_resources_accepts_kwargs() -> None:
     """
-    Test that init_worker_db accepts **kwargs.
+    Test that init_worker_resources accepts **kwargs.
 
     Celery signals pass arbitrary keyword arguments, so the handler
     must accept **kwargs even if it doesn't use them.
     """
     # Call with various kwargs (simulating Celery signal behavior)
     try:
-        init_worker_db(sender="test", signal="test_signal", extra="data")
+        init_worker_resources(sender="test", signal="test_signal", extra="data")
     except TypeError:
-        pytest.fail("init_worker_db should accept **kwargs")
+        pytest.fail("init_worker_resources should accept **kwargs")
 
 
-def test_init_worker_db_resets_event_loop_policy() -> None:
+def test_init_worker_resources_creates_event_loop() -> None:
     """
-    Test that init_worker_db resets the asyncio event loop policy.
+    Test that init_worker_resources creates a persistent event loop.
 
-    With lazy initialization, the signal handler only needs to reset
-    the event loop policy - each worker will create its own engine on first use.
+    The signal handler creates a persistent event loop that will be used
+    for all tasks in the worker process.
     """
-    # The function should run without error in any environment
-    init_worker_db()
-    # Test passes if no exception is raised
+    # Call the initialization
+    init_worker_resources()
+
+    # Verify an event loop exists and is accessible
+    loop = asyncio.get_event_loop()
+    assert loop is not None
+    assert loop.is_running() is False  # Not running yet, just set
+
+
+def test_cleanup_worker_resources_exists_and_callable() -> None:
+    """
+    Test that cleanup_worker_resources function exists and can be called.
+
+    This verifies the shutdown signal handler is properly defined.
+    """
+    assert callable(cleanup_worker_resources)
+    # Note: We don't call it here as it would close the event loop
+
+
+def test_cleanup_worker_resources_accepts_kwargs() -> None:
+    """
+    Test that cleanup_worker_resources accepts **kwargs.
+
+    Celery signals pass arbitrary keyword arguments, so the handler
+    must accept **kwargs even if it doesn't use them.
+    """
+    # First initialize to set up resources
+    init_worker_resources()
+
+    # Call cleanup with various kwargs (simulating Celery signal behavior)
+    # This should not raise TypeError
+    try:
+        cleanup_worker_resources(sender="test", signal="test_signal", extra="data")
+    except TypeError:
+        pytest.fail("cleanup_worker_resources should accept **kwargs")
+
+    # Re-initialize for subsequent tests
+    init_worker_resources()
 
 
 @pytest.mark.asyncio
@@ -95,3 +140,51 @@ async def test_lazy_engine_initialization() -> None:
         assert row == 1
     finally:
         await session.close()
+
+
+def test_get_worker_redis_client_returns_client() -> None:
+    """
+    Test that get_worker_redis_client returns a Redis client.
+
+    The client is created lazily on first access and satisfies
+    the RedisClientProtocol interface.
+    """
+    # Get the Redis client
+    client = get_worker_redis_client()
+    assert client is not None
+
+    # Verify it satisfies the protocol interface
+    assert hasattr(client, "get")
+    assert hasattr(client, "setex")
+    assert hasattr(client, "aclose")
+
+
+def test_get_worker_redis_client_returns_same_instance() -> None:
+    """
+    Test that get_worker_redis_client returns the same instance on repeated calls.
+
+    The Redis client is shared across all tasks in the same worker process.
+    """
+    # Get the client twice
+    client1 = get_worker_redis_client()
+    client2 = get_worker_redis_client()
+
+    # Should be the same instance
+    assert client1 is client2
+
+
+def test_redis_client_protocol_exported() -> None:
+    """
+    Test that RedisClientProtocol is exported from the module.
+
+    Other modules should be able to import and use this protocol
+    for type hints.
+    """
+    assert RedisClientProtocol is not None
+    # Verify it's a Protocol (has the right attributes)
+    # We can't easily check if it's a Protocol class, but we can verify
+    # the expected methods exist in the class definition
+    members = [name for name, _ in inspect.getmembers(RedisClientProtocol)]
+    assert "get" in members or hasattr(RedisClientProtocol, "get")
+    assert "setex" in members or hasattr(RedisClientProtocol, "setex")
+    assert "aclose" in members or hasattr(RedisClientProtocol, "aclose")

--- a/docs/adr/08-background-jobs.md
+++ b/docs/adr/08-background-jobs.md
@@ -137,7 +137,7 @@ See `docs/celery-fork-safety.md` for implementation details.
 **More Difficult:**
 - Must ensure sessions are closed per task (session lifecycle still per-task)
 - Worker shutdown must dispose resources before closing loop
-- Shared engine means if one task corrupts state, subsequent tasks affected
+- Shared engine means if one task corrupts state, subsequent tasks are affected
 
 ---
 

--- a/docs/celery-fork-safety.md
+++ b/docs/celery-fork-safety.md
@@ -178,7 +178,7 @@ Worker Process Lifecycle:
 - Redis client reused (no per-task connection overhead)
 
 **Cons:**
-- Shared engine means if one task corrupts state, subsequent tasks affected
+- Shared engine means if one task corrupts state, subsequent tasks are affected
 - Must ensure sessions are properly closed (session lifecycle still per-task)
 - More complex shutdown handling (must dispose resources before closing loop)
 

--- a/docs/celery-fork-safety.md
+++ b/docs/celery-fork-safety.md
@@ -1,160 +1,199 @@
 # Celery Fork Safety Implementation
 
-This document describes the implementation details for Issue #147 - Celery worker database connection errors with asyncpg.
+This document describes the implementation details for Issue #195 - Persistent event loop per Celery worker.
 
 ## Problem
 
-SQLAlchemy's async engine creates `asyncio.Queue` objects at construction time that become permanently bound to the event loop that created them. This causes conflicts in two scenarios:
+SQLAlchemy's async engine creates `asyncio.Queue` objects at construction time that become permanently bound to the event loop that created them. This causes conflicts in forked Celery workers:
 
-1. **Cross-process binding:** Engine created at import time → forked workers inherit Queue objects bound to parent's event loop
-2. **Cross-task binding:** Engine created lazily but persists across tasks → each task gets fresh event loop but reuses engine with Queue objects bound to first task's event loop
+1. **Per-task loop issue:** Each task creates a fresh event loop via `run_in_isolated_loop()`, but the database engine from the previous task is bound to the old (now closed) loop
+2. **Engine disposal failure:** When a new task tries to dispose the old engine, it fails because the engine's connections are bound to the closed loop
 
-Both cause:
+This causes:
 ```
+RuntimeError: Event loop is closed
 RuntimeError: Task <Task> got Future <Future> attached to a different loop
 asyncpg.exceptions._base.InterfaceError: cannot perform operation: another operation is in progress
 ```
 
 ## Solution
 
-Combine three techniques:
+Use a **persistent event loop per worker** that lives for the entire worker process lifetime:
 
-1. **Lazy engine initialization** - Defer creation until first access
-2. **Per-task engine reset** - Reset globals at start of each task
-3. **Event loop policy reset** - Clear inherited state after fork
+1. **Persistent event loop** - Created at worker initialization, persists across all tasks
+2. **Shared resources** - Database engine and Redis client are shared across tasks
+3. **Proper cleanup** - Resources are disposed on worker shutdown
 
 ## Implementation
 
-### 1. database.py - Lazy Initialization
+### 1. database.py - Persistent Loop with Lazy Resource Initialization
 
 ```python
 import asyncio
-from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+from celery.signals import worker_process_init, worker_process_shutdown
 
-# Module-level globals for lazy initialization
+# Module-level globals for worker resources
+_worker_loop: asyncio.AbstractEventLoop | None = None
 _worker_engine: AsyncEngine | None = None
 _worker_session_factory: async_sessionmaker[AsyncSession] | None = None
+_worker_redis_client: RedisClientProtocol | None = None
 
-async def reset_worker_engine() -> None:
-    """Reset engine globals to force fresh creation on next access.
+@worker_process_init.connect
+def init_worker_resources(**kwargs: object) -> None:
+    """Create persistent event loop after worker fork."""
+    global _worker_loop
 
-    Disposes the old engine before resetting to avoid connection leaks.
-    """
-    global _worker_engine, _worker_session_factory  # noqa: PLW0603
-    if _worker_engine is not None:
-        await _worker_engine.dispose()
-    _worker_engine = None
-    _worker_session_factory = None
+    # Create persistent event loop for this worker
+    _worker_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(_worker_loop)
+
+@worker_process_shutdown.connect
+def cleanup_worker_resources(**kwargs: object) -> None:
+    """Dispose resources and close event loop on worker shutdown."""
+    global _worker_loop, _worker_engine, _worker_redis_client
+
+    if _worker_loop is not None:
+        # Dispose database engine
+        if _worker_engine is not None:
+            _worker_loop.run_until_complete(_worker_engine.dispose())
+            _worker_engine = None
+
+        # Close Redis client
+        if _worker_redis_client is not None:
+            _worker_loop.run_until_complete(_worker_redis_client.aclose())
+            _worker_redis_client = None
+
+        # Close the event loop
+        _worker_loop.close()
+        _worker_loop = None
 
 def _get_worker_engine() -> AsyncEngine:
     """Get or create worker engine (lazy initialization)."""
-    global _worker_engine  # noqa: PLW0603
+    global _worker_engine
     if _worker_engine is None:
-        _worker_engine = create_async_engine(
-            settings.DATABASE_URL,
-            pool_size=settings.DATABASE_POOL_SIZE,
-            max_overflow=settings.DATABASE_MAX_OVERFLOW,
-            echo=settings.DATABASE_ECHO,
-            future=True,
-        )
+        _worker_engine = create_async_engine(...)
     return _worker_engine
 
 def get_worker_session() -> AsyncSession:
     """Get a worker database session."""
-    global _worker_session_factory  # noqa: PLW0603
+    global _worker_session_factory
     if _worker_session_factory is None:
-        _worker_session_factory = async_sessionmaker(
-            _get_worker_engine(),
-            class_=AsyncSession,
-            expire_on_commit=False,
-            autocommit=False,
-            autoflush=False,
-        )
+        _worker_session_factory = async_sessionmaker(_get_worker_engine(), ...)
     return _worker_session_factory()
 
-@worker_process_init.connect
-def init_worker_db(**kwargs: object) -> None:
-    """Reset asyncio event loop policy after fork."""
-    asyncio.set_event_loop_policy(None)
+def get_worker_redis_client() -> RedisClientProtocol:
+    """Get the worker's shared Redis client."""
+    global _worker_redis_client
+    if _worker_redis_client is None:
+        _worker_redis_client = redis.asyncio.from_url(...)
+    return _worker_redis_client
 ```
 
-### 2. tasks.py - Per-Task Reset
-
-Add `await reset_worker_engine()` call at the start of each async task function:
+### 2. tasks.py - Run in Worker Loop
 
 ```python
-from app.celery.database import get_worker_session, reset_worker_engine
+def run_in_worker_loop[T](
+    coro_func: Callable[..., Awaitable[T]],
+    *args: Any,
+    **kwargs: Any,
+) -> T:
+    """Run an async function in the worker's persistent event loop."""
+    loop = asyncio.get_event_loop()  # Get worker's persistent loop
+    coro = coro_func(*args, **kwargs)
+    return loop.run_until_complete(coro)
+
+@celery_app.task(bind=True, max_retries=3)
+def check_disruptions_and_alert(self: BoundTask) -> DisruptionCheckResult:
+    """Check for TfL disruptions and send alerts."""
+    try:
+        result = run_in_worker_loop(_check_disruptions_async)
+        return result
+    except Exception as exc:
+        raise self.retry(exc=exc, countdown=60) from exc
 
 async def _check_disruptions_async() -> DisruptionCheckResult:
-    # Force fresh engine for this task's event loop
-    await reset_worker_engine()
-
+    """Async implementation of disruption checking."""
     session = None
-    redis_client = None
     try:
+        # Get shared resources - no per-task reset needed
         session = get_worker_session()
-        redis_client = await get_redis_client()
-        # ... rest of task logic
-```
+        redis_client = get_worker_redis_client()  # Shared client
 
-Apply the same pattern to all async task functions:
-- `_check_disruptions_async()`
-- `_rebuild_indexes_async()`
-- `_detect_stale_routes_async()`
-
-### 3. tasks.py - Event Loop Helper
-
-The `run_in_isolated_loop()` helper creates a fresh, isolated event loop for each task:
-
-```python
-def run_in_isolated_loop(coro_func: Callable[..., Any], *args: Any, **kwargs: Any) -> Any:
-    """Run an async function in a fresh, isolated event loop."""
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        coro = coro_func(*args, **kwargs)
-        return loop.run_until_complete(coro)
+        alert_service = AlertService(db=session, redis_client=redis_client)
+        result = await alert_service.process_all_routes()
+        return result
     finally:
-        # Cancel any pending tasks
-        pending = asyncio.all_tasks(loop)
-        for task in pending:
-            task.cancel()
-        if pending:
-            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
-        loop.close()
-        asyncio.set_event_loop(None)
+        # Close session only - Redis client lifecycle managed by worker
+        if session is not None:
+            await session.close()
 ```
 
-## Key Insight
+## Key Improvements Over Previous Implementation
 
-Since each task gets a fresh event loop via `run_in_isolated_loop()`, the engine's asyncio primitives must be recreated for each task to bind to the correct loop. This is achieved by resetting the engine globals, forcing lazy re-initialization per task.
+1. **No per-task loop creation/destruction** - Event loop persists for worker lifetime
+2. **No per-task engine reset** - Engine persists and is shared across tasks
+3. **Connection pool reuse** - Database connections are properly pooled across tasks
+4. **Shared Redis client** - Redis client is reused across tasks in same worker
+5. **Proper cleanup** - Resources are disposed during worker shutdown
 
-## Testing
+## Resource Lifecycle
 
-Updated test mocks from `@patch("app.celery.tasks.asyncio.run")` to `@patch("app.celery.tasks.run_in_isolated_loop")` since we now use the custom helper.
+```
+Worker Process Lifecycle:
+┌─────────────────────────────────────────────────────────┐
+│ worker_process_init signal                              │
+│   └─ Create persistent event loop                       │
+├─────────────────────────────────────────────────────────┤
+│ Task 1: check_disruptions_and_alert()                   │
+│   └─ run_in_worker_loop(_check_disruptions_async)       │
+│       └─ Uses persistent loop                           │
+│       └─ Creates engine (first access, lazy init)       │
+│       └─ Creates Redis client (first access, lazy init) │
+│       └─ Creates session (per task)                     │
+│       └─ Closes session (per task)                      │
+├─────────────────────────────────────────────────────────┤
+│ Task 2: rebuild_route_indexes_task()                    │
+│   └─ run_in_worker_loop(_rebuild_indexes_async)         │
+│       └─ Uses same persistent loop                      │
+│       └─ Uses same engine (connection pool)             │
+│       └─ Creates session (per task)                     │
+│       └─ Closes session (per task)                      │
+├─────────────────────────────────────────────────────────┤
+│ ... more tasks ...                                      │
+├─────────────────────────────────────────────────────────┤
+│ worker_process_shutdown signal                          │
+│   └─ Dispose engine (closes all pooled connections)     │
+│   └─ Close Redis client                                 │
+│   └─ Close event loop                                   │
+└─────────────────────────────────────────────────────────┘
+```
 
 ## Trade-offs
 
 **Pros:**
-- Complete event loop isolation between tasks and workers
-- Connection pooling works in all environments (no DEBUG conditional)
+- Complete event loop consistency across tasks
+- Connection pooling actually works (shared engine)
 - No asyncpg errors or event loop conflicts
+- Faster task execution (no per-task loop creation overhead)
+- Redis client reused (no per-task connection overhead)
 
 **Cons:**
-- Engine is recreated per task (small overhead, but necessary for correctness)
-- Connection pool is not shared across tasks in the same worker process
-- Must remember to call `await reset_worker_engine()` at start of new async tasks
+- Shared engine means if one task corrupts state, subsequent tasks affected
+- Must ensure sessions are properly closed (session lifecycle still per-task)
+- More complex shutdown handling (must dispose resources before closing loop)
 
 ## Files Changed
 
-- `backend/app/celery/database.py` - Lazy initialization with per-task reset
-- `backend/app/celery/tasks.py` - Added `await reset_worker_engine()` calls to all async task functions
-- `backend/tests/test_celery_tasks.py` - Updated mocks to patch `run_in_isolated_loop`
-- `backend/tests/test_celery_database_integration.py` - Added/updated integration tests
-- `docs/adr/08-background-jobs.md` - Documented decision
+- `backend/app/celery/database.py` - Persistent loop with lazy resource initialization
+- `backend/app/celery/tasks.py` - Simplified `run_in_worker_loop()`, removed `reset_worker_engine()` calls
+- `backend/tests/test_celery_tasks.py` - Updated mocks to patch `run_in_worker_loop` and `get_worker_redis_client`
+- `backend/tests/test_celery_database_integration.py` - Added lifecycle tests for init/cleanup
+- `docs/adr/08-background-jobs.md` - Documented updated decision
 
 ## References
 
-- Issue #147: https://github.com/mnbf9rca/IsTheTubeRunning/issues/147
+- Issue #195: https://github.com/mnbf9rca/IsTheTubeRunning/issues/195
+- Issue #190: https://github.com/mnbf9rca/IsTheTubeRunning/issues/190 (original event loop errors)
+- Issue #147: https://github.com/mnbf9rca/IsTheTubeRunning/issues/147 (original fork safety implementation)
 - SQLAlchemy docs: [Using Connection Pools with Multiprocessing](https://docs.sqlalchemy.org/en/20/core/pooling.html#using-connection-pools-with-multiprocessing-or-os-fork)
 - Celery signals: [worker_process_init](https://docs.celeryq.dev/en/stable/userguide/signals.html#worker-process-init)


### PR DESCRIPTION
- Updated worker resource initialization to create a persistent event loop for the lifetime of the worker.
- Changed lazy initialization of database engine and Redis client to be shared across tasks.
- Removed per-task engine reset logic, simplifying task implementations.
- Enhanced cleanup procedures to ensure proper disposal of resources on worker shutdown.
- Updated tests to reflect changes in resource management and added lifecycle tests for initialization and cleanup.
- Revised documentation to clarify the new approach and its implications on task execution and resource management.
- add CI timeout to cancel hanging jobs
resolves #195

## Summary by Sourcery

Refactor Celery worker resource management to maintain a persistent event loop per worker, share lazy-initialized database and Redis clients across tasks, remove per-task engine resets, and improve cleanup, with corresponding updates to tests and documentation.

Bug Fixes:
- Resolve event loop binding conflicts and asyncpg errors in forked Celery workers by binding resources to the persistent loop

Enhancements:
- Introduce a persistent event loop per Celery worker and use a run_in_worker_loop helper for task execution
- Lazy initialize and share the async database engine and Redis client across all tasks
- Remove per-task engine reset logic and simplify task implementations
- Add proper cleanup on worker shutdown to dispose the engine, close the Redis client, and close the event loop

Documentation:
- Revise celery-fork-safety document and ADR to describe the persistent event loop and shared resource approach

Tests:
- Update tests to mock run_in_worker_loop and get_worker_redis_client instead of per-task resets
- Add lifecycle tests for worker initialization and cleanup signals