### PR TITLE
feat: Add OpenTelemetry instrumentation for Celery workers and SQLAlchemy

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,17 +19,15 @@
       "justMyCode": true,
       "env": {
         "PYTHONPATH": "${workspaceFolder}/backend"
-      }
+      },
+      "consoleName": "Backend"
     },
     {
       "name": "Backend: Run Tests",
       "type": "debugpy",
       "request": "launch",
       "module": "pytest",
-      "args": [
-        "-v",
-        "--tb=short"
-      ],
+      "args": ["-v", "--tb=short"],
       "cwd": "${workspaceFolder}/backend",
       "console": "integratedTerminal",
       "justMyCode": false
@@ -39,10 +37,7 @@
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "npm",
-      "runtimeArgs": [
-        "run",
-        "dev"
-      ],
+      "runtimeArgs": ["run", "dev"],
       "cwd": "${workspaceFolder}/frontend",
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
@@ -59,8 +54,8 @@
       "runtimeExecutable": "npm",
       "runtimeArgs": [
         "run",
-        "test:ui"
-      ],
+         "test:ui"
+        ],
       "cwd": "${workspaceFolder}/frontend",
       "console": "integratedTerminal"
     },
@@ -73,7 +68,7 @@
         "-A",
         "app.celery.app",
         "worker",
-        "--loglevel=info",
+        "--loglevel=debug",
         "--pool=solo"
       ],
       "cwd": "${workspaceFolder}/backend",
@@ -81,7 +76,8 @@
       "justMyCode": false,
       "env": {
         "PYTHONPATH": "${workspaceFolder}/backend"
-      }
+      },
+      "consoleName": "Celery Worker"
     },
     {
       "name": "Backend: Celery Beat",
@@ -90,16 +86,17 @@
       "module": "celery",
       "args": [
         "-A",
-        "app.celery.app",
+       "app.celery.app",
         "beat",
-        "--loglevel=info"
+        "--loglevel=debug"
       ],
       "cwd": "${workspaceFolder}/backend",
       "console": "integratedTerminal",
       "justMyCode": false,
       "env": {
         "PYTHONPATH": "${workspaceFolder}/backend"
-      }
+      },
+      "consoleName": "Celery Beat"
     }
   ],
   "compounds": [
@@ -107,8 +104,8 @@
       "name": "Full Stack",
       "configurations": [
         "Backend: FastAPI",
-        "Frontend: Vite Dev Server"
-      ],
+         "Frontend: Vite Dev Server"
+        ],
       "stopAll": true,
       "presentation": {
         "hidden": false,

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-http>=1.29.0",
     "opentelemetry-instrumentation-fastapi>=0.50b0",
     "opentelemetry-instrumentation-sqlalchemy>=0.50b0",
+    "opentelemetry-instrumentation-celery>=0.50b0",
 ]
 
 [dependency-groups]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -47,6 +47,9 @@ from tests.helpers.network_helpers import build_connections_from_routes
 from tests.helpers.railway_network import TestRailwayNetwork
 from tests.helpers.types import RailwayNetworkFixture
 
+# Import OTEL fixtures
+pytest_plugins = ["tests.fixtures.otel"]
+
 
 @dataclass
 class TestDatabaseContext:

--- a/backend/tests/fixtures/otel.py
+++ b/backend/tests/fixtures/otel.py
@@ -65,19 +65,22 @@ def reset_tracer_provider() -> Generator[None]:
         None
     """
     # Import here to avoid circular dependency at module level
+    from app.celery import database as celery_database  # noqa: PLC0415
     from app.core import database, telemetry  # noqa: PLC0415  # Lazy import to avoid circular dependency
 
     # Reset telemetry module globals
     telemetry._tracer_provider = None  # type: ignore[attr-defined]
 
-    # Reset database instrumentation flag
+    # Reset database instrumentation flags (FastAPI and Celery worker)
     database._sqlalchemy_instrumented = False  # type: ignore[attr-defined]
+    celery_database._worker_sqlalchemy_instrumented = False  # type: ignore[attr-defined]
 
     yield
 
     # Reset again after test to clean up
     telemetry._tracer_provider = None  # type: ignore[attr-defined]
     database._sqlalchemy_instrumented = False  # type: ignore[attr-defined]
+    celery_database._worker_sqlalchemy_instrumented = False  # type: ignore[attr-defined]
 
 
 def get_recorded_spans(exporter: InMemorySpanExporter) -> list["ReadableSpan"]:

--- a/backend/tests/test_celery_otel.py
+++ b/backend/tests/test_celery_otel.py
@@ -1,0 +1,396 @@
+"""Tests for Celery worker OpenTelemetry instrumentation.
+
+Tests cover:
+- Worker process initialization with OTEL TracerProvider
+- CeleryInstrumentor instrumentation
+- SQLAlchemy worker engine instrumentation
+- Graceful degradation when OTEL is disabled
+- TracerProvider shutdown on worker cleanup
+"""
+
+import asyncio
+import importlib
+from unittest.mock import MagicMock, patch
+
+import app.celery.app as celery_app_module
+from app.celery import database as celery_database
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+class TestWorkerOtelInitialization:
+    """Tests for OTEL initialization in worker_process_init signal."""
+
+    def test_worker_init_creates_tracer_provider_when_otel_enabled(
+        self,
+        test_tracer_provider: TracerProvider,
+        in_memory_span_exporter: InMemorySpanExporter,
+    ) -> None:
+        """Test that worker initialization creates TracerProvider when OTEL is enabled."""
+        # Reset the worker loop state
+        celery_database._worker_loop = None
+
+        with (
+            patch.object(celery_database.settings, "OTEL_ENABLED", True),
+            patch(
+                "app.core.telemetry.get_tracer_provider",
+                return_value=test_tracer_provider,
+            ) as mock_get_provider,
+        ):
+            # Call the signal handler
+            celery_database.init_worker_resources()
+
+            # Verify get_tracer_provider was called
+            mock_get_provider.assert_called_once()
+
+            # Clean up
+            if celery_database._worker_loop is not None:
+                celery_database._worker_loop.close()
+                celery_database._worker_loop = None
+
+    def test_worker_init_skips_otel_when_disabled(self) -> None:
+        """Test that worker initialization skips OTEL when disabled."""
+        # Reset the worker loop state
+        celery_database._worker_loop = None
+
+        with (
+            patch.object(celery_database.settings, "OTEL_ENABLED", False),
+            patch("app.core.telemetry.get_tracer_provider") as mock_get_provider,
+        ):
+            # Call the signal handler
+            celery_database.init_worker_resources()
+
+            # Verify get_tracer_provider was NOT called
+            mock_get_provider.assert_not_called()
+
+            # Clean up
+            if celery_database._worker_loop is not None:
+                celery_database._worker_loop.close()
+                celery_database._worker_loop = None
+
+    def test_worker_init_handles_none_tracer_provider(self) -> None:
+        """Test that worker initialization handles None TracerProvider gracefully."""
+        # Reset the worker loop state
+        celery_database._worker_loop = None
+
+        with (
+            patch.object(celery_database.settings, "OTEL_ENABLED", True),
+            patch(
+                "app.core.telemetry.get_tracer_provider",
+                return_value=None,
+            ) as mock_get_provider,
+        ):
+            # Call the signal handler - should not raise
+            celery_database.init_worker_resources()
+
+            # Verify get_tracer_provider was called
+            mock_get_provider.assert_called_once()
+
+            # Clean up
+            if celery_database._worker_loop is not None:
+                celery_database._worker_loop.close()
+                celery_database._worker_loop = None
+
+    def test_worker_init_is_idempotent(
+        self,
+        test_tracer_provider: TracerProvider,
+    ) -> None:
+        """Test that calling init_worker_resources multiple times is safe."""
+        # Create a loop to simulate already initialized state
+        celery_database._worker_loop = asyncio.new_event_loop()
+
+        with (
+            patch.object(celery_database.settings, "OTEL_ENABLED", True),
+            patch("app.core.telemetry.get_tracer_provider") as mock_get_provider,
+        ):
+            # Call the signal handler - should return early
+            celery_database.init_worker_resources()
+
+            # Verify get_tracer_provider was NOT called (early return)
+            mock_get_provider.assert_not_called()
+
+            # Clean up
+            celery_database._worker_loop.close()
+            celery_database._worker_loop = None
+
+
+class TestWorkerSqlAlchemyInstrumentation:
+    """Tests for SQLAlchemy instrumentation in worker engine creation."""
+
+    def test_get_worker_engine_instruments_sqlalchemy_when_otel_enabled(self) -> None:
+        """Test that _get_worker_engine instruments SQLAlchemy when OTEL is enabled."""
+        # Reset state
+        celery_database._worker_engine = None
+        celery_database._worker_sqlalchemy_instrumented = False
+
+        with (
+            patch.object(celery_database.settings, "OTEL_ENABLED", True),
+            patch("app.celery.database.create_async_engine") as mock_create_engine,
+            patch("opentelemetry.instrumentation.sqlalchemy.SQLAlchemyInstrumentor") as mock_instrumentor_class,
+        ):
+            # Setup mock engine
+            mock_engine = MagicMock()
+            mock_engine.sync_engine = MagicMock()
+            mock_create_engine.return_value = mock_engine
+
+            # Setup mock instrumentor
+            mock_instrumentor = MagicMock()
+            mock_instrumentor_class.return_value = mock_instrumentor
+
+            # Call _get_worker_engine
+            engine = celery_database._get_worker_engine()
+
+            # Verify engine was created
+            assert engine == mock_engine
+
+            # Verify SQLAlchemyInstrumentor was called
+            mock_instrumentor.instrument.assert_called_once_with(engine=mock_engine.sync_engine)
+
+            # Verify flag was set
+            assert celery_database._worker_sqlalchemy_instrumented is True
+
+            # Clean up
+            celery_database._worker_engine = None
+            celery_database._worker_sqlalchemy_instrumented = False
+
+    def test_get_worker_engine_skips_instrumentation_when_otel_disabled(self) -> None:
+        """Test that _get_worker_engine skips instrumentation when OTEL is disabled."""
+        # Reset state
+        celery_database._worker_engine = None
+        celery_database._worker_sqlalchemy_instrumented = False
+
+        with (
+            patch.object(celery_database.settings, "OTEL_ENABLED", False),
+            patch("app.celery.database.create_async_engine") as mock_create_engine,
+            patch("opentelemetry.instrumentation.sqlalchemy.SQLAlchemyInstrumentor") as mock_instrumentor_class,
+        ):
+            # Setup mock engine
+            mock_engine = MagicMock()
+            mock_create_engine.return_value = mock_engine
+
+            # Call _get_worker_engine
+            engine = celery_database._get_worker_engine()
+
+            # Verify engine was created
+            assert engine == mock_engine
+
+            # Verify SQLAlchemyInstrumentor was NOT called
+            mock_instrumentor_class.assert_not_called()
+
+            # Verify flag was not set
+            assert celery_database._worker_sqlalchemy_instrumented is False
+
+            # Clean up
+            celery_database._worker_engine = None
+
+    def test_get_worker_engine_instruments_only_once(self) -> None:
+        """Test that SQLAlchemy instrumentation only happens once."""
+        # Reset state and pre-set the flag
+        celery_database._worker_engine = None
+        celery_database._worker_sqlalchemy_instrumented = True
+
+        with (
+            patch.object(celery_database.settings, "OTEL_ENABLED", True),
+            patch("app.celery.database.create_async_engine") as mock_create_engine,
+            patch("opentelemetry.instrumentation.sqlalchemy.SQLAlchemyInstrumentor") as mock_instrumentor_class,
+        ):
+            # Setup mock engine
+            mock_engine = MagicMock()
+            mock_engine.sync_engine = MagicMock()
+            mock_create_engine.return_value = mock_engine
+
+            # Call _get_worker_engine
+            celery_database._get_worker_engine()
+
+            # Verify SQLAlchemyInstrumentor was NOT called (already instrumented)
+            mock_instrumentor_class.assert_not_called()
+
+            # Clean up
+            celery_database._worker_engine = None
+            celery_database._worker_sqlalchemy_instrumented = False
+
+
+class TestWorkerOtelShutdown:
+    """Tests for OTEL shutdown in worker cleanup."""
+
+    def test_cleanup_shuts_down_tracer_provider_when_otel_enabled(self) -> None:
+        """Test that worker cleanup shuts down TracerProvider when OTEL is enabled."""
+        # Setup worker loop
+        loop = asyncio.new_event_loop()
+        celery_database._worker_loop = loop
+
+        with (
+            patch.object(celery_database.settings, "OTEL_ENABLED", True),
+            patch("app.core.telemetry.shutdown_tracer_provider") as mock_shutdown,
+        ):
+            # Call the cleanup handler
+            celery_database.cleanup_worker_resources()
+
+            # Verify shutdown was called
+            mock_shutdown.assert_called_once()
+
+            # Verify loop was closed
+            assert celery_database._worker_loop is None
+
+    def test_cleanup_skips_shutdown_when_otel_disabled(self) -> None:
+        """Test that worker cleanup skips OTEL shutdown when disabled."""
+        # Setup worker loop
+        loop = asyncio.new_event_loop()
+        celery_database._worker_loop = loop
+
+        with (
+            patch.object(celery_database.settings, "OTEL_ENABLED", False),
+            patch("app.core.telemetry.shutdown_tracer_provider") as mock_shutdown,
+        ):
+            # Call the cleanup handler
+            celery_database.cleanup_worker_resources()
+
+            # Verify shutdown was NOT called
+            mock_shutdown.assert_not_called()
+
+            # Verify loop was closed
+            assert celery_database._worker_loop is None
+
+    def test_cleanup_resets_instrumentation_flag(self) -> None:
+        """Test that worker cleanup resets the SQLAlchemy instrumentation flag."""
+        # Setup worker loop and set the flag
+        loop = asyncio.new_event_loop()
+        celery_database._worker_loop = loop
+        celery_database._worker_sqlalchemy_instrumented = True
+
+        with patch.object(celery_database.settings, "OTEL_ENABLED", False):
+            # Call the cleanup handler
+            celery_database.cleanup_worker_resources()
+
+            # Verify flag was reset
+            assert celery_database._worker_sqlalchemy_instrumented is False
+
+
+class TestCeleryAppInstrumentation:
+    """Tests for CeleryInstrumentor in app.py."""
+
+    def test_celery_instrumentor_called_when_otel_enabled(self) -> None:
+        """Test that CeleryInstrumentor is called when OTEL is enabled."""
+        with (
+            patch("app.core.config.settings.OTEL_ENABLED", True),
+            patch("opentelemetry.instrumentation.celery.CeleryInstrumentor") as mock_instrumentor_class,
+        ):
+            # Setup mock instrumentor
+            mock_instrumentor = MagicMock()
+            mock_instrumentor_class.return_value = mock_instrumentor
+
+            # Re-import to trigger the instrumentation code
+            # This is a bit hacky but necessary to test module-level code
+            importlib.reload(celery_app_module)
+
+            # Verify CeleryInstrumentor was called
+            mock_instrumentor.instrument.assert_called()
+
+    def test_celery_instrumentor_not_called_when_otel_disabled(self) -> None:
+        """Test that CeleryInstrumentor is not called when OTEL is disabled."""
+        with (
+            patch("app.core.config.settings.OTEL_ENABLED", False),
+            patch("opentelemetry.instrumentation.celery.CeleryInstrumentor") as mock_instrumentor_class,
+        ):
+            # Re-import to trigger the instrumentation code
+            importlib.reload(celery_app_module)
+
+            # Verify CeleryInstrumentor was NOT called
+            mock_instrumentor_class.assert_not_called()
+
+
+class TestWorkerOtelForkSafety:
+    """Tests for fork-safety of OTEL initialization."""
+
+    def test_each_worker_gets_own_tracer_provider(
+        self,
+        test_tracer_provider: TracerProvider,
+    ) -> None:
+        """Test that each worker process gets its own TracerProvider instance."""
+        # This simulates what happens after fork - each worker should create
+        # its own TracerProvider via get_tracer_provider()
+
+        # Reset state to simulate fresh forked process
+        celery_database._worker_loop = None
+
+        with (
+            patch.object(celery_database.settings, "OTEL_ENABLED", True),
+            patch(
+                "app.core.telemetry.get_tracer_provider",
+                return_value=test_tracer_provider,
+            ),
+        ):
+            # First worker init
+            celery_database.init_worker_resources()
+
+            # Verify get_tracer_provider was called (we can't check global provider
+            # because OTEL doesn't allow override)
+
+            # Clean up first worker
+            if celery_database._worker_loop is not None:
+                celery_database._worker_loop.close()
+                celery_database._worker_loop = None
+
+        # Create a second TracerProvider to simulate second worker
+        second_provider = TracerProvider(resource=Resource(attributes={"service.name": "worker-2"}))
+
+        with (
+            patch.object(celery_database.settings, "OTEL_ENABLED", True),
+            patch(
+                "app.core.telemetry.get_tracer_provider",
+                return_value=second_provider,
+            ) as mock_get_provider,
+        ):
+            # Second worker init
+            celery_database.init_worker_resources()
+
+            # Verify get_tracer_provider was called for the second worker
+            mock_get_provider.assert_called_once()
+
+            # Clean up
+            if celery_database._worker_loop is not None:
+                celery_database._worker_loop.close()
+                celery_database._worker_loop = None
+
+    def test_worker_engine_instrumentation_is_per_process(self) -> None:
+        """Test that SQLAlchemy instrumentation state is per-process."""
+        # Reset state to simulate fresh forked process
+        celery_database._worker_engine = None
+        celery_database._worker_sqlalchemy_instrumented = False
+
+        with (
+            patch.object(celery_database.settings, "OTEL_ENABLED", True),
+            patch("app.celery.database.create_async_engine") as mock_create_engine,
+            patch("opentelemetry.instrumentation.sqlalchemy.SQLAlchemyInstrumentor") as mock_instrumentor_class,
+        ):
+            # Setup mock engine
+            mock_engine = MagicMock()
+            mock_engine.sync_engine = MagicMock()
+            mock_create_engine.return_value = mock_engine
+
+            # Setup mock instrumentor
+            mock_instrumentor = MagicMock()
+            mock_instrumentor_class.return_value = mock_instrumentor
+
+            # First access
+            celery_database._get_worker_engine()
+            assert celery_database._worker_sqlalchemy_instrumented is True
+
+            # Cleanup simulating worker shutdown
+            celery_database._worker_engine = None
+            celery_database._worker_sqlalchemy_instrumented = False
+
+            # Second access (simulating new worker process)
+            mock_create_engine.reset_mock()
+            mock_instrumentor.reset_mock()
+
+            celery_database._get_worker_engine()
+
+            # Verify instrumentation was called again for the new "process"
+            assert celery_database._worker_sqlalchemy_instrumented is True
+            mock_instrumentor.instrument.assert_called_once()
+
+            # Clean up
+            celery_database._worker_engine = None
+            celery_database._worker_sqlalchemy_instrumented = False

--- a/backend/tests/test_celery_otel.py
+++ b/backend/tests/test_celery_otel.py
@@ -148,7 +148,7 @@ class TestWorkerSqlAlchemyInstrumentation:
             mock_instrumentor.instrument.assert_called_once_with(engine=mock_engine.sync_engine)
 
             # Verify flag was set
-            assert celery_database._worker_sqlalchemy_instrumented is True
+            assert celery_database._worker_sqlalchemy_instrumented
 
             # Clean up
             celery_database._worker_engine = None
@@ -179,7 +179,7 @@ class TestWorkerSqlAlchemyInstrumentation:
             mock_instrumentor_class.assert_not_called()
 
             # Verify flag was not set
-            assert celery_database._worker_sqlalchemy_instrumented is False
+            assert not celery_database._worker_sqlalchemy_instrumented
 
             # Clean up
             celery_database._worker_engine = None
@@ -264,7 +264,7 @@ class TestWorkerOtelShutdown:
             celery_database.cleanup_worker_resources()
 
             # Verify flag was reset
-            assert celery_database._worker_sqlalchemy_instrumented is False
+            assert not celery_database._worker_sqlalchemy_instrumented
 
 
 class TestCeleryAppInstrumentation:
@@ -375,7 +375,7 @@ class TestWorkerOtelForkSafety:
 
             # First access
             celery_database._get_worker_engine()
-            assert celery_database._worker_sqlalchemy_instrumented is True
+            assert celery_database._worker_sqlalchemy_instrumented
 
             # Cleanup simulating worker shutdown
             celery_database._worker_engine = None
@@ -388,7 +388,7 @@ class TestWorkerOtelForkSafety:
             celery_database._get_worker_engine()
 
             # Verify instrumentation was called again for the new "process"
-            assert celery_database._worker_sqlalchemy_instrumented is True
+            assert celery_database._worker_sqlalchemy_instrumented
             mock_instrumentor.instrument.assert_called_once()
 
             # Clean up

--- a/backend/tests/test_celery_otel_propagation.py
+++ b/backend/tests/test_celery_otel_propagation.py
@@ -1,0 +1,257 @@
+"""Tests for Celery OpenTelemetry context propagation.
+
+Tests cover:
+- Context propagation from API requests to Celery tasks
+- Parent-child span relationships
+- Celery span attributes (task_name, task_id, etc.)
+- Trace context in Celery message headers
+
+Note: These tests use mocks since OTEL_SDK_DISABLED=true in tests by default.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from app.celery import database as celery_database
+from opentelemetry import trace
+from opentelemetry.instrumentation.celery import CeleryInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+
+class TestCeleryContextPropagation:
+    """Tests for trace context propagation to Celery tasks."""
+
+    @pytest.fixture
+    def enabled_tracer_provider(self, in_memory_span_exporter: InMemorySpanExporter) -> TracerProvider:
+        """Create an enabled TracerProvider for context propagation tests."""
+        provider = TracerProvider(resource=Resource(attributes={"service.name": "test"}))
+        provider.add_span_processor(SimpleSpanProcessor(in_memory_span_exporter))
+        return provider
+
+    def test_trace_context_format_is_valid(self) -> None:
+        """Test that trace context format follows W3C traceparent specification."""
+        # Create a mock span with known trace_id and span_id
+        mock_span = MagicMock()
+        mock_span_context = MagicMock()
+        mock_span_context.trace_id = 0x12345678901234567890123456789012
+        mock_span_context.span_id = 0x1234567890123456
+        mock_span_context.is_valid = True
+        mock_span_context.trace_flags = 1
+        mock_span.get_span_context.return_value = mock_span_context
+
+        # Verify traceparent format
+        trace_id_hex = format(mock_span_context.trace_id, "032x")
+        span_id_hex = format(mock_span_context.span_id, "016x")
+
+        assert len(trace_id_hex) == 32
+        assert len(span_id_hex) == 16
+
+    def test_traceparent_header_structure(self) -> None:
+        """Test that traceparent header follows W3C format."""
+        # W3C traceparent format: version-trace_id-parent_id-trace_flags
+        # Example: 00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
+
+        traceparent = "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"
+        parts = traceparent.split("-")
+
+        assert len(parts) == 4
+        assert parts[0] == "00"  # Version
+        assert len(parts[1]) == 32  # Trace ID (128-bit)
+        assert len(parts[2]) == 16  # Parent ID (64-bit)
+        assert len(parts[3]) == 2  # Trace flags
+
+    def test_context_extraction_from_headers(self) -> None:
+        """Test that context can be extracted from carrier headers."""
+        propagator = TraceContextTextMapPropagator()
+
+        # Simulate headers that would come from a parent context
+        headers = {"traceparent": "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"}
+
+        # Extract context
+        extracted_context = propagator.extract(headers)
+
+        # Verify extraction succeeded (returns a context object)
+        assert extracted_context is not None
+
+
+class TestCeleryInstrumentorBehavior:
+    """Tests for CeleryInstrumentor automatic behavior."""
+
+    def test_celery_instrumentor_can_be_instantiated(self) -> None:
+        """Test that CeleryInstrumentor can be instantiated."""
+        instrumentor = CeleryInstrumentor()
+        assert instrumentor is not None
+
+
+class TestSpanAttributePatterns:
+    """Tests for expected span attribute patterns."""
+
+    def test_celery_task_span_attributes_format(self) -> None:
+        """Test that Celery task span attributes follow expected format."""
+        # Expected attributes that CeleryInstrumentor sets
+        expected_attributes = {
+            "celery.task_name": "app.celery.tasks.check_disruptions_and_alert",
+            "celery.task_id": "abc123-def456-ghi789",
+            "celery.state": "SUCCESS",
+        }
+
+        # Verify attribute names and value types
+        assert isinstance(expected_attributes["celery.task_name"], str)
+        assert isinstance(expected_attributes["celery.task_id"], str)
+        assert isinstance(expected_attributes["celery.state"], str)
+
+    def test_db_span_attributes_format(self) -> None:
+        """Test that database span attributes follow expected format."""
+        # Expected attributes that SQLAlchemyInstrumentor sets
+        expected_attributes = {
+            "db.system": "postgresql",
+            "db.statement": "SELECT * FROM routes WHERE active = true",
+        }
+
+        # Verify attribute names and value types
+        assert isinstance(expected_attributes["db.system"], str)
+        assert isinstance(expected_attributes["db.statement"], str)
+
+
+class TestWorkerOtelIntegration:
+    """Tests for worker OTEL integration patterns."""
+
+    def test_worker_tracer_provider_initialization_pattern(self) -> None:
+        """Test that worker initializes TracerProvider correctly."""
+        # Reset state
+        celery_database._worker_loop = None
+
+        with (
+            patch.object(celery_database.settings, "OTEL_ENABLED", True),
+            patch("app.core.telemetry.get_tracer_provider") as mock_get,
+            patch("opentelemetry.trace.set_tracer_provider") as mock_set,
+        ):
+            mock_provider = MagicMock()
+            mock_get.return_value = mock_provider
+
+            # Initialize worker
+            celery_database.init_worker_resources()
+
+            # Verify TracerProvider was obtained and set
+            mock_get.assert_called_once()
+            mock_set.assert_called_once_with(mock_provider)
+
+            # Clean up
+            if celery_database._worker_loop is not None:
+                celery_database._worker_loop.close()
+                celery_database._worker_loop = None
+
+    def test_worker_sqlalchemy_instrumentation_pattern(self) -> None:
+        """Test that worker instruments SQLAlchemy correctly."""
+        # Reset state
+        celery_database._worker_engine = None
+        celery_database._worker_sqlalchemy_instrumented = False
+
+        with (
+            patch.object(celery_database.settings, "OTEL_ENABLED", True),
+            patch("app.celery.database.create_async_engine") as mock_create,
+            patch("opentelemetry.instrumentation.sqlalchemy.SQLAlchemyInstrumentor") as mock_instrumentor_class,
+        ):
+            mock_engine = MagicMock()
+            mock_engine.sync_engine = MagicMock()
+            mock_create.return_value = mock_engine
+
+            mock_instrumentor = MagicMock()
+            mock_instrumentor_class.return_value = mock_instrumentor
+
+            # Create worker engine
+            celery_database._get_worker_engine()
+
+            # Verify instrumentation was called with sync_engine
+            mock_instrumentor.instrument.assert_called_once_with(engine=mock_engine.sync_engine)
+
+            # Clean up
+            celery_database._worker_engine = None
+            celery_database._worker_sqlalchemy_instrumented = False
+
+
+class TestContextPropagationMechanics:
+    """Tests for context propagation mechanics."""
+
+    def test_propagator_inject_and_extract(self) -> None:
+        """Test that propagator can inject and extract context."""
+        propagator = TraceContextTextMapPropagator()
+
+        # Create a carrier to hold headers
+        carrier: dict[str, str] = {}
+
+        # In a real scenario, inject would add traceparent header
+        # Here we simulate what happens
+        carrier["traceparent"] = "00-12345678901234567890123456789012-1234567890123456-01"
+
+        # Extract should return a context
+        context = propagator.extract(carrier)
+        assert context is not None
+
+    def test_multiple_traces_are_independent(self) -> None:
+        """Test that different traces have different IDs."""
+        trace_id_1 = 0x12345678901234567890123456789012
+        trace_id_2 = 0xABCDEFABCDEFABCDEFABCDEFABCDEFAB
+
+        # Trace IDs should be different
+        assert trace_id_1 != trace_id_2
+
+        # Each can have its own parent span
+        parent_id_1 = 0x1234567890123456
+        parent_id_2 = 0xABCDEFABCDEFABCD
+
+        assert parent_id_1 != parent_id_2
+
+
+class TestAsyncWorkerSpanPatterns:
+    """Tests for async worker span patterns."""
+
+    def test_span_kind_for_celery_tasks(self) -> None:
+        """Test that Celery tasks should use CONSUMER span kind."""
+        # Celery task receiving work is a consumer
+        assert SpanKind.CONSUMER is not None
+
+    def test_span_kind_for_api_requests(self) -> None:
+        """Test that API requests should use SERVER span kind."""
+        # FastAPI handling requests is a server
+        assert SpanKind.SERVER is not None
+
+    def test_parent_child_span_relationship_concept(self) -> None:
+        """Test the concept of parent-child span relationships."""
+        # A child span should reference its parent via parent_id
+        parent_trace_id = 0x12345678901234567890123456789012
+        parent_span_id = 0x1234567890123456
+
+        # Child span inherits trace_id but has different span_id
+        child_trace_id = parent_trace_id  # Same trace
+        child_span_id = 0xABCDEFABCDEFABCD  # Different span
+
+        assert child_trace_id == parent_trace_id
+        assert child_span_id != parent_span_id
+
+
+@pytest.mark.asyncio
+class TestAsyncContextPropagation:
+    """Tests for async context propagation patterns."""
+
+    async def test_async_span_creation_pattern(self) -> None:
+        """Test the pattern for creating spans in async code."""
+        # In async code, spans are created the same way as sync
+        # The key is that context propagation works across await boundaries
+
+        # Mock tracer usage pattern
+        tracer = trace.get_tracer(__name__)
+        assert tracer is not None
+
+    async def test_span_context_available_in_async_code(self) -> None:
+        """Test that span context is accessible in async code."""
+        # Context should be accessible via trace.get_current_span()
+        current_span = trace.get_current_span()
+
+        # With OTEL_SDK_DISABLED, this returns a NoOp span
+        assert current_span is not None

--- a/backend/tests/test_celery_otel_propagation.py
+++ b/backend/tests/test_celery_otel_propagation.py
@@ -182,12 +182,8 @@ class TestContextPropagationMechanics:
         """Test that propagator can inject and extract context."""
         propagator = TraceContextTextMapPropagator()
 
-        # Create a carrier to hold headers
-        carrier: dict[str, str] = {}
-
-        # In a real scenario, inject would add traceparent header
-        # Here we simulate what happens
-        carrier["traceparent"] = "00-12345678901234567890123456789012-1234567890123456-01"
+        # Create a carrier with traceparent header
+        carrier: dict[str, str] = {"traceparent": "00-12345678901234567890123456789012-1234567890123456-01"}
 
         # Extract should return a context
         context = propagator.extract(carrier)
@@ -224,14 +220,10 @@ class TestAsyncWorkerSpanPatterns:
     def test_parent_child_span_relationship_concept(self) -> None:
         """Test the concept of parent-child span relationships."""
         # A child span should reference its parent via parent_id
-        parent_trace_id = 0x12345678901234567890123456789012
+        # Child inherits trace_id from parent but has different span_id
         parent_span_id = 0x1234567890123456
+        child_span_id = 0xABCDEFABCDEFABCD
 
-        # Child span inherits trace_id but has different span_id
-        child_trace_id = parent_trace_id  # Same trace
-        child_span_id = 0xABCDEFABCDEFABCD  # Different span
-
-        assert child_trace_id == parent_trace_id
         assert child_span_id != parent_span_id
 
 

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -625,6 +625,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation-celery" },
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-sqlalchemy" },
     { name = "opentelemetry-sdk" },
@@ -672,6 +673,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "opentelemetry-api", specifier = ">=1.29.0" },
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.29.0" },
+    { name = "opentelemetry-instrumentation-celery", specifier = ">=0.50b0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.50b0" },
     { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.50b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.29.0" },
@@ -902,6 +904,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b7/a4/cfbb6fc1ec0aa9bf5a93f548e6a11ab3ac1956272f17e0d399aa2c1f85bc/opentelemetry_instrumentation_asgi-0.59b0.tar.gz", hash = "sha256:2509d6fe9fd829399ce3536e3a00426c7e3aa359fc1ed9ceee1628b56da40e7a", size = 25116, upload-time = "2025-10-16T08:39:36.092Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/88/fe02d809963b182aafbf5588685d7a05af8861379b0ec203d48e360d4502/opentelemetry_instrumentation_asgi-0.59b0-py3-none-any.whl", hash = "sha256:ba9703e09d2c33c52fa798171f344c8123488fcd45017887981df088452d3c53", size = 16797, upload-time = "2025-10-16T08:38:37.214Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-celery"
+version = "0.59b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/d3/a2f9625c54e2562739001e221f5b2953bdc9f6bdc8b1f551281c0b6c6190/opentelemetry_instrumentation_celery-0.59b0.tar.gz", hash = "sha256:b90e54708ef7377cf5d66b54e9a1adf7e3daa30aba84b6a61d0416b58e5438de", size = 14769, upload-time = "2025-10-16T08:39:41.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/af/0f/881120f89a537e8d7ac6b5832fe11fbc13062e85e7e6bdcc3c37d388e5fc/opentelemetry_instrumentation_celery-0.59b0-py3-none-any.whl", hash = "sha256:f6959b6e8498a823f06ca11e9a0bcf3e84f0d31caa8d634d908f4db348f46108", size = 13806, upload-time = "2025-10-16T08:38:45.67Z" },
 ]
 
 [[package]]

--- a/docs/adr/12-observability.md
+++ b/docs/adr/12-observability.md
@@ -3,7 +3,7 @@
 ## OpenTelemetry for Distributed Tracing
 
 ### Status
-Active (Implemented 2025-11-17, Issue #172)
+Active
 
 ### Context
 Operating a distributed system (FastAPI backend, Celery workers, PostgreSQL, Redis) without observability is challenging:
@@ -21,14 +21,13 @@ Need structured observability to:
 ### Decision
 Use OpenTelemetry (OTEL) for distributed tracing with OTLP protocol to send traces to Grafana Cloud.
 
-**Phase 1 (MVP - Issue #172):**
-- Instrument FastAPI endpoints (HTTP request tracing)
-- Instrument SQLAlchemy (database query tracing)
-- Export traces via OTLP HTTP to Grafana Cloud
-- Backend only (no frontend, no Celery)
+**Scope:**
+- FastAPI endpoint tracing
+- SQLAlchemy database query tracing
+- Celery worker task tracing with context propagation
+- OTLP HTTP export to Grafana Cloud
 
-**Deferred to Phase 2:**
-- Celery worker tracing (Issue #2)
+**Deferred:**
 - Custom application spans
 - Metrics collection
 - Frontend browser tracing
@@ -50,16 +49,11 @@ Use OpenTelemetry (OTEL) for distributed tracing with OTLP protocol to send trac
 - Familiar Grafana UI for visualization
 - OTLP native support (no vendor-specific SDK needed)
 
-**Why Traces Only (Phase 1)?**
+**Why Traces Only (not Metrics)?**
 - **Highest ROI**: Traces provide immediate value for debugging API performance
 - **Auto-Generated Metrics**: Grafana auto-generates RED metrics (Rate, Errors, Duration) from trace data
 - **YAGNI Principle**: Metrics collection can be added later if needed
 - **Simplicity**: Start simple, add complexity only when justified
-
-**Why Defer Celery Instrumentation?**
-- Separate concern (different process, different lifecycle)
-- FastAPI/SQLAlchemy provides 80% of value for initial observability
-- Celery instrumentation requires additional complexity (Issue #2)
 
 **Why Defer Frontend Tracing?**
 - Backend priority (API performance is more critical than frontend)
@@ -70,7 +64,7 @@ Use OpenTelemetry (OTEL) for distributed tracing with OTLP protocol to send trac
 ### Consequences
 
 **Easier:**
-- **Debug Production Issues**: Trace requests from API entry → DB queries → response
+- **Debug Production Issues**: Trace requests from API entry → DB queries → Celery tasks
 - **Identify Slow Queries**: See exact SQL statements with execution time
 - **Find Performance Bottlenecks**: Visual flamegraphs show where time is spent
 - **Correlate Errors**: Traces link errors across services
@@ -86,14 +80,6 @@ Use OpenTelemetry (OTEL) for distributed tracing with OTLP protocol to send trac
 - **Dependency on External Service**: If Grafana Cloud is down, traces are lost (not critical for hobby project)
 
 ### Related ADRs
-- **ADR 08**: Worker Pool Fork Safety (lazy initialization requirement)
+- **ADR 08**: Worker Pool Fork Safety (Celery worker lazy initialization)
 - **ADR 10**: Testing Strategy (test coverage and mocking approach)
 - **ADR 02**: Development Tools (dependency management)
-
-### Future Enhancements (Post-MVP)
-- **Issue #2**: Celery worker tracing (task-level spans)
-- **Custom Spans**: TfL API calls, email sending, complex business logic
-- **Metrics Collection**: RED metrics, custom business metrics
-- **Log Correlation**: Inject trace IDs into structlog for log-trace correlation
-- **Frontend Tracing**: Browser performance monitoring (if needed)
-- **Alerting**: Grafana alerts for high latency or error rates


### PR DESCRIPTION
Also removed unhelpful test of instrumentor which was testing the library code not our code

resolves #173

## Summary by Sourcery

Add OpenTelemetry instrumentation for Celery workers and SQLAlchemy in a fork-safe manner, update observability ADR to include Celery tracing, and introduce end-to-end tests for task spans and context propagation.

New Features:
- Instrument Celery workers with OpenTelemetry, including fork-safe TracerProvider initialization and shutdown
- Automatically instrument worker SQLAlchemy engines for OTEL query tracing only once per process
- Enable CeleryInstrumentor to wrap task execution and propagate trace context
- Extend ADR documentation to include Celery worker tracing in the initial observability scope

Enhancements:
- Integrate structlog-based logging for Celery app initialization
- Refine ADR 12 decision section to replace phased plan with updated scope and consequences

Build:
- Add opentelemetry-instrumentation-celery to project dependencies

Documentation:
- Update ADR 12 to reflect Celery worker tracing scope, remove phase labels, and adjust consequences

Tests:
- Add tests for Celery worker OTEL initialization, SQLAlchemy instrumentation, and TracerProvider shutdown
- Add tests for CeleryInstrumentor behavior, fork-safety, and context propagation between API and tasks
- Include fixture to reset OTEL instrumentation flags in FastAPI and Celery contexts