### PR TITLE
Add mode-aware severity filtering for disruption alerts (#203)

### DIFF
--- a/backend/alembic/versions/7df10ab411af_add_mode_to_severity_codes_and_alert_.py
+++ b/backend/alembic/versions/7df10ab411af_add_mode_to_severity_codes_and_alert_.py
@@ -104,14 +104,15 @@ def upgrade() -> None:
     # This means "Good Service" will NOT trigger alerts
     now = datetime.now(UTC)
     for mode in TFL_MODES:
-        new_id = str(uuid.uuid4())
+        new_id = uuid.uuid4()
         op.execute(
             sa.text(
-                f"""
+                """
                 INSERT INTO alert_disabled_severities (id, mode_id, severity_level, created_at, updated_at)
-                VALUES ('{new_id}'::uuid, :mode_id, :severity_level, :created_at, :updated_at)
+                VALUES (:id, :mode_id, :severity_level, :created_at, :updated_at)
                 """
             ).bindparams(
+                id=new_id,
                 mode_id=mode,
                 severity_level=10,  # Good Service
                 created_at=now,

--- a/backend/alembic/versions/7df10ab411af_add_mode_to_severity_codes_and_alert_.py
+++ b/backend/alembic/versions/7df10ab411af_add_mode_to_severity_codes_and_alert_.py
@@ -1,0 +1,150 @@
+"""add_mode_to_severity_codes_and_alert_disabled_severities
+
+Revision ID: 7df10ab411af
+Revises: 8ed2312f54f3
+Create Date: 2025-11-19 08:15:48.224661
+
+"""
+
+import uuid
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "7df10ab411af"
+down_revision: str | Sequence[str] | None = "8ed2312f54f3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# All TfL transport modes that may have severity codes
+TFL_MODES = [
+    "tube",
+    "dlr",
+    "overground",
+    "elizabeth-line",
+    "tram",
+    "tfl-rail",
+    "cable-car",
+    "river-bus",
+    "national-rail",
+]
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Create the alert_disabled_severities table
+    op.create_table(
+        "alert_disabled_severities",
+        sa.Column(
+            "mode_id",
+            sa.String(length=50),
+            nullable=False,
+            comment="Transport mode (e.g., 'tube', 'dlr', 'overground')",
+        ),
+        sa.Column("severity_level", sa.Integer(), nullable=False),
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("mode_id", "severity_level", name="uq_alert_disabled_severity_mode_level"),
+    )
+    op.create_index(
+        op.f("ix_alert_disabled_severities_mode_id"),
+        "alert_disabled_severities",
+        ["mode_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_alert_disabled_severities_severity_level"),
+        "alert_disabled_severities",
+        ["severity_level"],
+        unique=False,
+    )
+
+    # Clear existing severity_codes data (table should be empty, but handle gracefully)
+    # This is needed because existing rows don't have mode_id
+    op.execute("DELETE FROM severity_codes")
+
+    # Add mode_id column to severity_codes
+    op.add_column(
+        "severity_codes",
+        sa.Column(
+            "mode_id",
+            sa.String(length=50),
+            nullable=False,
+            comment="Transport mode (e.g., 'tube', 'dlr', 'overground')",
+        ),
+    )
+
+    # Update indexes and constraints on severity_codes
+    op.drop_index(op.f("ix_severity_codes_severity_level"), table_name="severity_codes")
+    op.create_index(
+        op.f("ix_severity_codes_severity_level"),
+        "severity_codes",
+        ["severity_level"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_severity_codes_mode_id"),
+        "severity_codes",
+        ["mode_id"],
+        unique=False,
+    )
+    op.create_unique_constraint(
+        "uq_severity_code_mode_level",
+        "severity_codes",
+        ["mode_id", "severity_level"],
+    )
+
+    # Populate alert_disabled_severities with severity_level=10 (Good Service) for all modes
+    # This means "Good Service" will NOT trigger alerts
+    now = datetime.now(UTC)
+    for mode in TFL_MODES:
+        new_id = str(uuid.uuid4())
+        op.execute(
+            sa.text(
+                f"""
+                INSERT INTO alert_disabled_severities (id, mode_id, severity_level, created_at, updated_at)
+                VALUES ('{new_id}'::uuid, :mode_id, :severity_level, :created_at, :updated_at)
+                """
+            ).bindparams(
+                mode_id=mode,
+                severity_level=10,  # Good Service
+                created_at=now,
+                updated_at=now,
+            )
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Remove the unique constraint and new indexes from severity_codes
+    op.drop_constraint("uq_severity_code_mode_level", "severity_codes", type_="unique")
+    op.drop_index(op.f("ix_severity_codes_mode_id"), table_name="severity_codes")
+    op.drop_index(op.f("ix_severity_codes_severity_level"), table_name="severity_codes")
+
+    # Restore original unique index on severity_level
+    op.create_index(
+        op.f("ix_severity_codes_severity_level"),
+        "severity_codes",
+        ["severity_level"],
+        unique=True,
+    )
+
+    # Remove mode_id column
+    op.drop_column("severity_codes", "mode_id")
+
+    # Drop alert_disabled_severities table
+    op.drop_index(
+        op.f("ix_alert_disabled_severities_severity_level"),
+        table_name="alert_disabled_severities",
+    )
+    op.drop_index(
+        op.f("ix_alert_disabled_severities_mode_id"),
+        table_name="alert_disabled_severities",
+    )
+    op.drop_table("alert_disabled_severities")

--- a/backend/app/celery/tasks.py
+++ b/backend/app/celery/tasks.py
@@ -135,6 +135,7 @@ def check_disruptions_and_alert(self: BoundTask) -> DisruptionCheckResult:
         Retry: If the task should be retried due to transient failure
     """
     try:
+        logger.info("check_disruptions_task_started")
         # run_in_worker_loop() uses the worker's persistent event loop.
         # This allows database and Redis connections to be pooled and
         # reused across tasks in the same worker process.
@@ -216,6 +217,7 @@ def rebuild_route_indexes_task(
         Retry: If the task should be retried due to transient failure
     """
     try:
+        logger.info("rebuild_indexes_task_started", route_id=route_id)
         # run_in_worker_loop() uses the worker's persistent event loop.
         # This allows database connections to be pooled and reused
         # across tasks in the same worker process.
@@ -344,6 +346,7 @@ def detect_and_rebuild_stale_routes(self: BoundTask) -> DetectStaleRoutesResult:
         Retry: If the task should be retried due to transient failure
     """
     try:
+        logger.info("detect_stale_routes_task_started")
         # run_in_worker_loop() uses the worker's persistent event loop.
         # This allows database connections to be pooled and reused
         # across tasks in the same worker process.

--- a/backend/app/core/logging.py
+++ b/backend/app/core/logging.py
@@ -45,7 +45,9 @@ def configure_logging(*, log_level: str = "INFO") -> None:
             # Format exceptions
             structlog.processors.format_exc_info,
             # Render as JSON or key-value depending on environment
-            structlog.processors.JSONRenderer() if log_level.upper() == "DEBUG" else structlog.dev.ConsoleRenderer(),
+            structlog.processors.JSONRenderer()
+            if log_level.upper() == "DEBUG"
+            else structlog.dev.ConsoleRenderer(colors=True),
         ],
         # Use LoggerFactory for stdlib integration
         logger_factory=structlog.stdlib.LoggerFactory(),

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -11,7 +11,14 @@ from app.models.notification import (
     NotificationStatus,
 )
 from app.models.rate_limit import RateLimitAction, RateLimitLog
-from app.models.tfl import Line, LineDisruptionStateLog, Station, StationConnection
+from app.models.tfl import (
+    AlertDisabledSeverity,
+    Line,
+    LineDisruptionStateLog,
+    SeverityCode,
+    Station,
+    StationConnection,
+)
 from app.models.user import (
     EmailAddress,
     PhoneNumber,
@@ -36,8 +43,10 @@ __all__ = [
     "RateLimitLog",
     "RateLimitAction",
     # TfL models
+    "AlertDisabledSeverity",
     "Line",
     "LineDisruptionStateLog",
+    "SeverityCode",
     "Station",
     "StationConnection",
     # Route models

--- a/backend/app/schemas/tfl.py
+++ b/backend/app/schemas/tfl.py
@@ -76,6 +76,7 @@ class DisruptionResponse(BaseModel):
 
     line_id: str  # TfL line ID
     line_name: str
+    mode: str  # Transport mode (tube, dlr, overground, etc.)
     status_severity: int  # 0-20 (0=special service, 10=good service, 20=closed)
     status_severity_description: str  # e.g., "Good Service", "Severe Delays"
     reason: str | None = None  # Description of disruption
@@ -197,9 +198,30 @@ class SeverityCodeResponse(BaseModel):
 
     model_config = ConfigDict(from_attributes=True)
 
+    mode_id: str = Field(..., description="Transport mode (e.g., 'tube', 'dlr')")
     severity_level: int = Field(..., description="Severity level (0-20)")
     description: str = Field(..., description="Description of severity level")
     last_updated: datetime = Field(..., description="When this code was last updated")
+
+
+class AlertConfigResponse(BaseModel):
+    """Response schema for alert configuration per severity code."""
+
+    mode_id: str = Field(..., description="Transport mode (e.g., 'tube', 'dlr')")
+    severity_level: int = Field(..., description="Severity level (0-20)")
+    description: str = Field(..., description="Description of severity level")
+    alerts_enabled: bool = Field(..., description="Whether alerts are enabled for this severity")
+
+
+class LineStateResponse(BaseModel):
+    """Response schema for current line status."""
+
+    line_id: str = Field(..., description="TfL line ID")
+    line_name: str = Field(..., description="Line name")
+    mode: str = Field(..., description="Transport mode")
+    status_severity: int = Field(..., description="Current severity level")
+    status_severity_description: str = Field(..., description="Current status description")
+    reason: str | None = Field(None, description="Disruption reason if any")
 
 
 class DisruptionCategoryResponse(BaseModel):

--- a/backend/app/services/tfl_service.py
+++ b/backend/app/services/tfl_service.py
@@ -564,18 +564,15 @@ class TfLService:
         disabled_severities = {(d.mode_id, d.severity_level) for d in disabled_result.scalars().all()}
 
         # Build the response
-        config = []
-        for code in severity_codes:
-            config.append(
-                {
-                    "mode_id": code.mode_id,
-                    "severity_level": code.severity_level,
-                    "description": code.description,
-                    "alerts_enabled": (code.mode_id, code.severity_level) not in disabled_severities,
-                }
-            )
-
-        return config
+        return [
+            {
+                "mode_id": code.mode_id,
+                "severity_level": code.severity_level,
+                "description": code.description,
+                "alerts_enabled": (code.mode_id, code.severity_level) not in disabled_severities,
+            }
+            for code in severity_codes
+        ]
 
     async def fetch_disruption_categories(self, use_cache: bool = True) -> list[DisruptionCategory]:
         """

--- a/backend/app/services/tfl_service.py
+++ b/backend/app/services/tfl_service.py
@@ -61,6 +61,7 @@ from app.helpers.station_resolution import (
     select_station_from_candidates,
 )
 from app.models.tfl import (
+    AlertDisabledSeverity,
     DisruptionCategory,
     Line,
     SeverityCode,
@@ -461,6 +462,9 @@ class TfLService:
         """
         Fetch severity codes metadata from TfL API.
 
+        The TfL API returns severity codes with mode information (e.g., tube, dlr).
+        Each mode has its own set of severity levels.
+
         Args:
             use_cache: Whether to use Redis cache (default: True)
 
@@ -490,19 +494,30 @@ class TfLService:
             ttl = self._extract_cache_ttl(response) or DEFAULT_METADATA_CACHE_TTL
 
             # Process and upsert severity codes (avoids race conditions)
-            # response.content is a SeverityCodeArray (RootModel), access via .root
+            # response.content is a StatusSeveritiesArray (RootModel), access via .root
             severity_data_list = response.content.root
 
             now = datetime.now(UTC)
             for severity_data in severity_data_list:
+                # Skip entries with missing required fields
+                if severity_data.modeName is None or severity_data.severityLevel is None:
+                    logger.warning(
+                        "skipping_severity_code_missing_fields",
+                        mode_name=severity_data.modeName,
+                        severity_level=severity_data.severityLevel,
+                    )
+                    continue
+
                 # Use PostgreSQL INSERT ... ON CONFLICT to atomically upsert
+                # Now keyed on (mode_id, severity_level)
                 stmt = insert(SeverityCode).values(
+                    mode_id=severity_data.modeName,
                     severity_level=severity_data.severityLevel,
-                    description=severity_data.description,
+                    description=severity_data.description or "",
                     last_updated=now,
                 )
                 stmt = stmt.on_conflict_do_update(
-                    index_elements=["severity_level"],
+                    constraint="uq_severity_code_mode_level",
                     set_={
                         "description": stmt.excluded.description,
                         "last_updated": stmt.excluded.last_updated,
@@ -530,6 +545,37 @@ class TfLService:
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Failed to fetch severity codes from TfL API.",
             ) from e
+
+    async def get_alert_config(self) -> list[dict[str, Any]]:
+        """
+        Get the alert configuration showing which severities trigger alerts.
+
+        Returns a list of all severity codes with their alert status.
+
+        Returns:
+            List of dicts with mode_id, severity_level, description, alerts_enabled
+        """
+        # Fetch all severity codes
+        result = await self.db.execute(select(SeverityCode).order_by(SeverityCode.mode_id, SeverityCode.severity_level))
+        severity_codes = result.scalars().all()
+
+        # Fetch all disabled severities
+        disabled_result = await self.db.execute(select(AlertDisabledSeverity))
+        disabled_severities = {(d.mode_id, d.severity_level) for d in disabled_result.scalars().all()}
+
+        # Build the response
+        config = []
+        for code in severity_codes:
+            config.append(
+                {
+                    "mode_id": code.mode_id,
+                    "severity_level": code.severity_level,
+                    "description": code.description,
+                    "alerts_enabled": (code.mode_id, code.severity_level) not in disabled_severities,
+                }
+            )
+
+        return config
 
     async def fetch_disruption_categories(self, use_cache: bool = True) -> list[DisruptionCategory]:
         """
@@ -1250,6 +1296,7 @@ class TfLService:
         line_status: LineStatus,
         line_id: str,
         line_name: str,
+        mode: str,
     ) -> DisruptionResponse:
         """
         Extract line status information from a LineStatus object.
@@ -1261,6 +1308,7 @@ class TfLService:
             line_status: LineStatus object from TfL API containing statusSeverity and nested disruption
             line_id: ID of the line
             line_name: Name of the line
+            mode: Transport mode (tube, dlr, overground, etc.)
 
         Returns:
             DisruptionResponse object containing current line status
@@ -1283,6 +1331,7 @@ class TfLService:
         return DisruptionResponse(
             line_id=line_id,
             line_name=line_name,
+            mode=mode,
             status_severity=status_severity,
             status_severity_description=status_severity_description,
             reason=reason,
@@ -1308,8 +1357,9 @@ class TfLService:
             List of line status responses for all currently active statuses (including Good Service and disruptions)
         """
         disruptions: list[DisruptionResponse] = []
-        line_id = getattr(line_data, "id", "unknown")
-        line_name = getattr(line_data, "name", "Unknown")
+        line_id = getattr(line_data, "id", None) or "unknown"
+        line_name = getattr(line_data, "name", None) or "Unknown"
+        mode_name = getattr(line_data, "modeName", None) or "unknown"
         line_statuses = getattr(line_data, "lineStatuses", None)
 
         if not line_statuses:
@@ -1338,6 +1388,7 @@ class TfLService:
                 line_status,
                 line_id,
                 line_name,
+                mode_name,
             )
             disruptions.append(disruption)
 

--- a/backend/tests/test_alert_service.py
+++ b/backend/tests/test_alert_service.py
@@ -212,6 +212,7 @@ def sample_disruptions() -> list[DisruptionResponse]:
         DisruptionResponse(
             line_id="victoria",
             line_name="Victoria",
+            mode="tube",
             status_severity=5,
             status_severity_description="Severe Delays",
             reason="Signal failure at King's Cross",
@@ -637,6 +638,7 @@ async def test_get_route_disruptions_returns_relevant(
         DisruptionResponse(
             line_id="northern",
             line_name="Northern",
+            mode="tube",
             status_severity=6,
             status_severity_description="Minor Delays",
             reason="Train cancellations",
@@ -646,7 +648,11 @@ async def test_get_route_disruptions_returns_relevant(
     mock_tfl_instance.fetch_line_disruptions = AsyncMock(return_value=all_disruptions)
     mock_tfl_class.return_value = mock_tfl_instance
 
-    disruptions, error_occurred = await alert_service._get_route_disruptions(test_route_with_schedule)
+    disabled_severity_pairs: set[tuple[str, int]] = set()
+
+    disruptions, error_occurred = await alert_service._get_route_disruptions(
+        test_route_with_schedule, disabled_severity_pairs
+    )
 
     # Should return no error
     assert not error_occurred
@@ -672,7 +678,10 @@ async def test_get_route_disruptions_empty(
     mock_tfl_instance.fetch_line_disruptions = AsyncMock(return_value=[])
     mock_tfl_class.return_value = mock_tfl_instance
 
-    disruptions, error_occurred = await alert_service._get_route_disruptions(test_route_with_schedule)
+    disabled_severity_pairs: set[tuple[str, int]] = set()
+    disruptions, error_occurred = await alert_service._get_route_disruptions(
+        test_route_with_schedule, disabled_severity_pairs
+    )
 
     assert not error_occurred
     assert len(disruptions) == 0
@@ -698,6 +707,7 @@ async def test_get_route_disruptions_filters_correctly(
             DisruptionResponse(
                 line_id="central",  # Not in route
                 line_name="Central",
+                mode="tube",
                 status_severity=5,
                 status_severity_description="Severe Delays",
                 reason="Signal failure",
@@ -707,7 +717,10 @@ async def test_get_route_disruptions_filters_correctly(
     )
     mock_tfl_class.return_value = mock_tfl_instance
 
-    disruptions, error_occurred = await alert_service._get_route_disruptions(test_route_with_schedule)
+    disabled_severity_pairs: set[tuple[str, int]] = set()
+    disruptions, error_occurred = await alert_service._get_route_disruptions(
+        test_route_with_schedule, disabled_severity_pairs
+    )
 
     # Should return no error
     assert not error_occurred
@@ -792,6 +805,7 @@ async def test_should_send_alert_changed_disruption(
         DisruptionResponse(
             line_id="victoria",
             line_name="Victoria",
+            mode="tube",
             status_severity=6,
             status_severity_description="Minor Delays",  # Changed
             reason="Different reason",  # Changed
@@ -1279,6 +1293,7 @@ def test_create_disruption_hash_stable(alert_service: AlertService) -> None:
         DisruptionResponse(
             line_id="victoria",
             line_name="Victoria",
+            mode="tube",
             status_severity=5,
             status_severity_description="Severe Delays",
             reason="Signal failure",
@@ -1298,6 +1313,7 @@ def test_create_disruption_hash_different_for_different_content(alert_service: A
         DisruptionResponse(
             line_id="victoria",
             line_name="Victoria",
+            mode="tube",
             status_severity=5,
             status_severity_description="Severe Delays",
             reason="Signal failure",
@@ -1309,6 +1325,7 @@ def test_create_disruption_hash_different_for_different_content(alert_service: A
         DisruptionResponse(
             line_id="victoria",
             line_name="Victoria",
+            mode="tube",
             status_severity=6,
             status_severity_description="Minor Delays",  # Different
             reason="Signal failure",
@@ -1336,6 +1353,7 @@ def test_create_disruption_hash_order_independent(alert_service: AlertService) -
         DisruptionResponse(
             line_id="victoria",
             line_name="Victoria",
+            mode="tube",
             status_severity=5,
             status_severity_description="Severe Delays",
             reason="Signal failure",
@@ -1344,6 +1362,7 @@ def test_create_disruption_hash_order_independent(alert_service: AlertService) -
         DisruptionResponse(
             line_id="northern",
             line_name="Northern",
+            mode="tube",
             status_severity=6,
             status_severity_description="Minor Delays",
             reason="Train cancellations",
@@ -1355,6 +1374,7 @@ def test_create_disruption_hash_order_independent(alert_service: AlertService) -
         DisruptionResponse(
             line_id="northern",
             line_name="Northern",
+            mode="tube",
             status_severity=6,
             status_severity_description="Minor Delays",
             reason="Train cancellations",
@@ -1363,6 +1383,7 @@ def test_create_disruption_hash_order_independent(alert_service: AlertService) -
         DisruptionResponse(
             line_id="victoria",
             line_name="Victoria",
+            mode="tube",
             status_severity=5,
             status_severity_description="Severe Delays",
             reason="Signal failure",
@@ -1403,6 +1424,7 @@ async def test_alert_service_skips_duplicate_alerts(
         DisruptionResponse(
             line_id="victoria",
             line_name="Victoria",
+            mode="tube",
             status_severity=5,
             status_severity_description="Severe Delays",
             reason="Signal failure",
@@ -1652,6 +1674,7 @@ async def test_send_alerts_for_route_no_preferences(
         DisruptionResponse(
             line_id="victoria",
             line_name="Victoria",
+            mode="tube",
             status_severity=5,
             status_severity_description="Severe Delays",
             reason="Signal failure",
@@ -1873,6 +1896,7 @@ class TestExtractLineStationPairs:
         disruption = DisruptionResponse(
             line_id="piccadilly",
             line_name="Piccadilly",
+            mode="tube",
             status_severity=10,
             status_severity_description="Minor Delays",
             reason="Signal failure",
@@ -1899,6 +1923,7 @@ class TestExtractLineStationPairs:
         disruption = DisruptionResponse(
             line_id="northern",
             line_name="Northern",
+            mode="tube",
             status_severity=15,
             status_severity_description="Severe Delays",
             reason="Customer incident",
@@ -1930,6 +1955,7 @@ class TestExtractLineStationPairs:
         disruption = DisruptionResponse(
             line_id="victoria",
             line_name="Victoria",
+            mode="tube",
             status_severity=10,
             status_severity_description="Minor Delays",
             reason="Earlier signal failure",
@@ -1947,6 +1973,7 @@ class TestExtractLineStationPairs:
         disruption = DisruptionResponse(
             line_id="district",
             line_name="District",
+            mode="tube",
             status_severity=10,
             status_severity_description="Good Service",
             created_at=datetime.now(UTC),
@@ -1963,6 +1990,7 @@ class TestExtractLineStationPairs:
         disruption = DisruptionResponse(
             line_id="central",
             line_name="Central",
+            mode="tube",
             status_severity=10,
             status_severity_description="Minor Delays",
             created_at=datetime.now(UTC),
@@ -2158,6 +2186,7 @@ class TestGetAffectedRoutesForDisruption:
         disruption = DisruptionResponse(
             line_id="victoria",
             line_name="Victoria",
+            mode="tube",
             status_severity=10,
             status_severity_description="Minor Delays",
             reason="Signal failure",
@@ -2208,6 +2237,7 @@ class TestGetAffectedRoutesForDisruption:
         disruption = DisruptionResponse(
             line_id="victoria",
             line_name="Victoria",
+            mode="tube",
             status_severity=10,
             status_severity_description="Minor Delays",
             reason="Earlier signal failure",
@@ -2229,6 +2259,7 @@ class TestGetAffectedRoutesForDisruption:
         disruption = DisruptionResponse(
             line_id="imaginary-line",
             line_name="Imaginary Line",
+            mode="tube",
             status_severity=10,
             status_severity_description="Minor Delays",
             created_at=datetime.now(UTC),
@@ -2308,6 +2339,7 @@ class TestGetAffectedRoutesForDisruption:
         disruption = DisruptionResponse(
             line_id="victoria",
             line_name="Victoria",
+            mode="tube",
             status_severity=10,
             status_severity_description="Minor Delays",
             created_at=datetime.now(UTC),
@@ -2397,6 +2429,7 @@ class TestBranchDisambiguation:
         disruption = DisruptionResponse(
             line_id="piccadilly",
             line_name="Piccadilly",
+            mode="tube",
             status_severity=10,
             status_severity_description="Minor Delays",
             reason="Signal failure at Russell Square",
@@ -2488,6 +2521,7 @@ class TestBranchDisambiguation:
         disruption = DisruptionResponse(
             line_id="northern",
             line_name="Northern",
+            mode="tube",
             status_severity=15,
             status_severity_description="Severe Delays",
             reason="Customer incident",
@@ -2564,6 +2598,7 @@ class TestPerformance:
             disruption = DisruptionResponse(
                 line_id="piccadilly",
                 line_name="Piccadilly",
+                mode="tube",
                 status_severity=10,
                 status_severity_description="Minor Delays",
                 reason=f"Disruption {i}",
@@ -2686,6 +2721,7 @@ class TestLineDisruptionStateLogging:
         disruption = DisruptionResponse(
             line_id="bakerloo",
             line_name="Bakerloo",
+            mode="tube",
             status_severity=10,
             status_severity_description="Minor Delays",
             reason="Signal failure at Baker Street",
@@ -2719,6 +2755,7 @@ class TestLineDisruptionStateLogging:
         disruption = DisruptionResponse(
             line_id="central",
             line_name="Central",
+            mode="tube",
             status_severity=10,
             status_severity_description="Minor Delays",
             reason="Train cancellation",
@@ -2751,6 +2788,7 @@ class TestLineDisruptionStateLogging:
         disruption1 = DisruptionResponse(
             line_id="piccadilly",
             line_name="Piccadilly",
+            mode="tube",
             status_severity=10,
             status_severity_description="Minor Delays",
             reason="Passenger incident",
@@ -2764,6 +2802,7 @@ class TestLineDisruptionStateLogging:
         disruption2 = DisruptionResponse(
             line_id="piccadilly",
             line_name="Piccadilly",
+            mode="tube",
             status_severity=20,
             status_severity_description="Severe Delays",
             reason="Passenger incident",
@@ -2796,6 +2835,7 @@ class TestLineDisruptionStateLogging:
         disruption1 = DisruptionResponse(
             line_id="district",
             line_name="District",
+            mode="tube",
             status_severity=10,
             status_severity_description="Minor Delays",
             reason="Signal failure at Earl's Court",
@@ -2809,6 +2849,7 @@ class TestLineDisruptionStateLogging:
         disruption2 = DisruptionResponse(
             line_id="district",
             line_name="District",
+            mode="tube",
             status_severity=10,
             status_severity_description="Minor Delays",
             reason="Signal failure at Tower Hill",
@@ -2842,6 +2883,7 @@ class TestLineDisruptionStateLogging:
             DisruptionResponse(
                 line_id="northern",
                 line_name="Northern",
+                mode="tube",
                 status_severity=10,
                 status_severity_description="Minor Delays",
                 reason="Train cancellation",
@@ -2849,6 +2891,7 @@ class TestLineDisruptionStateLogging:
             DisruptionResponse(
                 line_id="jubilee",
                 line_name="Jubilee",
+                mode="tube",
                 status_severity=20,
                 status_severity_description="Severe Delays",
                 reason="Signal failure",
@@ -2856,6 +2899,7 @@ class TestLineDisruptionStateLogging:
             DisruptionResponse(
                 line_id="metropolitan",
                 line_name="Metropolitan",
+                mode="tube",
                 status_severity=6,
                 status_severity_description="Good Service",
                 reason=None,
@@ -2890,6 +2934,7 @@ class TestLineDisruptionStateLogging:
             DisruptionResponse(
                 line_id="bakerloo",
                 line_name="Bakerloo",
+                mode="tube",
                 status_severity=10,
                 status_severity_description="Minor Delays",
                 reason="Signal failure",
@@ -2897,6 +2942,7 @@ class TestLineDisruptionStateLogging:
             DisruptionResponse(
                 line_id="bakerloo",
                 line_name="Bakerloo",
+                mode="tube",
                 status_severity=20,
                 status_severity_description="Severe Delays",
                 reason="Signal failure worsening",
@@ -2940,6 +2986,7 @@ class TestLineDisruptionStateLogging:
         disruption1 = DisruptionResponse(
             line_id="district",
             line_name="District",
+            mode="tube",
             status_severity=6,
             status_severity_description="Good Service",
             reason=None,
@@ -2951,6 +2998,7 @@ class TestLineDisruptionStateLogging:
         disruption2 = DisruptionResponse(
             line_id="district",
             line_name="District",
+            mode="tube",
             status_severity=6,
             status_severity_description="Good Service",
             reason="",
@@ -2962,6 +3010,7 @@ class TestLineDisruptionStateLogging:
         disruption3 = DisruptionResponse(
             line_id="district",
             line_name="District",
+            mode="tube",
             status_severity=6,
             status_severity_description="Good Service",
             reason="   ",
@@ -2990,6 +3039,7 @@ class TestLineDisruptionStateLogging:
         disruption = DisruptionResponse(
             line_id="central",
             line_name="Central",
+            mode="tube",
             status_severity=20,
             status_severity_description="Severe Delays",
             reason=long_reason,
@@ -3021,6 +3071,7 @@ class TestLineDisruptionStateLogging:
         disruption = DisruptionResponse(
             line_id="circle",
             line_name="Circle",
+            mode="tube",
             status_severity=6,
             status_severity_description="Good Service",
             reason=None,
@@ -3050,6 +3101,7 @@ class TestLineDisruptionStateLogging:
         disruption = DisruptionResponse(
             line_id="hammersmith-city",
             line_name="Hammersmith & City",
+            mode="tube",
             status_severity=10,
             status_severity_description="Minor Delays",
             reason="Test error",

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -361,9 +361,11 @@ def test_check_disruptions_task_logs_on_success(mock_run_async_task: MagicMock) 
         result = check_disruptions_and_alert()
 
         assert result == mock_result
-        mock_logger.info.assert_called_once()
-        call_args = mock_logger.info.call_args
-        assert call_args[0][0] == "check_disruptions_task_completed"
+        assert mock_logger.info.call_count == 2
+        # First call: task started
+        assert mock_logger.info.call_args_list[0][0][0] == "check_disruptions_task_started"
+        # Second call: task completed
+        assert mock_logger.info.call_args_list[1][0][0] == "check_disruptions_task_completed"
 
 
 @patch("app.celery.tasks.run_in_worker_loop")
@@ -650,9 +652,11 @@ def test_rebuild_indexes_task_logs_on_success(mock_run_async_task: MagicMock) ->
         result = rebuild_route_indexes_task(route_id=None)
 
         assert result == mock_result
-        mock_logger.info.assert_called_once()
-        call_args = mock_logger.info.call_args
-        assert call_args[0][0] == "rebuild_indexes_task_completed"
+        assert mock_logger.info.call_count == 2
+        # First call: task started
+        assert mock_logger.info.call_args_list[0][0][0] == "rebuild_indexes_task_started"
+        # Second call: task completed
+        assert mock_logger.info.call_args_list[1][0][0] == "rebuild_indexes_task_completed"
 
 
 @patch("app.celery.tasks.run_in_worker_loop")
@@ -1050,9 +1054,11 @@ def test_detect_stale_routes_task_logs_on_success(mock_run_async_task: MagicMock
         result = detect_and_rebuild_stale_routes()
 
         assert result == mock_result
-        mock_logger.info.assert_called_once()
-        call_args = mock_logger.info.call_args
-        assert call_args[0][0] == "detect_stale_routes_task_completed"
+        assert mock_logger.info.call_count == 2
+        # First call: task started
+        assert mock_logger.info.call_args_list[0][0][0] == "detect_stale_routes_task_started"
+        # Second call: task completed
+        assert mock_logger.info.call_args_list[1][0][0] == "detect_stale_routes_task_completed"
 
 
 @patch("app.celery.tasks.run_in_worker_loop")

--- a/backend/tests/test_notification_service.py
+++ b/backend/tests/test_notification_service.py
@@ -25,6 +25,7 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id="victoria",
                 line_name="Victoria",
+                mode="tube",
                 status_severity=6,
                 status_severity_description="Minor Delays",
                 reason="Signal failure at Oxford Circus",
@@ -50,6 +51,7 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id="victoria",
                 line_name="Victoria",
+                mode="tube",
                 status_severity=6,
                 status_severity_description="Minor Delays",
                 reason=None,
@@ -75,6 +77,7 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id="victoria",
                 line_name="Victoria",
+                mode="tube",
                 status_severity=6,
                 status_severity_description="Minor Delays",
                 reason="Signal failure",
@@ -82,6 +85,7 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id="northern",
                 line_name="Northern",
+                mode="tube",
                 status_severity=3,
                 status_severity_description="Severe Delays",
                 reason="Train breakdown",
@@ -106,6 +110,7 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id="victoria",
                 line_name="Victoria",
+                mode="tube",
                 status_severity=6,
                 status_severity_description="Minor Delays",
             )
@@ -125,6 +130,7 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id="victoria",
                 line_name="Victoria",
+                mode="tube",
                 status_severity=6,
                 status_severity_description="Minor Delays",
                 reason="Signal failure",
@@ -150,18 +156,21 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id="victoria",
                 line_name="Victoria",
+                mode="tube",
                 status_severity=6,
                 status_severity_description="Minor Delays",
             ),
             DisruptionResponse(
                 line_id="northern",
                 line_name="Northern",
+                mode="tube",
                 status_severity=3,
                 status_severity_description="Severe Delays",
             ),
             DisruptionResponse(
                 line_id="central",
                 line_name="Central",
+                mode="tube",
                 status_severity=6,
                 status_severity_description="Minor Delays",
             ),
@@ -180,6 +189,7 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id="victoria",
                 line_name="Victoria",
+                mode="tube",
                 status_severity=6,
                 status_severity_description="Minor Delays",
                 reason="Signal failure",
@@ -209,6 +219,7 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id="victoria",
                 line_name="Victoria",
+                mode="tube",
                 status_severity=6,
                 status_severity_description="Minor Delays",
                 reason="Signal failure at Oxford Circus",
@@ -236,6 +247,7 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id="victoria",
                 line_name="Victoria",
+                mode="tube",
                 status_severity=6,
                 status_severity_description="Minor Delays",
             )
@@ -264,6 +276,7 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id=f"line-{i}",
                 line_name=f"Line {i}",
+                mode="tube",
                 status_severity=5,
                 status_severity_description="Severe Delays",
                 reason=f"Signal failure at station {i}",
@@ -287,6 +300,7 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id="victoria",
                 line_name="Victoria",
+                mode="tube",
                 status_severity=5,
                 status_severity_description="Severe Delays",
                 reason="Signal failure",
@@ -312,6 +326,7 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id="victoria",
                 line_name="Victoria",
+                mode="tube",
                 status_severity=5,
                 status_severity_description="Severe Delays",
                 reason="Signal failure",
@@ -339,6 +354,7 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id="line-1",
                 line_name="Line 1",
+                mode="tube",
                 status_severity=5,
                 status_severity_description="Severe Delays" * 20,  # Make it very long
                 reason="Signal failure " * 50,  # Very long reason
@@ -385,6 +401,7 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id="metropolitan",
                 line_name="Metropolitan Line Experiencing",
+                mode="tube",
                 status_severity="9",
                 status_severity_description="Severe Delays and Signal Failures Throughout",
                 reason="Signal failure",
@@ -392,6 +409,7 @@ class TestNotificationService:
             DisruptionResponse(
                 line_id="hammersmith-city",
                 line_name="Hammersmith & City Line Now",
+                mode="tube",
                 status_severity="10",
                 status_severity_description="Part Suspended Between Multiple Stations",
                 reason="Engineering works",

--- a/backend/tests/test_tfl_api.py
+++ b/backend/tests/test_tfl_api.py
@@ -258,6 +258,7 @@ async def test_get_disruptions(
         {
             "line_id": "victoria",
             "line_name": "Victoria",
+            "mode": "tube",
             "status_severity": 5,
             "status_severity_description": "Severe Delays",
             "reason": "Signal failure at Victoria",

--- a/backend/tests/test_tfl_service.py
+++ b/backend/tests/test_tfl_service.py
@@ -164,10 +164,12 @@ def create_mock_disruption(
 def create_mock_severity_code(
     severity_level: int = 10,
     description: str = "Good Service",
+    mode_name: str = "tube",
     **kwargs: Any,  # noqa: ANN401
 ) -> TflStatusSeverity:
     """Factory for TfL StatusSeverity mocks using actual pydantic model."""
     return TflStatusSeverity(
+        modeName=mode_name,
         severityLevel=severity_level,
         description=description,
         **kwargs,
@@ -2130,6 +2132,7 @@ async def test_fetch_disruptions_cache_hit(tfl_service: TfLService) -> None:
         DisruptionResponse(
             line_id="northern",
             line_name="Northern",
+            mode="tube",
             status_severity=5,
             status_severity_description="Severe Delays",
             reason="Signal failure",
@@ -2784,8 +2787,10 @@ async def test_fetch_severity_codes(
         )
 
         # Verify specific attributes
+        assert codes[0].mode_id == "tube"
         assert codes[0].severity_level == 0
         assert codes[0].description == "Special Service"
+        assert codes[3].mode_id == "tube"
         assert codes[3].severity_level == 10
         assert codes[3].description == "Good Service"
 
@@ -2795,6 +2800,7 @@ async def test_fetch_severity_codes_cache_hit(tfl_service: TfLService) -> None:
     # Setup cached severity codes
     cached_codes = [
         SeverityCode(
+            mode_id="tube",
             severity_level=10,
             description="Good Service",
             last_updated=datetime.now(UTC),

--- a/backend/tests/test_tfl_service.py
+++ b/backend/tests/test_tfl_service.py
@@ -2816,6 +2816,45 @@ async def test_fetch_severity_codes_cache_hit(tfl_service: TfLService) -> None:
     )
 
 
+async def test_fetch_severity_codes_cache_hit_multiple_modes(tfl_service: TfLService) -> None:
+    """Test fetching severity codes from cache with multiple modes."""
+    # Setup cached severity codes with varying mode_id values
+    cached_codes = [
+        SeverityCode(
+            mode_id="tube",
+            severity_level=10,
+            description="Good Service",
+            last_updated=datetime.now(UTC),
+        ),
+        SeverityCode(
+            mode_id="tube",
+            severity_level=5,
+            description="Severe Delays",
+            last_updated=datetime.now(UTC),
+        ),
+        SeverityCode(
+            mode_id="bus",
+            severity_level=10,
+            description="Good Service",
+            last_updated=datetime.now(UTC),
+        ),
+        SeverityCode(
+            mode_id="dlr",
+            severity_level=10,
+            description="Good Service",
+            last_updated=datetime.now(UTC),
+        ),
+    ]
+
+    # Execute with helper
+    await assert_cache_hit(
+        tfl_service=tfl_service,
+        method_callable=lambda: tfl_service.fetch_severity_codes(use_cache=True),
+        cache_key="severity_codes:all",
+        cached_data=cached_codes,
+    )
+
+
 async def test_fetch_severity_codes_cache_miss(
     tfl_service: TfLService,
 ) -> None:


### PR DESCRIPTION
Resolves #203

Prevents alerts being sent for "Good Service" (severity 10) by adding
mode-specific severity filtering.

Changes:
- Database: New migration adding mode column to severity_codes table and new
alert_disabled_severities table
- Models: Added AlertDisabledSeverity model and updated SeverityCode with mode support
- TfL Service: Extract modeName from TfL API responses, add mode field to DisruptionResponse
- Alert Service: Filter disruptions by disabled severity pairs (mode + severity) before sending
alerts
- API: New endpoints GET /tfl/line-states and GET /tfl/alert-config for debugging
- Logging: Added start timestamps to Celery tasks for better debugging

## Summary by Sourcery

Add mode-aware severity filtering to prevent alerts for specified severity levels per transport mode, introduce configuration endpoints, and update related data models and database schema.

New Features:
- Implement per-mode severity filtering to suppress alerts (e.g., "Good Service").
- Expose GET /tfl/line-states and GET /tfl/alert-config endpoints for debugging alert behavior.

Enhancements:
- Extend SeverityCode and DisruptionResponse with a mode field and populate it from TfL API.
- Introduce AlertDisabledSeverity model and table to store non‐alertable (mode, severity) pairs.
- Enhance Celery tasks to log start timestamps for better observability.

Build:
- Add Alembic migration to add mode_id to severity_codes, create alert_disabled_severities table, and seed default disabled severities.

Tests:
- Update existing tests to include mode in DisruptionResponse and validate severity filtering logic.