### PR TITLE
feat: Enhance OpenTelemetry instrumentation for Celery and Redis, including service name differentiation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,8 @@
       "console": "integratedTerminal",
       "justMyCode": true,
       "env": {
-        "PYTHONPATH": "${workspaceFolder}/backend"
+        "PYTHONPATH": "${workspaceFolder}/backend",
+        "OTEL_SERVICE_NAME": "isthetuberunning-api"
       },
       "consoleName": "Backend"
     },
@@ -75,7 +76,8 @@
       "console": "integratedTerminal",
       "justMyCode": false,
       "env": {
-        "PYTHONPATH": "${workspaceFolder}/backend"
+        "PYTHONPATH": "${workspaceFolder}/backend",
+        "OTEL_SERVICE_NAME": "isthetuberunning-worker"
       },
       "consoleName": "Celery Worker"
     },
@@ -94,7 +96,8 @@
       "console": "integratedTerminal",
       "justMyCode": false,
       "env": {
-        "PYTHONPATH": "${workspaceFolder}/backend"
+        "PYTHONPATH": "${workspaceFolder}/backend",
+        "OTEL_SERVICE_NAME": "isthetuberunning-beat"
       },
       "consoleName": "Celery Beat"
     }

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -74,6 +74,10 @@ VITE_API_URL=http://localhost:8000
 OTEL_ENABLED=true
 
 # Service identification
+# Default service name - can be overridden per component for service graph differentiation:
+#   - FastAPI/Backend: isthetuberunning-api
+#   - Celery Worker: isthetuberunning-worker
+#   - Celery Beat: isthetuberunning-beat
 OTEL_SERVICE_NAME="isthetuberunning-backend"
 OTEL_ENVIRONMENT="production"
 

--- a/backend/app/celery/app.py
+++ b/backend/app/celery/app.py
@@ -1,6 +1,8 @@
 """Celery application instance and configuration."""
 
 import structlog
+from celery.signals import beat_init
+from opentelemetry import trace
 
 from app.core.config import require_config, settings
 from app.core.logging import configure_logging
@@ -50,6 +52,29 @@ if settings.OTEL_ENABLED:
 
     CeleryInstrumentor().instrument()
     logger.info("celery_otel_instrumentation_enabled")
+
+
+@beat_init.connect
+def init_beat_otel(
+    **kwargs: object,
+) -> None:
+    """
+    Initialize OpenTelemetry for Celery Beat scheduler process.
+
+    This is called when the Beat scheduler process starts. It initializes
+    the TracerProvider for the Beat process, enabling distributed tracing
+    for scheduled task triggers.
+
+    Note: CeleryInstrumentor is already applied at module level above,
+    this just ensures the Beat process has its own TracerProvider.
+    """
+    if settings.OTEL_ENABLED:
+        from app.core.telemetry import get_tracer_provider  # noqa: PLC0415  # Lazy import for fork-safety
+
+        if provider := get_tracer_provider():
+            trace.set_tracer_provider(provider)
+            logger.info("beat_otel_tracer_provider_initialized")
+
 
 # Import tasks to register them with Celery
 # This must come after celery_app is created so tasks can use the @celery_app.task decorator

--- a/backend/app/celery/app.py
+++ b/backend/app/celery/app.py
@@ -69,11 +69,15 @@ def init_beat_otel(
     this just ensures the Beat process has its own TracerProvider.
     """
     if settings.OTEL_ENABLED:
-        from app.core.telemetry import get_tracer_provider  # noqa: PLC0415  # Lazy import for fork-safety
+        try:
+            from app.core.telemetry import get_tracer_provider  # noqa: PLC0415  # Lazy import for fork-safety
 
-        if provider := get_tracer_provider():
-            trace.set_tracer_provider(provider)
-            logger.info("beat_otel_tracer_provider_initialized")
+            if provider := get_tracer_provider():
+                trace.set_tracer_provider(provider)
+                logger.info("beat_otel_tracer_provider_initialized")
+        except Exception:
+            logger.exception("beat_otel_initialization_failed")
+            # Continue without OTEL - graceful degradation
 
 
 # Import tasks to register them with Celery

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,7 +28,7 @@ configure_logging(log_level=settings.LOG_LEVEL)
 
 logger = structlog.get_logger(__name__)
 
-# Initialize OpenTelemetry instrumentors at module level (before app creation)
+# Initialize OpenTelemetry instrumentors at module level (before FastAPI app instantiation)
 # These just patch classes - safe before fork. TracerProvider is set in lifespan (after fork).
 if settings.OTEL_ENABLED:
     FastAPIInstrumentor().instrument(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -28,6 +28,14 @@ configure_logging(log_level=settings.LOG_LEVEL)
 
 logger = structlog.get_logger(__name__)
 
+# Initialize OpenTelemetry instrumentors at module level (before app creation)
+# These just patch classes - safe before fork. TracerProvider is set in lifespan (after fork).
+if settings.OTEL_ENABLED:
+    FastAPIInstrumentor().instrument(
+        excluded_urls=",".join(settings.OTEL_EXCLUDED_URLS),
+    )
+    logger.info("otel_fastapi_instrumented")
+
 
 def _check_alembic_migrations(sync_conn: Connection) -> str | None:
     """
@@ -75,26 +83,25 @@ def _check_alembic_migrations(sync_conn: Connection) -> str | None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
-    """Application lifespan - validate database migrations and initialize OTEL on startup."""
-    # Skip all validation in DEBUG mode (tests use mock databases/contexts)
+    """Application lifespan - initialize OTEL TracerProvider and validate database on startup."""
+    # Initialize TracerProvider in lifespan (after fork) so each worker gets its own
+    # BatchSpanProcessor with proper threading. Instrumentors were already called at module level.
+    if settings.OTEL_ENABLED and (provider := get_tracer_provider()):
+        trace.set_tracer_provider(provider)
+        logger.info("otel_tracer_provider_initialized")
+
+    # Skip database validation in DEBUG mode (tests use mock databases/contexts)
     if settings.DEBUG:
-        logger.info("debug_mode_startup", message="skipping startup validation")
+        logger.info("debug_mode_startup", message="skipping database validation")
         yield
+        # Shutdown OTEL if enabled
+        if settings.OTEL_ENABLED:
+            shutdown_tracer_provider()
         logger.info("shutdown_complete")
         return
 
-    # Production mode: Initialize OTEL and validate database
-    logger.info("startup_initializing", message="initializing observability and validating database")
-
-    # Initialize OpenTelemetry if enabled
-    if settings.OTEL_ENABLED and (provider := get_tracer_provider()):
-        trace.set_tracer_provider(provider)
-        # Instrument FastAPI with excluded URLs
-        FastAPIInstrumentor.instrument_app(
-            app,
-            excluded_urls=",".join(settings.OTEL_EXCLUDED_URLS),
-        )
-        logger.info("otel_initialized")
+    # Production mode: Validate database
+    logger.info("startup_initializing", message="validating database")
 
     try:
         async with get_engine().begin() as conn:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi>=0.50b0",
     "opentelemetry-instrumentation-sqlalchemy>=0.50b0",
     "opentelemetry-instrumentation-celery>=0.50b0",
+    "opentelemetry-instrumentation-redis>=0.50b0",
 ]
 
 [dependency-groups]

--- a/backend/tests/services/test_tfl_otel.py
+++ b/backend/tests/services/test_tfl_otel.py
@@ -137,7 +137,7 @@ class TestTflApiSpans:
 
         # Patch the tracer and mock the API call
         with (
-            patch.object(tfl_service, "tracer", test_tracer),
+            patch("opentelemetry.trace.get_tracer", return_value=test_tracer),
             patch.object(
                 tfl_service_with_mock.line_client,
                 "MetaModes",
@@ -179,7 +179,7 @@ class TestTflApiSpans:
 
         # Patch the tracer and mock the API call (will be called twice, once per mode)
         with (
-            patch.object(tfl_service, "tracer", test_tracer),
+            patch("opentelemetry.trace.get_tracer", return_value=test_tracer),
             patch.object(
                 tfl_service_with_mock.line_client,
                 "GetByModeByPathModes",
@@ -222,7 +222,7 @@ class TestTflApiSpans:
 
         # Patch the tracer and mock the API call
         with (
-            patch.object(tfl_service, "tracer", test_tracer),
+            patch("opentelemetry.trace.get_tracer", return_value=test_tracer),
             patch.object(
                 tfl_service_with_mock.stoppoint_client,
                 "GetByPathIdsQueryIncludeCrowdingData",
@@ -256,7 +256,7 @@ class TestTflApiSpans:
         stop_point = create_mock_stop_point()
         # hubNaptanCode is None by default
 
-        with patch.object(tfl_service, "tracer", test_tracer):
+        with patch("opentelemetry.trace.get_tracer", return_value=test_tracer):
             hub_code, hub_name = await tfl_service_with_mock._extract_hub_fields(stop_point)
 
         # Verify no span was created
@@ -285,7 +285,7 @@ class TestTflApiSpans:
         mock_response.content = mock_route_sequence
 
         with (
-            patch.object(tfl_service, "tracer", test_tracer),
+            patch("opentelemetry.trace.get_tracer", return_value=test_tracer),
             patch.object(
                 tfl_service_with_mock.line_client,
                 "RouteSequenceByPathIdPathDirectionQueryServiceTypesQueryExcludeCrowding",
@@ -320,7 +320,7 @@ class TestTflApiSpans:
         cached_modes = ["tube", "dlr"]
         tfl_service_with_mock.cache.get = AsyncMock(return_value=cached_modes)
 
-        with patch.object(tfl_service, "tracer", test_tracer):
+        with patch("opentelemetry.trace.get_tracer", return_value=test_tracer):
             result = await tfl_service_with_mock.fetch_available_modes()
 
         # Verify no spans were created
@@ -361,7 +361,7 @@ class TestTflApiSpans:
         tfl_service_with_mock.db.refresh = AsyncMock()
 
         with (
-            patch.object(tfl_service, "tracer", test_tracer),
+            patch("opentelemetry.trace.get_tracer", return_value=test_tracer),
             patch.object(
                 tfl_service_with_mock.line_client,
                 "MetaSeverity",
@@ -410,7 +410,7 @@ class TestTflApiSpans:
         tfl_service_with_mock.db.refresh = AsyncMock()
 
         with (
-            patch.object(tfl_service, "tracer", test_tracer),
+            patch("opentelemetry.trace.get_tracer", return_value=test_tracer),
             patch.object(
                 tfl_service_with_mock.line_client,
                 "MetaDisruptionCategories",
@@ -459,7 +459,7 @@ class TestTflApiSpans:
         tfl_service_with_mock.db.refresh = AsyncMock()
 
         with (
-            patch.object(tfl_service, "tracer", test_tracer),
+            patch("opentelemetry.trace.get_tracer", return_value=test_tracer),
             patch.object(
                 tfl_service_with_mock.stoppoint_client,
                 "MetaStopTypes",
@@ -512,7 +512,7 @@ class TestTflApiSpans:
         tfl_service_with_mock.cache.get = AsyncMock(side_effect=lambda key: [mock_line] if key == cache_key else None)
 
         with (
-            patch.object(tfl_service, "tracer", test_tracer),
+            patch("opentelemetry.trace.get_tracer", return_value=test_tracer),
             patch.object(
                 tfl_service_with_mock.line_client,
                 "StatusByIdsByPathIdsQueryDetail",
@@ -553,7 +553,7 @@ class TestTflApiSpans:
         )
 
         with (
-            patch.object(tfl_service, "tracer", test_tracer),
+            patch("opentelemetry.trace.get_tracer", return_value=test_tracer),
             patch.object(
                 tfl_service_with_mock.stoppoint_client,
                 "DisruptionByModeByPathModesQueryIncludeRouteBlockedStops",
@@ -600,7 +600,7 @@ class TestTflApiSpanErrorHandling:
         api_error = Exception("TfL API connection error")
 
         with (
-            patch.object(tfl_service, "tracer", test_tracer),
+            patch("opentelemetry.trace.get_tracer", return_value=test_tracer),
             patch.object(
                 tfl_service_with_mock.line_client,
                 "MetaModes",
@@ -643,7 +643,7 @@ class TestTflApiSpanErrorHandling:
         api_error = Exception("Network timeout")
 
         with (
-            patch.object(tfl_service, "tracer", test_tracer),
+            patch("opentelemetry.trace.get_tracer", return_value=test_tracer),
             patch.object(
                 tfl_service_with_mock.line_client,
                 "GetByModeByPathModes",
@@ -681,7 +681,7 @@ class TestTflApiSpanErrorHandling:
         api_error = Exception("Hub API error")
 
         with (
-            patch.object(tfl_service, "tracer", test_tracer),
+            patch("opentelemetry.trace.get_tracer", return_value=test_tracer),
             patch.object(
                 tfl_service_with_mock.stoppoint_client,
                 "GetByPathIdsQueryIncludeCrowdingData",

--- a/backend/tests/test_beat_otel.py
+++ b/backend/tests/test_beat_otel.py
@@ -1,0 +1,165 @@
+"""Tests for Celery Beat OpenTelemetry initialization.
+
+Tests cover:
+- Beat process initialization with OTEL TracerProvider
+- Graceful skip when OTEL is disabled
+- Handling of None TracerProvider
+"""
+
+from unittest.mock import MagicMock, patch
+
+import app.celery.app as celery_app_module
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+
+
+class TestBeatOtelInitialization:
+    """Tests for OTEL initialization in beat_init signal."""
+
+    def test_beat_init_creates_tracer_provider_when_otel_enabled(self) -> None:
+        """Test that beat_init initializes TracerProvider when OTEL is enabled."""
+        # Create a test TracerProvider
+        test_provider = TracerProvider(resource=Resource(attributes={"service.name": "test-beat"}))
+
+        with (
+            patch.object(celery_app_module.settings, "OTEL_ENABLED", True),
+            patch(
+                "app.core.telemetry.get_tracer_provider",
+                return_value=test_provider,
+            ) as mock_get_provider,
+            patch("opentelemetry.trace.set_tracer_provider") as mock_set_provider,
+        ):
+            # Call the signal handler
+            celery_app_module.init_beat_otel()
+
+            # Verify get_tracer_provider was called
+            mock_get_provider.assert_called_once()
+
+            # Verify set_tracer_provider was called with the provider
+            mock_set_provider.assert_called_once_with(test_provider)
+
+    def test_beat_init_skips_otel_when_disabled(self) -> None:
+        """Test that beat_init skips OTEL initialization when disabled."""
+        with (
+            patch.object(celery_app_module.settings, "OTEL_ENABLED", False),
+            patch("app.core.telemetry.get_tracer_provider") as mock_get_provider,
+            patch("opentelemetry.trace.set_tracer_provider") as mock_set_provider,
+        ):
+            # Call the signal handler
+            celery_app_module.init_beat_otel()
+
+            # Verify get_tracer_provider was NOT called
+            mock_get_provider.assert_not_called()
+
+            # Verify set_tracer_provider was NOT called
+            mock_set_provider.assert_not_called()
+
+    def test_beat_init_handles_none_tracer_provider(self) -> None:
+        """Test that beat_init handles None TracerProvider gracefully."""
+        with (
+            patch.object(celery_app_module.settings, "OTEL_ENABLED", True),
+            patch(
+                "app.core.telemetry.get_tracer_provider",
+                return_value=None,
+            ) as mock_get_provider,
+            patch("opentelemetry.trace.set_tracer_provider") as mock_set_provider,
+        ):
+            # Call the signal handler - should not raise
+            celery_app_module.init_beat_otel()
+
+            # Verify get_tracer_provider was called
+            mock_get_provider.assert_called_once()
+
+            # Verify set_tracer_provider was NOT called (walrus operator returns None)
+            mock_set_provider.assert_not_called()
+
+    def test_beat_init_logs_initialization(self) -> None:
+        """Test that beat_init logs when TracerProvider is initialized."""
+        # Create a test TracerProvider
+        test_provider = TracerProvider(resource=Resource(attributes={"service.name": "test-beat"}))
+
+        with (
+            patch.object(celery_app_module.settings, "OTEL_ENABLED", True),
+            patch(
+                "app.core.telemetry.get_tracer_provider",
+                return_value=test_provider,
+            ),
+            patch("opentelemetry.trace.set_tracer_provider"),
+            patch.object(celery_app_module.logger, "info") as mock_logger_info,
+        ):
+            # Call the signal handler
+            celery_app_module.init_beat_otel()
+
+            # Verify logging was called
+            mock_logger_info.assert_called_once_with("beat_otel_tracer_provider_initialized")
+
+
+class TestBeatOtelForkSafety:
+    """Tests for fork-safety of Beat OTEL initialization."""
+
+    def test_beat_init_can_be_called_multiple_times(self) -> None:
+        """Test that beat_init is safe to call multiple times."""
+        # Create a test TracerProvider
+        test_provider = TracerProvider(resource=Resource(attributes={"service.name": "test-beat"}))
+
+        with (
+            patch.object(celery_app_module.settings, "OTEL_ENABLED", True),
+            patch(
+                "app.core.telemetry.get_tracer_provider",
+                return_value=test_provider,
+            ) as mock_get_provider,
+            patch("opentelemetry.trace.set_tracer_provider") as mock_set_provider,
+        ):
+            # Call the signal handler multiple times
+            celery_app_module.init_beat_otel()
+            celery_app_module.init_beat_otel()
+
+            # Verify get_tracer_provider was called twice
+            assert mock_get_provider.call_count == 2
+
+            # Verify set_tracer_provider was called twice
+            assert mock_set_provider.call_count == 2
+
+    def test_beat_gets_own_tracer_provider_instance(self) -> None:
+        """Test that Beat process gets its own TracerProvider via get_tracer_provider."""
+        # This verifies the pattern used - Beat calls get_tracer_provider() which
+        # creates a new provider in the Beat process (fork-safe)
+
+        mock_provider = MagicMock(spec=TracerProvider)
+
+        with (
+            patch.object(celery_app_module.settings, "OTEL_ENABLED", True),
+            patch(
+                "app.core.telemetry.get_tracer_provider",
+                return_value=mock_provider,
+            ) as mock_get_provider,
+            patch("opentelemetry.trace.set_tracer_provider") as mock_set_provider,
+        ):
+            # Call the signal handler
+            celery_app_module.init_beat_otel()
+
+            # Verify the lazy initialization pattern is used
+            mock_get_provider.assert_called_once()
+            mock_set_provider.assert_called_once_with(mock_provider)
+
+
+class TestBeatOtelSignalConnection:
+    """Tests for beat_init signal connection."""
+
+    def test_beat_init_signal_handler_exists(self) -> None:
+        """Test that the beat_init signal handler is defined."""
+        # Verify the function exists and has correct signature
+        assert hasattr(celery_app_module, "init_beat_otel")
+        assert callable(celery_app_module.init_beat_otel)
+
+    def test_beat_init_accepts_kwargs(self) -> None:
+        """Test that beat_init accepts arbitrary kwargs (Celery signal pattern)."""
+        with (
+            patch.object(celery_app_module.settings, "OTEL_ENABLED", False),
+        ):
+            # Call with extra kwargs - should not raise
+            celery_app_module.init_beat_otel(
+                sender=None,
+                signal=None,
+                extra_param="test",
+            )

--- a/backend/tests/test_redis_otel.py
+++ b/backend/tests/test_redis_otel.py
@@ -1,0 +1,203 @@
+"""Tests for Redis OpenTelemetry instrumentation.
+
+Tests cover:
+- Redis instrumentation when OTEL is enabled
+- Graceful skip when OTEL is disabled
+- Instrumentation called only once (idempotent)
+"""
+
+from unittest.mock import MagicMock, patch
+
+from app.core import telemetry as telemetry_module
+
+
+class TestRedisInstrumentation:
+    """Tests for RedisInstrumentor in telemetry module."""
+
+    def test_redis_instrumentor_called_when_otel_enabled(self) -> None:
+        """Test that RedisInstrumentor is called when OTEL is enabled."""
+        # Reset module state
+        telemetry_module._tracer_provider = None
+        telemetry_module._redis_instrumented = False
+
+        with (
+            patch.object(telemetry_module.settings, "OTEL_ENABLED", True),
+            patch.object(telemetry_module.settings, "DEBUG", True),  # Skip endpoint requirement
+            patch.object(telemetry_module.settings, "OTEL_SERVICE_NAME", "test-service"),
+            patch.object(telemetry_module.settings, "OTEL_ENVIRONMENT", "test"),
+            patch.object(telemetry_module.settings, "OTEL_EXPORTER_OTLP_ENDPOINT", ""),
+            patch.object(telemetry_module, "RedisInstrumentor") as mock_redis_instrumentor_class,
+        ):
+            # Setup mock instrumentor
+            mock_instrumentor = MagicMock()
+            mock_redis_instrumentor_class.return_value = mock_instrumentor
+
+            # Call get_tracer_provider which triggers _create_tracer_provider
+            provider = telemetry_module.get_tracer_provider()
+
+            # Verify provider was created
+            assert provider is not None
+
+            # Verify RedisInstrumentor was called
+            mock_instrumentor.instrument.assert_called_once()
+
+            # Verify flag was set
+            assert telemetry_module._redis_instrumented
+
+            # Clean up
+            telemetry_module._tracer_provider = None
+            telemetry_module._redis_instrumented = False
+
+    def test_redis_instrumentor_not_called_when_otel_disabled(self) -> None:
+        """Test that RedisInstrumentor is not called when OTEL is disabled."""
+        # Reset module state
+        telemetry_module._tracer_provider = None
+        telemetry_module._redis_instrumented = False
+
+        with (
+            patch.object(telemetry_module.settings, "OTEL_ENABLED", False),
+            patch.object(telemetry_module, "RedisInstrumentor") as mock_redis_instrumentor_class,
+        ):
+            # Call get_tracer_provider
+            provider = telemetry_module.get_tracer_provider()
+
+            # Verify provider was not created
+            assert provider is None
+
+            # Verify RedisInstrumentor was NOT called
+            mock_redis_instrumentor_class.assert_not_called()
+
+            # Verify flag was not set
+            assert not telemetry_module._redis_instrumented
+
+    def test_redis_instrumentor_called_only_once(self) -> None:
+        """Test that RedisInstrumentor is only called once (idempotent)."""
+        # Reset module state and pre-set the flag
+        telemetry_module._tracer_provider = None
+        telemetry_module._redis_instrumented = True
+
+        with (
+            patch.object(telemetry_module.settings, "OTEL_ENABLED", True),
+            patch.object(telemetry_module.settings, "DEBUG", True),
+            patch.object(telemetry_module.settings, "OTEL_SERVICE_NAME", "test-service"),
+            patch.object(telemetry_module.settings, "OTEL_ENVIRONMENT", "test"),
+            patch.object(telemetry_module.settings, "OTEL_EXPORTER_OTLP_ENDPOINT", ""),
+            patch.object(telemetry_module, "RedisInstrumentor") as mock_redis_instrumentor_class,
+        ):
+            # Call get_tracer_provider
+            telemetry_module.get_tracer_provider()
+
+            # Verify RedisInstrumentor was NOT called (already instrumented)
+            mock_redis_instrumentor_class.assert_not_called()
+
+            # Clean up
+            telemetry_module._tracer_provider = None
+            telemetry_module._redis_instrumented = False
+
+    def test_redis_instrumentation_happens_during_provider_creation(self) -> None:
+        """Test that Redis instrumentation happens in _create_tracer_provider."""
+        # Reset module state
+        telemetry_module._tracer_provider = None
+        telemetry_module._redis_instrumented = False
+
+        with (
+            patch.object(telemetry_module.settings, "OTEL_ENABLED", True),
+            patch.object(telemetry_module.settings, "DEBUG", True),
+            patch.object(telemetry_module.settings, "OTEL_SERVICE_NAME", "test-service"),
+            patch.object(telemetry_module.settings, "OTEL_ENVIRONMENT", "test"),
+            patch.object(telemetry_module.settings, "OTEL_EXPORTER_OTLP_ENDPOINT", ""),
+            patch.object(telemetry_module, "RedisInstrumentor") as mock_redis_instrumentor_class,
+        ):
+            # Setup mock instrumentor
+            mock_instrumentor = MagicMock()
+            mock_redis_instrumentor_class.return_value = mock_instrumentor
+
+            # Directly call _create_tracer_provider
+            provider = telemetry_module._create_tracer_provider()
+
+            # Verify provider was created
+            assert provider is not None
+
+            # Verify RedisInstrumentor was called
+            mock_instrumentor.instrument.assert_called_once()
+
+            # Clean up
+            telemetry_module._tracer_provider = None
+            telemetry_module._redis_instrumented = False
+
+
+class TestRedisInstrumentationCoverage:
+    """Additional tests for edge cases and coverage."""
+
+    def test_redis_instrumentation_with_otlp_endpoint(self) -> None:
+        """Test that Redis instrumentation works with OTLP endpoint configured."""
+        # Reset module state
+        telemetry_module._tracer_provider = None
+        telemetry_module._redis_instrumented = False
+
+        with (
+            patch.object(telemetry_module.settings, "OTEL_ENABLED", True),
+            patch.object(telemetry_module.settings, "DEBUG", False),
+            patch.object(telemetry_module.settings, "OTEL_SERVICE_NAME", "test-service"),
+            patch.object(telemetry_module.settings, "OTEL_ENVIRONMENT", "test"),
+            patch.object(
+                telemetry_module.settings,
+                "OTEL_EXPORTER_OTLP_ENDPOINT",
+                "http://localhost:4318",
+            ),
+            patch.object(telemetry_module.settings, "OTEL_EXPORTER_OTLP_HEADERS", ""),
+            patch.object(telemetry_module, "RedisInstrumentor") as mock_redis_instrumentor_class,
+            patch.object(telemetry_module, "OTLPSpanExporter"),
+        ):
+            # Setup mock instrumentor
+            mock_instrumentor = MagicMock()
+            mock_redis_instrumentor_class.return_value = mock_instrumentor
+
+            # Call get_tracer_provider
+            provider = telemetry_module.get_tracer_provider()
+
+            # Verify provider was created
+            assert provider is not None
+
+            # Verify RedisInstrumentor was called
+            mock_instrumentor.instrument.assert_called_once()
+
+            # Verify flag was set
+            assert telemetry_module._redis_instrumented
+
+            # Clean up
+            telemetry_module._tracer_provider = None
+            telemetry_module._redis_instrumented = False
+
+    def test_multiple_get_tracer_provider_calls_instrument_once(self) -> None:
+        """Test that multiple calls to get_tracer_provider only instrument once."""
+        # Reset module state
+        telemetry_module._tracer_provider = None
+        telemetry_module._redis_instrumented = False
+
+        with (
+            patch.object(telemetry_module.settings, "OTEL_ENABLED", True),
+            patch.object(telemetry_module.settings, "DEBUG", True),
+            patch.object(telemetry_module.settings, "OTEL_SERVICE_NAME", "test-service"),
+            patch.object(telemetry_module.settings, "OTEL_ENVIRONMENT", "test"),
+            patch.object(telemetry_module.settings, "OTEL_EXPORTER_OTLP_ENDPOINT", ""),
+            patch.object(telemetry_module, "RedisInstrumentor") as mock_redis_instrumentor_class,
+        ):
+            # Setup mock instrumentor
+            mock_instrumentor = MagicMock()
+            mock_redis_instrumentor_class.return_value = mock_instrumentor
+
+            # Call get_tracer_provider multiple times
+            provider1 = telemetry_module.get_tracer_provider()
+            provider2 = telemetry_module.get_tracer_provider()
+            provider3 = telemetry_module.get_tracer_provider()
+
+            # Verify same provider returned
+            assert provider1 is provider2 is provider3
+
+            # Verify RedisInstrumentor was called only once
+            mock_instrumentor.instrument.assert_called_once()
+
+            # Clean up
+            telemetry_module._tracer_provider = None
+            telemetry_module._redis_instrumented = False

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -627,6 +627,7 @@ dependencies = [
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-instrumentation-celery" },
     { name = "opentelemetry-instrumentation-fastapi" },
+    { name = "opentelemetry-instrumentation-redis" },
     { name = "opentelemetry-instrumentation-sqlalchemy" },
     { name = "opentelemetry-sdk" },
     { name = "phonenumbers" },
@@ -675,6 +676,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.29.0" },
     { name = "opentelemetry-instrumentation-celery", specifier = ">=0.50b0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.50b0" },
+    { name = "opentelemetry-instrumentation-redis", specifier = ">=0.50b0" },
     { name = "opentelemetry-instrumentation-sqlalchemy", specifier = ">=0.50b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.29.0" },
     { name = "phonenumbers", specifier = ">=8.13.0" },
@@ -934,6 +936,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ab/a7/7a6ce5009584ce97dbfd5ce77d4f9d9570147507363349d2cb705c402bcf/opentelemetry_instrumentation_fastapi-0.59b0.tar.gz", hash = "sha256:e8fe620cfcca96a7d634003df1bc36a42369dedcdd6893e13fb5903aeeb89b2b", size = 24967, upload-time = "2025-10-16T08:39:46.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/27/5914c8bf140ffc70eff153077e225997c7b054f0bf28e11b9ab91b63b18f/opentelemetry_instrumentation_fastapi-0.59b0-py3-none-any.whl", hash = "sha256:0d8d00ff7d25cca40a4b2356d1d40a8f001e0668f60c102f5aa6bb721d660c4f", size = 13492, upload-time = "2025-10-16T08:38:52.312Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-redis"
+version = "0.59b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/58bf83b10a97f67c7f06505bc4c4accbea7d961dec653a8c9e91fb65887e/opentelemetry_instrumentation_redis-0.59b0.tar.gz", hash = "sha256:d7f1c7c55ab57e10e0155c4c65d028a7e436aec7ccc7ccbf1d77e8cd12b55abd", size = 13922, upload-time = "2025-10-16T08:39:59.507Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/87/fef04827239ce84e2729b11611e8d5be7892288f620961ee9b9bafd035c5/opentelemetry_instrumentation_redis-0.59b0-py3-none-any.whl", hash = "sha256:8f7494dede5a6bfe5d8f20da67b371a502883398081856378380efef27da0bdf", size = 14946, upload-time = "2025-10-16T08:39:07.887Z" },
 ]
 
 [[package]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ services:
   #     - REDIS_URL=redis://redis:6379/0
   #     - CELERY_BROKER_URL=redis://redis:6379/1
   #     - CELERY_RESULT_BACKEND=redis://redis:6379/2
+  #     - OTEL_SERVICE_NAME=isthetuberunning-worker
   #   depends_on:
   #     postgres:
   #       condition: service_healthy
@@ -78,6 +79,7 @@ services:
   #     - REDIS_URL=redis://redis:6379/0
   #     - CELERY_BROKER_URL=redis://redis:6379/1
   #     - CELERY_RESULT_BACKEND=redis://redis:6379/2
+  #     - OTEL_SERVICE_NAME=isthetuberunning-beat
   #   depends_on:
   #     - redis
   #   volumes:


### PR DESCRIPTION
## Summary by Sourcery

Enhance OpenTelemetry integration with fork-safe initialization for Celery and FastAPI workers, introduce Redis auto-instrumentation, service name differentiation for API, worker, and beat, and add comprehensive documentation and tests.

New Features:
- Differentiate OTEL service names for API, Celery worker, and Celery Beat via OTEL_SERVICE_NAME
- Auto-instrument Redis operations for OpenTelemetry
- Initialize OpenTelemetry in Celery Beat scheduler via beat_init signal

Enhancements:
- Implement fork-safety by lazily initializing TracerProvider and SQLAlchemy/Redis engines post-fork for Celery and uvicorn workers
- Apply FastAPI and Celery instrumentors at module load and set TracerProvider in lifespan hooks
- Acquire tracers at call time to ensure correct provider context
- Restructure application startup to separate OTEL initialization and database validation

Documentation:
- Expand fork-safety documentation to cover Celery, FastAPI, SQLAlchemy, Redis, and general OTEL guidelines
- Document service name differentiation, Redis instrumentation, and Beat instrumentation in ADR

Tests:
- Add unit tests for Redis instrumentation idempotency and conditional behavior
- Add tests for Celery Beat OTEL initialization across enabled/disabled and multiple-invocation scenarios

closes #198 