### PR TITLE
fix: Remove isNow filtering for TfL disruptions; API now handles active status filtering

### DIFF
--- a/backend/tests/test_tfl_service.py
+++ b/backend/tests/test_tfl_service.py
@@ -182,7 +182,11 @@ def create_mock_validity_period(
     to_date: str | None = None,
     **kwargs: Any,  # noqa: ANN401
 ) -> TflValidityPeriod:
-    """Factory for TfL ValidityPeriod mocks using actual pydantic model."""
+    """Factory for TfL ValidityPeriod mocks using actual pydantic model.
+
+    Note: The isNow field indicates disruption category (RealTime vs PlannedWork),
+    not temporal validity. It is no longer used for filtering in the application.
+    """
     return TflValidityPeriod(
         isNow=is_now,
         fromDate=from_date,
@@ -206,7 +210,7 @@ def create_mock_line_status(
         status_severity: Numeric severity (0-20, with 10 = Good Service)
         status_severity_description: Human-readable severity description
         disruption: Optional nested disruption object
-        validity_periods: List of validity periods (defaults to isNow=True if None)
+        validity_periods: List of validity periods (optional, no default)
         reason: Optional reason text
         created: Creation timestamp
     """
@@ -216,10 +220,6 @@ def create_mock_line_status(
         created_str = created.isoformat()
     elif created is not None:
         created_str = str(created)
-
-    # Default to isNow=True if no validity periods provided
-    if validity_periods is None:
-        validity_periods = [create_mock_validity_period(is_now=True)]
 
     return TflLineStatus(
         statusSeverity=status_severity,
@@ -2382,6 +2382,82 @@ async def test_fetch_disruptions_without_affected_routes(
         assert disruptions[1].line_id == "central"
         assert disruptions[1].status_severity == 10
         assert disruptions[1].affected_routes is None  # No disruption at all
+
+
+async def test_fetch_disruptions_includes_both_realtime_and_planned(
+    tfl_service: TfLService,
+) -> None:
+    """Test that both RealTime (isNow=true) and PlannedWork (isNow=false) disruptions are included.
+
+    This test verifies the fix for issue #208. The isNow field indicates disruption
+    category (RealTime vs PlannedWork), not temporal validity. Both types should be
+    included since the TfL API filters by time when StartDate/EndDate are not specified.
+    """
+    with freeze_time("2025-01-01 12:00:00"):
+        # Mock fetch_lines
+        mock_line = Line(tfl_id="victoria", name="Victoria", mode="tube")
+        tfl_service.fetch_lines = AsyncMock(return_value=[mock_line])
+
+        # Create mock line with BOTH RealTime and PlannedWork disruptions
+        mock_lines = [
+            create_mock_line_with_status(
+                line_id="victoria",
+                line_name="Victoria",
+                line_statuses=[
+                    # RealTime disruption (isNow=true)
+                    create_mock_line_status(
+                        status_severity=6,
+                        status_severity_description="Severe Delays",
+                        disruption=create_mock_disruption(
+                            category="RealTime",
+                            description="Signal failure at Victoria",
+                            created=datetime(2025, 1, 1, 11, 30, 0, tzinfo=UTC),
+                        ),
+                        validity_periods=[create_mock_validity_period(is_now=True)],
+                        created=datetime(2025, 1, 1, 11, 30, 0, tzinfo=UTC),
+                    ),
+                    # PlannedWork disruption (isNow=false)
+                    create_mock_line_status(
+                        status_severity=9,
+                        status_severity_description="Minor Delays",
+                        disruption=create_mock_disruption(
+                            category="PlannedWork",
+                            description="Station closure at Pimlico for maintenance",
+                            created=datetime(2025, 1, 1, 10, 0, 0, tzinfo=UTC),
+                        ),
+                        validity_periods=[create_mock_validity_period(is_now=False)],
+                        created=datetime(2025, 1, 1, 10, 0, 0, tzinfo=UTC),
+                    ),
+                ],
+            ),
+        ]
+        mock_response = MockResponse(
+            data=mock_lines,
+            shared_expires=datetime(2025, 1, 1, 12, 2, 0, tzinfo=UTC),
+        )
+
+        # Mock the async client method
+        with patch.object(
+            tfl_service.line_client,
+            "StatusByIdsByPathIdsQueryDetail",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            # Execute
+            disruptions = await tfl_service.fetch_line_disruptions(modes=["tube"], use_cache=False)
+
+        # Verify BOTH disruptions are included (not just isNow=true)
+        assert len(disruptions) == 2
+
+        # First disruption: RealTime (isNow=true)
+        assert disruptions[0].line_id == "victoria"
+        assert disruptions[0].status_severity == 6
+        assert disruptions[0].reason == "Signal failure at Victoria"
+
+        # Second disruption: PlannedWork (isNow=false) - this is the fix for #208
+        assert disruptions[1].line_id == "victoria"
+        assert disruptions[1].status_severity == 9
+        assert disruptions[1].reason == "Station closure at Pimlico for maintenance"
 
 
 async def test_fetch_disruptions_with_empty_affected_station_sequence(

--- a/backend/tests/test_tfl_service.py
+++ b/backend/tests/test_tfl_service.py
@@ -210,10 +210,22 @@ def create_mock_line_status(
         status_severity: Numeric severity (0-20, with 10 = Good Service)
         status_severity_description: Human-readable severity description
         disruption: Optional nested disruption object
-        validity_periods: List of validity periods (optional, no default)
+        validity_periods: List of validity periods. Defaults to empty list (no validity periods),
+            which matches typical "Good Service" statuses. For disruptions, explicitly pass
+            validity periods to match real API responses.
         reason: Optional reason text
         created: Creation timestamp
+
+    Note:
+        validity_periods can contain ValidityPeriod objects with isNow field, but this field
+        is NOT used for filtering (it indicates category: RealTime vs PlannedWork, not temporal
+        validity). The TfL API handles temporal filtering server-side when StartDate/EndDate
+        are omitted from requests.
     """
+    # Default to empty list for validity periods (common for Good Service statuses)
+    if validity_periods is None:
+        validity_periods = []
+
     # Convert created to string format if it's a datetime
     created_str = None
     if isinstance(created, datetime):
@@ -2458,6 +2470,48 @@ async def test_fetch_disruptions_includes_both_realtime_and_planned(
         assert disruptions[1].line_id == "victoria"
         assert disruptions[1].status_severity == 9
         assert disruptions[1].reason == "Station closure at Pimlico for maintenance"
+
+
+async def test_fetch_disruptions_no_disruptions(
+    tfl_service: TfLService,
+) -> None:
+    """Test that the service handles empty responses correctly when no disruptions are present.
+
+    This test confirms that when the TfL API returns lines with no line statuses,
+    the service correctly returns an empty list rather than failing or returning
+    incorrect data.
+    """
+    with freeze_time("2025-01-01 12:00:00"):
+        # Mock fetch_lines
+        mock_line = Line(tfl_id="victoria", name="Victoria", mode="tube")
+        tfl_service.fetch_lines = AsyncMock(return_value=[mock_line])
+
+        # Create mock line with NO line statuses (no disruptions, not even Good Service)
+        mock_lines = [
+            create_mock_line_with_status(
+                line_id="victoria",
+                line_name="Victoria",
+                line_statuses=[],  # Empty - no statuses at all
+            ),
+        ]
+        mock_response = MockResponse(
+            data=mock_lines,
+            shared_expires=datetime(2025, 1, 1, 12, 2, 0, tzinfo=UTC),
+        )
+
+        # Mock the async client method
+        with patch.object(
+            tfl_service.line_client,
+            "StatusByIdsByPathIdsQueryDetail",
+            new_callable=AsyncMock,
+            return_value=mock_response,
+        ):
+            # Execute
+            disruptions = await tfl_service.fetch_line_disruptions(modes=["tube"], use_cache=False)
+
+        # Verify empty list returned (not None, not an error)
+        assert disruptions == []
+        assert len(disruptions) == 0
 
 
 async def test_fetch_disruptions_with_empty_affected_station_sequence(

--- a/docs/adr/07-external-apis.md
+++ b/docs/adr/07-external-apis.md
@@ -167,6 +167,9 @@ Use `/Line/{ids}/Status` endpoint (`StatusByIdsByPathIdsQueryDetail`) instead of
 - Structured severity scale (0-20) matches TfL's official MetaSeverity codes
 - More accurate data (real-world testing showed Disruption endpoint missed planned closures)
 - Both RealTime and PlannedWork disruptions included (Issue #208)
+  - Note: The `ValidityPeriod.isNow` field indicates disruption category (RealTime vs PlannedWork), NOT temporal validity
+  - We do NOT use `isNow` for filtering - TfL API handles temporal filtering server-side
+  - The `isNow` field cannot be removed from `pydantic_tfl_api.ValidityPeriod` as it's defined by the external library
 
 **More Difficult:**
 - Requires fetching line IDs first (extra `fetch_lines()` call)


### PR DESCRIPTION
fixes #208

## Summary by Sourcery

Remove client-side filtering of line statuses based on validityPeriods.isNow and rely on the TfL API’s built-in active status filtering, update code and documentation accordingly, and add tests to verify inclusion of both RealTime and PlannedWork disruptions

Enhancements:
- Eliminate validityPeriods.isNow filtering logic from the line status processing
- Simplify service method docstrings to reflect server-side time filtering

Documentation:
- Revise ADR to state that omitting StartDate/EndDate triggers server-side active status filtering and includes both disruption categories

Tests:
- Update mock factory for validity periods to remove default isNow behavior
- Add test to ensure both RealTime and PlannedWork disruptions are returned