### PR TITLE
Fix/issue 216 redis warm up and persistence fix

### DIFF
--- a/backend/app/api/admin.py
+++ b/backend/app/api/admin.py
@@ -124,6 +124,10 @@ async def sync_tfl_metadata(
     disruption_categories = await tfl_service.fetch_disruption_categories()
     stop_types = await tfl_service.fetch_stop_types()
 
+    # Explicit commit to ensure data persists before session closes
+    # Service methods already commit, but this ensures no rollback occurs
+    await db.commit()
+
     return SyncMetadataResponse(
         success=True,
         message="TfL metadata synchronized successfully.",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,10 +18,11 @@ from sqlalchemy.engine import Connection
 from app import __version__
 from app.api import admin, auth, contacts, notification_preferences, routes, tfl
 from app.core.config import settings
-from app.core.database import get_engine
+from app.core.database import get_engine, get_session_factory
 from app.core.logging import configure_logging
 from app.core.telemetry import get_tracer_provider, shutdown_tracer_provider
 from app.middleware import AccessLoggingMiddleware
+from app.services.tfl_service import warm_up_metadata_cache
 
 # Configure logging at module level so Uvicorn startup logs go through structlog pipeline
 configure_logging(log_level=settings.LOG_LEVEL)
@@ -117,6 +118,24 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     except Exception as e:
         logger.error("startup_failed", error=str(e))
         raise
+
+    # Warm up Redis cache from database (eliminates cold-start TfL API dependency)
+    try:
+        async with get_session_factory()() as session:
+            counts = await warm_up_metadata_cache(session, settings.REDIS_URL)
+            logger.info(
+                "redis_cache_warmup_complete",
+                severity_codes=counts["severity_codes_count"],
+                disruption_categories=counts["disruption_categories_count"],
+                stop_types=counts["stop_types_count"],
+            )
+    except Exception as exc:
+        # Log warning but don't block startup - application can fetch from TfL API on demand
+        logger.warning(
+            "redis_cache_warmup_failed",
+            error=str(exc),
+            error_type=type(exc).__name__,
+        )
 
     logger.info("startup_complete")
 

--- a/backend/app/services/tfl_service.py
+++ b/backend/app/services/tfl_service.py
@@ -144,7 +144,7 @@ def tfl_api_span(
 DEFAULT_LINES_CACHE_TTL = 86400  # 24 hours
 DEFAULT_STATIONS_CACHE_TTL = 86400  # 24 hours
 DEFAULT_DISRUPTIONS_CACHE_TTL = 120  # 2 minutes
-DEFAULT_METADATA_CACHE_TTL = 604800  # 7 days
+DEFAULT_METADATA_CACHE_TTL = 86400  # 24 hours (matches typical TfL API expiry)
 
 # TfL API constants
 MIN_ROUTE_SEGMENTS = 2  # Minimum number of segments required for route validation
@@ -253,6 +253,116 @@ def _extract_station_atco_code(disrupted_point: DisruptedPoint) -> str | None:
     # Fall back to atcoCode (less specific but often same value)
     atco_code: str | None = getattr(disrupted_point, "atcoCode", None)
     return atco_code
+
+
+async def warm_up_metadata_cache(db: AsyncSession, redis_url: str) -> dict[str, int]:
+    """
+    Warm up Redis cache with metadata from database on application startup.
+
+    Called during application lifespan to rehydrate Redis from PostgreSQL,
+    eliminating cold-start dependency on TfL API. If database tables are empty
+    (fresh installation), returns zero counts and logs warnings.
+
+    Args:
+        db: Database session for querying metadata tables
+        redis_url: Redis connection URL for cache initialization
+
+    Returns:
+        dict with counts: {
+            "severity_codes_count": int,
+            "disruption_categories_count": int,
+            "stop_types_count": int
+        }
+
+    Raises:
+        Does not raise exceptions - logs warnings for graceful degradation.
+        Application startup continues even if warm-up fails.
+
+    Example:
+        >>> async with get_session_factory()() as session:
+        ...     counts = await warm_up_metadata_cache(session, "redis://localhost:6379/0")
+        ...     print(counts)
+        {"severity_codes_count": 233, "disruption_categories_count": 7, "stop_types_count": 3}
+    """
+    try:
+        # Query all metadata from database
+        severity_result = await db.execute(select(SeverityCode))
+        severity_codes = list(severity_result.scalars().all())
+
+        disruption_result = await db.execute(select(DisruptionCategory))
+        disruption_categories = list(disruption_result.scalars().all())
+
+        stop_result = await db.execute(select(StopType))
+        stop_types = list(stop_result.scalars().all())
+
+        # Initialize cache (same configuration as TfLService)
+        # Parse Redis URL to extract host and port
+        parsed = urlparse(redis_url)
+        redis_host = parsed.hostname or "localhost"
+        redis_port = parsed.port or 6379
+
+        cache = Cache(
+            Cache.REDIS,
+            endpoint=redis_host,
+            port=redis_port,
+            serializer=PickleSerializer(),
+            namespace="tfl",
+        )
+
+        # Populate Redis with same keys used by fetch_* methods
+        # Use DEFAULT_METADATA_CACHE_TTL (24 hours) matching typical TfL API expiry
+        ttl = DEFAULT_METADATA_CACHE_TTL
+
+        if severity_codes:
+            await cache.set("severity_codes:all", severity_codes, ttl=ttl)
+            logger.info(
+                "severity_codes_cache_warmed",
+                count=len(severity_codes),
+                ttl=ttl,
+            )
+        else:
+            logger.warning("severity_codes_table_empty_skipping_cache_warmup")
+
+        if disruption_categories:
+            await cache.set("disruption_categories:all", disruption_categories, ttl=ttl)
+            logger.info(
+                "disruption_categories_cache_warmed",
+                count=len(disruption_categories),
+                ttl=ttl,
+            )
+        else:
+            logger.warning("disruption_categories_table_empty_skipping_cache_warmup")
+
+        if stop_types:
+            await cache.set("stop_types:all", stop_types, ttl=ttl)
+            logger.info(
+                "stop_types_cache_warmed",
+                count=len(stop_types),
+                ttl=ttl,
+            )
+        else:
+            logger.warning("stop_types_table_empty_skipping_cache_warmup")
+
+        return {
+            "severity_codes_count": len(severity_codes),
+            "disruption_categories_count": len(disruption_categories),
+            "stop_types_count": len(stop_types),
+        }
+
+    except Exception as exc:
+        # Log error but don't block application startup
+        logger.error(
+            "metadata_cache_warmup_failed",
+            error=str(exc),
+            error_type=type(exc).__name__,
+            exc_info=exc,
+        )
+        # Return zero counts to indicate failure
+        return {
+            "severity_codes_count": 0,
+            "disruption_categories_count": 0,
+            "stop_types_count": 0,
+        }
 
 
 class TfLService:
@@ -587,11 +697,15 @@ class TfLService:
                 )
                 await self.db.execute(stmt)
 
+            # DEBUG: Log before commit
+            logger.debug("severity_codes_committing_to_database", severity_count=len(severity_data_list))
             await self.db.commit()
+            logger.info("severity_codes_committed_to_database", severity_count=len(severity_data_list))
 
             # Fetch all codes from database to return
             result = await self.db.execute(select(SeverityCode))
             codes = list(result.scalars().all())
+            logger.debug("severity_codes_queried_from_database_after_commit", query_result_count=len(codes))
 
             # Cache the results
             await self.cache.set(cache_key, codes, ttl=ttl)

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -159,6 +159,10 @@ async def test_lifespan_production_success() -> None:
     with (
         patch("app.main.settings") as mock_settings,
         patch("app.main._check_alembic_migrations", return_value="test_revision"),
+        patch(
+            "app.main.warm_up_metadata_cache",
+            return_value={"severity_codes_count": 0, "disruption_categories_count": 0, "stop_types_count": 0},
+        ),
     ):
         mock_settings.DEBUG = False
         mock_settings.LOG_LEVEL = "INFO"

--- a/backend/tests/test_tfl_service.py
+++ b/backend/tests/test_tfl_service.py
@@ -8932,29 +8932,32 @@ async def test_warm_up_metadata_cache_populates_redis(
         namespace="tfl",
     )
 
-    # Check severity codes
-    cached_severity_codes = await cache.get("severity_codes:all")
-    assert cached_severity_codes is not None
-    assert len(cached_severity_codes) == 1
-    assert cached_severity_codes[0].mode_id == "tube"
-    assert cached_severity_codes[0].severity_level == 10
+    try:
+        # Check severity codes
+        cached_severity_codes = await cache.get("severity_codes:all")
+        assert cached_severity_codes is not None
+        assert len(cached_severity_codes) == 1
+        assert cached_severity_codes[0].mode_id == "tube"
+        assert cached_severity_codes[0].severity_level == 10
 
-    # Check disruption categories
-    cached_categories = await cache.get("disruption_categories:all")
-    assert cached_categories is not None
-    assert len(cached_categories) == 1
-    assert cached_categories[0].category_name == "PlannedWork"
+        # Check disruption categories
+        cached_categories = await cache.get("disruption_categories:all")
+        assert cached_categories is not None
+        assert len(cached_categories) == 1
+        assert cached_categories[0].category_name == "PlannedWork"
 
-    # Check stop types
-    cached_stop_types = await cache.get("stop_types:all")
-    assert cached_stop_types is not None
-    assert len(cached_stop_types) == 1
-    assert cached_stop_types[0].type_name == "NaptanMetroStation"
+        # Check stop types
+        cached_stop_types = await cache.get("stop_types:all")
+        assert cached_stop_types is not None
+        assert len(cached_stop_types) == 1
+        assert cached_stop_types[0].type_name == "NaptanMetroStation"
 
-    # Clean up Redis cache after test
-    await cache.delete("severity_codes:all")
-    await cache.delete("disruption_categories:all")
-    await cache.delete("stop_types:all")
+        # Clean up Redis cache after test
+        await cache.delete("severity_codes:all")
+        await cache.delete("disruption_categories:all")
+        await cache.delete("stop_types:all")
+    finally:
+        await cache.close()
 
 
 async def test_warm_up_metadata_cache_uses_correct_ttl(
@@ -8984,16 +8987,19 @@ async def test_warm_up_metadata_cache_uses_correct_ttl(
         namespace="tfl",
     )
 
-    # Check TTL on the severity_codes key
-    # aiocache RedisCache stores keys with namespace prefix
-    redis_ttl = await cache.client.ttl("tfl:severity_codes:all")
-    # TTL should be close to DEFAULT_METADATA_CACHE_TTL (allow small margin for execution time)
-    assert redis_ttl > 0, "TTL should be set (positive value)"
-    assert redis_ttl <= DEFAULT_METADATA_CACHE_TTL, "TTL should not exceed DEFAULT_METADATA_CACHE_TTL"
-    assert redis_ttl >= DEFAULT_METADATA_CACHE_TTL - 10, "TTL should be close to DEFAULT_METADATA_CACHE_TTL"
+    try:
+        # Check TTL on the severity_codes key
+        # aiocache RedisCache stores keys with namespace prefix
+        redis_ttl = await cache.client.ttl("tfl:severity_codes:all")
+        # TTL should be close to DEFAULT_METADATA_CACHE_TTL (allow small margin for execution time)
+        assert redis_ttl > 0, "TTL should be set (positive value)"
+        assert redis_ttl <= DEFAULT_METADATA_CACHE_TTL, "TTL should not exceed DEFAULT_METADATA_CACHE_TTL"
+        assert redis_ttl >= DEFAULT_METADATA_CACHE_TTL - 10, "TTL should be close to DEFAULT_METADATA_CACHE_TTL"
 
-    # Clean up
-    await cache.delete("severity_codes:all")
+        # Clean up
+        await cache.delete("severity_codes:all")
+    finally:
+        await cache.close()
 
 
 async def test_warm_up_metadata_cache_handles_redis_failure_gracefully(

--- a/backend/tests/test_tfl_service.py
+++ b/backend/tests/test_tfl_service.py
@@ -697,7 +697,7 @@ async def test_fetch_available_modes_from_api(
             mock_data=mock_modes,
             expected_count=5,
             cache_key="modes:all",
-            expected_ttl=604800,  # 7 days (DEFAULT_METADATA_CACHE_TTL)
+            expected_ttl=86400,  # 24 hours (DEFAULT_METADATA_CACHE_TTL)
             shared_expires=datetime(2025, 1, 8, 12, 0, 0, tzinfo=UTC),
         )
 
@@ -2916,7 +2916,7 @@ async def test_fetch_severity_codes(
             mock_data=mock_severity_codes,
             expected_count=4,
             cache_key="severity_codes:all",
-            expected_ttl=604800,  # 7 days
+            expected_ttl=86400,  # 24 hours
             shared_expires=datetime(2025, 1, 8, 12, 0, 0, tzinfo=UTC),
             client_attr="line_client",
             client_method="MetaSeverity",
@@ -3123,7 +3123,7 @@ async def test_fetch_disruption_categories(
             mock_data=mock_categories,
             expected_count=4,
             cache_key="disruption_categories:all",
-            expected_ttl=604800,  # 7 days
+            expected_ttl=86400,  # 24 hours
             shared_expires=datetime(2025, 1, 8, 12, 0, 0, tzinfo=UTC),
             client_attr="line_client",
             client_method="MetaDisruptionCategories",
@@ -3215,7 +3215,7 @@ async def test_fetch_stop_types(
             mock_data=mock_stop_types,
             expected_count=3,  # Only 3 relevant types
             cache_key="stop_types:all",
-            expected_ttl=604800,  # 7 days
+            expected_ttl=86400,  # 24 hours
             shared_expires=datetime(2025, 1, 8, 12, 0, 0, tzinfo=UTC),
             client_attr="stoppoint_client",
             client_method="MetaStopTypes",


### PR DESCRIPTION
fixes #216
related: #220

## Summary by Sourcery

Preload metadata from PostgreSQL into Redis on startup by adding a warm-up function, adjust default metadata TTL to 24 hours, enhance logging and commit behavior for metadata sync, and cover these changes with targeted tests

New Features:
- Introduce warm_up_metadata_cache function to preload metadata into Redis with graceful error handling
- Invoke Redis cache warm-up during application startup to eliminate cold-start dependency on TfL API

Bug Fixes:
- Adjust DEFAULT_METADATA_CACHE_TTL from 7 days to 24 hours to align with TfL API expiry
- Ensure metadata synchronization in admin API persists data by explicitly committing the database session

Enhancements:
- Add debug and info logs around severity codes commit in fetch_severity_codes

Tests:
- Add comprehensive tests for warm_up_metadata_cache covering empty database, cache population, TTL usage, and Redis failures
- Add (skipped) test to verify database persistence of severity codes across sessions