### PR TITLE
Feature/issue 218 scheduled tfl refresh

### DIFF
--- a/backend/app/celery/schedules.py
+++ b/backend/app/celery/schedules.py
@@ -1,8 +1,12 @@
 """Celery Beat periodic task schedules.
 
 This module configures the schedule for periodic tasks that run automatically
-via Celery Beat. The check_disruptions_and_alert task runs every 30 seconds
-to monitor TfL status and send alerts to users with matching notification preferences.
+via Celery Beat.
+
+Scheduled tasks:
+- check_disruptions_and_alert: Every 30 seconds - monitor TfL disruptions and send alerts
+- refresh_tfl_metadata: Daily - refresh severity codes, categories, stop types with change detection
+- rebuild_network_graph: Daily - rebuild station graph and trigger stale route detection
 
 Note: Route index staleness detection is event-driven (triggered after TfL data updates)
 rather than scheduled. See POST /admin/tfl/build-graph endpoint.
@@ -11,13 +15,32 @@ rather than scheduled. See POST /admin/tfl/build-graph endpoint.
 from app.celery.app import celery_app
 from celery.schedules import schedule
 
+# Schedule configuration constants
+DISRUPTION_CHECK_INTERVAL = 30.0  # 30 seconds
+METADATA_REFRESH_INTERVAL = 86400.0  # 24 hours (daily)
+GRAPH_REBUILD_INTERVAL = 86400.0  # 24 hours (daily)
+
 # Configure Celery Beat schedule
 celery_app.conf.beat_schedule = {
     "check-disruptions-and-alert": {
         "task": "app.celery.tasks.check_disruptions_and_alert",
-        "schedule": schedule(run_every=30.0),  # Run every 30 seconds
+        "schedule": schedule(run_every=DISRUPTION_CHECK_INTERVAL),
         "options": {
             "expires": 60,  # Task expires if not picked up within 60 seconds
+        },
+    },
+    "refresh-tfl-metadata": {
+        "task": "app.celery.tasks.refresh_tfl_metadata",
+        "schedule": schedule(run_every=METADATA_REFRESH_INTERVAL),
+        "options": {
+            "expires": 3600,  # Task expires if not picked up within 1 hour
+        },
+    },
+    "rebuild-network-graph": {
+        "task": "app.celery.tasks.rebuild_network_graph",
+        "schedule": schedule(run_every=GRAPH_REBUILD_INTERVAL),
+        "options": {
+            "expires": 3600,  # Task expires if not picked up within 1 hour
         },
     },
 }

--- a/backend/tests/test_celery_metadata_and_graph_tasks.py
+++ b/backend/tests/test_celery_metadata_and_graph_tasks.py
@@ -125,8 +125,8 @@ async def test_refresh_metadata_async_ensures_session_cleanup(
     mock_tfl_service.refresh_metadata_with_change_detection = AsyncMock(side_effect=Exception("Database error"))
     mock_tfl_service_class.return_value = mock_tfl_service
 
-    # Execute async function - should handle exception gracefully
-    # (actually it will return error result due to MetadataChangeDetectedError handling)
+    # Execute async function - generic exceptions will propagate up
+    # The test suppresses them to verify session cleanup still happens
     with contextlib.suppress(Exception):
         await _refresh_metadata_async()
 

--- a/backend/tests/test_celery_metadata_and_graph_tasks.py
+++ b/backend/tests/test_celery_metadata_and_graph_tasks.py
@@ -1,0 +1,344 @@
+"""Tests for metadata refresh and graph rebuild Celery tasks."""
+
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from app.celery.tasks import (
+    _rebuild_graph_async,
+    _refresh_metadata_async,
+    rebuild_network_graph_task,
+    refresh_tfl_metadata_task,
+)
+from app.services.tfl_service import MetadataChangeDetectedError
+
+# ==================== refresh_tfl_metadata_task Tests ====================
+
+
+def test_refresh_metadata_task_registered() -> None:
+    """Test that task function exists."""
+    assert refresh_tfl_metadata_task is not None
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.TfLService")
+@patch("app.celery.tasks.get_worker_session")
+async def test_refresh_metadata_async_success_no_changes(
+    mock_session_factory: MagicMock,
+    mock_tfl_service_class: MagicMock,
+) -> None:
+    """Test successful metadata refresh with no changes detected."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session.commit = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock TfLService
+    mock_tfl_service = AsyncMock()
+    mock_tfl_service.refresh_metadata_with_change_detection = AsyncMock(
+        return_value=(10, 5, 3)  # counts: severity_codes, categories, stop_types
+    )
+    mock_tfl_service_class.return_value = mock_tfl_service
+
+    # Execute async function
+    result = await _refresh_metadata_async()
+
+    # Verify result
+    assert result["status"] == "success"
+    assert result["severity_codes_count"] == 10
+    assert result["disruption_categories_count"] == 5
+    assert result["stop_types_count"] == 3
+    assert result["changes_detected"] is False
+    assert result["error"] is None
+
+    # Verify TfLService was instantiated correctly
+    mock_tfl_service_class.assert_called_once_with(db=mock_session)
+
+    # Verify refresh method was called
+    mock_tfl_service.refresh_metadata_with_change_detection.assert_called_once()
+
+    # Verify session was committed and closed
+    mock_session.commit.assert_called_once()
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.TfLService")
+@patch("app.celery.tasks.get_worker_session")
+async def test_refresh_metadata_async_changes_detected(
+    mock_session_factory: MagicMock,
+    mock_tfl_service_class: MagicMock,
+) -> None:
+    """Test metadata refresh when changes are detected."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session.commit = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock TfLService to raise MetadataChangeDetectedError
+    mock_tfl_service = AsyncMock()
+    test_error = MetadataChangeDetectedError(
+        "TfL metadata changed unexpectedly: severity_codes",
+        details={
+            "changed_types": ["severity_codes"],
+            "severity_codes": {
+                "before_count": 10,
+                "after_count": 11,
+                "before_hash": "abc123",
+                "after_hash": "def456",
+            },
+        },
+    )
+    mock_tfl_service.refresh_metadata_with_change_detection = AsyncMock(side_effect=test_error)
+    mock_tfl_service_class.return_value = mock_tfl_service
+
+    # Execute async function - should NOT raise exception, should return error result
+    result = await _refresh_metadata_async()
+
+    # Verify result indicates changes detected
+    assert result["status"] == "changes_detected"
+    assert result["changes_detected"] is True
+    assert result["error"] is not None
+    assert "severity_codes" in result["error"]
+
+    # Verify session was closed (but not committed due to exception)
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.TfLService")
+@patch("app.celery.tasks.get_worker_session")
+async def test_refresh_metadata_async_ensures_session_cleanup(
+    mock_session_factory: MagicMock,
+    mock_tfl_service_class: MagicMock,
+) -> None:
+    """Test that session is always closed even on generic exception."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock TfLService to raise generic exception
+    mock_tfl_service = AsyncMock()
+    mock_tfl_service.refresh_metadata_with_change_detection = AsyncMock(side_effect=Exception("Database error"))
+    mock_tfl_service_class.return_value = mock_tfl_service
+
+    # Execute async function - should handle exception gracefully
+    # (actually it will return error result due to MetadataChangeDetectedError handling)
+    with contextlib.suppress(Exception):
+        await _refresh_metadata_async()
+
+    # Verify session was closed
+    mock_session.close.assert_called_once()
+
+
+# ==================== rebuild_network_graph_task Tests ====================
+
+
+def test_rebuild_graph_task_registered() -> None:
+    """Test that task function exists."""
+    assert rebuild_network_graph_task is not None
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.detect_and_rebuild_stale_routes")
+@patch("app.celery.tasks.TfLService")
+@patch("app.celery.tasks.get_worker_session")
+async def test_rebuild_graph_async_success(
+    mock_session_factory: MagicMock,
+    mock_tfl_service_class: MagicMock,
+    mock_stale_detection_task: MagicMock,
+) -> None:
+    """Test successful graph rebuild."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session.commit = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock TfLService
+    mock_tfl_service = AsyncMock()
+    mock_tfl_service.build_station_graph = AsyncMock(
+        return_value={
+            "lines_count": 12,
+            "connections_count": 500,
+        }
+    )
+    mock_tfl_service_class.return_value = mock_tfl_service
+
+    # Mock stale detection task
+    mock_stale_detection_task.delay = MagicMock()
+
+    # Execute async function
+    result = await _rebuild_graph_async()
+
+    # Verify result
+    assert result["status"] == "success"
+    assert result["lines_count"] == 12
+    assert result["connections_count"] == 500
+    assert result["stale_detection_triggered"] is True
+    assert result["error"] is None
+
+    # Verify TfLService was instantiated correctly
+    mock_tfl_service_class.assert_called_once_with(db=mock_session)
+
+    # Verify build_station_graph was called
+    mock_tfl_service.build_station_graph.assert_called_once()
+
+    # Verify stale detection was triggered
+    mock_stale_detection_task.delay.assert_called_once()
+
+    # Verify session was committed and closed
+    mock_session.commit.assert_called_once()
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.detect_and_rebuild_stale_routes")
+@patch("app.celery.tasks.TfLService")
+@patch("app.celery.tasks.get_worker_session")
+async def test_rebuild_graph_async_handles_stale_detection_failure(
+    mock_session_factory: MagicMock,
+    mock_tfl_service_class: MagicMock,
+    mock_stale_detection_task: MagicMock,
+) -> None:
+    """Test that graph rebuild continues even if stale detection triggering fails."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session.commit = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock TfLService
+    mock_tfl_service = AsyncMock()
+    mock_tfl_service.build_station_graph = AsyncMock(return_value={"lines_count": 12, "connections_count": 500})
+    mock_tfl_service_class.return_value = mock_tfl_service
+
+    # Mock stale detection task to fail
+    mock_stale_detection_task.delay = MagicMock(side_effect=Exception("Task queue error"))
+
+    # Execute async function - should not fail
+    result = await _rebuild_graph_async()
+
+    # Verify result shows graph rebuild succeeded but stale detection failed
+    assert result["status"] == "success"
+    assert result["lines_count"] == 12
+    assert result["stale_detection_triggered"] is False  # Failed to trigger
+    assert result["error"] is None  # Graph rebuild itself succeeded
+
+    # Verify session was closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.TfLService")
+@patch("app.celery.tasks.get_worker_session")
+async def test_rebuild_graph_async_handles_build_failure(
+    mock_session_factory: MagicMock,
+    mock_tfl_service_class: MagicMock,
+) -> None:
+    """Test that graph rebuild handles build failures gracefully."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock TfLService to fail
+    mock_tfl_service = AsyncMock()
+    mock_tfl_service.build_station_graph = AsyncMock(side_effect=Exception("TfL API error"))
+    mock_tfl_service_class.return_value = mock_tfl_service
+
+    # Execute async function
+    result = await _rebuild_graph_async()
+
+    # Verify result indicates failure
+    assert result["status"] == "failure"
+    assert result["lines_count"] == 0
+    assert result["connections_count"] == 0
+    assert result["stale_detection_triggered"] is False
+    assert result["error"] is not None
+    assert "TfL API error" in result["error"]
+
+    # Verify session was closed
+    mock_session.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.TfLService")
+@patch("app.celery.tasks.get_worker_session")
+async def test_rebuild_graph_async_ensures_session_cleanup_on_failure(
+    mock_session_factory: MagicMock,
+    mock_tfl_service_class: MagicMock,
+) -> None:
+    """Test that session is always closed even when graph rebuild fails."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session.commit = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock TfLService to raise exception
+    mock_tfl_service = AsyncMock()
+    mock_tfl_service.build_station_graph = AsyncMock(side_effect=Exception("Network error"))
+    mock_tfl_service_class.return_value = mock_tfl_service
+
+    # Execute async function
+    result = await _rebuild_graph_async()
+
+    # Verify result shows failure
+    assert result["status"] == "failure"
+
+    # Verify session was closed (even though build failed)
+    mock_session.close.assert_called_once()
+
+    # Verify commit was NOT called (no successful build)
+    mock_session.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+@patch("app.celery.tasks.detect_and_rebuild_stale_routes")
+@patch("app.celery.tasks.TfLService")
+@patch("app.celery.tasks.get_worker_session")
+async def test_rebuild_graph_async_full_success_flow(
+    mock_session_factory: MagicMock,
+    mock_tfl_service_class: MagicMock,
+    mock_stale_detection_task: MagicMock,
+) -> None:
+    """Test complete success flow: graph rebuild + stale detection + cleanup."""
+    # Mock database session
+    mock_session = AsyncMock()
+    mock_session.close = AsyncMock()
+    mock_session.commit = AsyncMock()
+    mock_session_factory.return_value = mock_session
+
+    # Mock TfLService
+    mock_tfl_service = AsyncMock()
+    mock_tfl_service.build_station_graph = AsyncMock(
+        return_value={
+            "lines_count": 15,
+            "connections_count": 650,
+        }
+    )
+    mock_tfl_service_class.return_value = mock_tfl_service
+
+    # Mock stale detection task
+    mock_stale_detection_task.delay = MagicMock()
+
+    # Execute async function
+    result = await _rebuild_graph_async()
+
+    # Verify complete flow
+    assert result["status"] == "success"
+    assert result["lines_count"] == 15
+    assert result["connections_count"] == 650
+    assert result["stale_detection_triggered"] is True
+    assert result["error"] is None
+
+    # Verify all steps executed in order
+    mock_tfl_service_class.assert_called_once()
+    mock_tfl_service.build_station_graph.assert_called_once()
+    mock_session.commit.assert_called_once()
+    mock_stale_detection_task.delay.assert_called_once()
+    mock_session.close.assert_called_once()

--- a/backend/tests/test_compute_metadata_hash.py
+++ b/backend/tests/test_compute_metadata_hash.py
@@ -1,0 +1,132 @@
+"""Tests for _compute_metadata_hash helper function."""
+
+from app.models.tfl import DisruptionCategory, SeverityCode, StopType
+from app.services.tfl_service import _compute_metadata_hash
+
+
+def test_compute_metadata_hash_severity_codes_stable() -> None:
+    """Test that hash is stable for same severity codes."""
+    codes = [
+        SeverityCode(
+            mode_id="tube",
+            severity_level=10,
+            description="Severe Delays",
+        ),
+        SeverityCode(
+            mode_id="tube",
+            severity_level=6,
+            description="Minor Delays",
+        ),
+    ]
+
+    hash1 = _compute_metadata_hash(codes)
+    hash2 = _compute_metadata_hash(codes)
+
+    assert hash1 == hash2
+    assert len(hash1) == 64  # SHA256 produces 64 hex characters
+
+
+def test_compute_metadata_hash_severity_codes_sorted() -> None:
+    """Test that hash is same regardless of input order (items are sorted)."""
+    codes_order1 = [
+        SeverityCode(mode_id="tube", severity_level=10, description="Severe Delays"),
+        SeverityCode(mode_id="tube", severity_level=6, description="Minor Delays"),
+    ]
+
+    codes_order2 = [
+        SeverityCode(mode_id="tube", severity_level=6, description="Minor Delays"),
+        SeverityCode(mode_id="tube", severity_level=10, description="Severe Delays"),
+    ]
+
+    hash1 = _compute_metadata_hash(codes_order1)
+    hash2 = _compute_metadata_hash(codes_order2)
+
+    assert hash1 == hash2, "Hash should be same regardless of input order"
+
+
+def test_compute_metadata_hash_disruption_categories() -> None:
+    """Test hash computation for disruption categories."""
+    categories = [
+        DisruptionCategory(category_name="RealTime", description="Real-time disruption"),
+        DisruptionCategory(category_name="PlannedWork", description="Planned work"),
+    ]
+
+    hash1 = _compute_metadata_hash(categories)
+    hash2 = _compute_metadata_hash(categories)
+
+    assert hash1 == hash2
+    assert len(hash1) == 64
+
+
+def test_compute_metadata_hash_stop_types() -> None:
+    """Test hash computation for stop types."""
+    types = [
+        StopType(type_name="NaptanMetroStation", description="Metro station"),
+        StopType(type_name="NaptanRailStation", description="Rail station"),
+    ]
+
+    hash1 = _compute_metadata_hash(types)
+    hash2 = _compute_metadata_hash(types)
+
+    assert hash1 == hash2
+    assert len(hash1) == 64
+
+
+def test_compute_metadata_hash_empty_list() -> None:
+    """Test hash computation for empty list."""
+    # Empty list of severity codes
+    hash_result = _compute_metadata_hash([])  # type: ignore[arg-type]
+
+    assert isinstance(hash_result, str)
+    assert len(hash_result) == 64
+    # Hash of empty list "[]" should be consistent
+    assert hash_result == _compute_metadata_hash([])  # type: ignore[arg-type]
+
+
+def test_compute_metadata_hash_changes_when_data_changes() -> None:
+    """Test that hash changes when data changes."""
+    codes_before = [
+        SeverityCode(mode_id="tube", severity_level=10, description="Severe Delays"),
+    ]
+
+    codes_after = [
+        SeverityCode(mode_id="tube", severity_level=10, description="Severe Delays"),
+        SeverityCode(mode_id="tube", severity_level=6, description="Minor Delays"),  # Added
+    ]
+
+    hash_before = _compute_metadata_hash(codes_before)
+    hash_after = _compute_metadata_hash(codes_after)
+
+    assert hash_before != hash_after, "Hash should change when data changes"
+
+
+def test_compute_metadata_hash_detects_description_changes() -> None:
+    """Test that hash changes when description changes."""
+    codes_before = [
+        SeverityCode(mode_id="tube", severity_level=10, description="Severe Delays"),
+    ]
+
+    codes_after = [
+        SeverityCode(mode_id="tube", severity_level=10, description="Very Severe Delays"),
+    ]
+
+    hash_before = _compute_metadata_hash(codes_before)
+    hash_after = _compute_metadata_hash(codes_after)
+
+    assert hash_before != hash_after, "Hash should change when description changes"
+
+
+def test_compute_metadata_hash_different_types_produce_different_hashes() -> None:
+    """Test that different metadata types produce different hashes even with similar data."""
+    severity_codes = [
+        SeverityCode(mode_id="tube", severity_level=10, description="Test"),
+    ]
+
+    stop_types = [
+        StopType(type_name="test", description="Test"),
+    ]
+
+    hash_codes = _compute_metadata_hash(severity_codes)
+    hash_types = _compute_metadata_hash(stop_types)
+
+    assert hash_codes != hash_types, "Different types should produce different hashes"

--- a/backend/tests/test_refresh_metadata_with_change_detection.py
+++ b/backend/tests/test_refresh_metadata_with_change_detection.py
@@ -319,13 +319,12 @@ async def test_refresh_metadata_with_change_detection_empty_database(
             return_value=[StopType(type_name="NaptanMetroStation", description="Metro", last_updated=now)],
         ),
     ):
-        # Should raise exception because empty -> populated is a change
-        with pytest.raises(MetadataChangeDetectedError) as exc_info:
-            await tfl_service.refresh_metadata_with_change_detection()
+        # Should NOT raise exception - this is initial population (empty database)
+        # Returns counts successfully without raising MetadataChangeDetectedError
+        counts = await tfl_service.refresh_metadata_with_change_detection()
 
-        error = exc_info.value
-        # All three types changed (empty to populated)
-        assert len(error.details["changed_types"]) == 3
+        # Verify counts match the fetched data
+        assert counts == (1, 1, 1)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_refresh_metadata_with_change_detection.py
+++ b/backend/tests/test_refresh_metadata_with_change_detection.py
@@ -1,0 +1,476 @@
+"""Tests for refresh_metadata_with_change_detection method."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from app.models.tfl import DisruptionCategory, SeverityCode, StopType
+from app.services.tfl_service import MetadataChangeDetectedError, TfLService
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.mark.asyncio
+async def test_refresh_metadata_with_change_detection_no_changes(
+    db_session: AsyncSession,
+) -> None:
+    """Test refresh when metadata hasn't changed."""
+    now = datetime.now(UTC)
+
+    # Create initial metadata
+    severity_code = SeverityCode(
+        mode_id="tube",
+        severity_level=10,
+        description="Severe Delays",
+        last_updated=now,
+    )
+    category = DisruptionCategory(
+        category_name="RealTime",
+        description="Real-time disruption",
+        last_updated=now,
+    )
+    stop_type = StopType(
+        type_name="NaptanMetroStation",
+        description="Metro station",
+        last_updated=now,
+    )
+
+    db_session.add_all([severity_code, category, stop_type])
+    await db_session.commit()
+
+    # Create service
+    tfl_service = TfLService(db=db_session)
+
+    # Mock fetch methods to return fresh instances with same data (no changes)
+    # Note: Must return NEW instances, not the same objects already in session
+    with (
+        patch.object(
+            tfl_service,
+            "fetch_severity_codes",
+            new_callable=AsyncMock,
+            return_value=[
+                SeverityCode(mode_id="tube", severity_level=10, description="Severe Delays", last_updated=now)
+            ],
+        ),
+        patch.object(
+            tfl_service,
+            "fetch_disruption_categories",
+            new_callable=AsyncMock,
+            return_value=[
+                DisruptionCategory(category_name="RealTime", description="Real-time disruption", last_updated=now)
+            ],
+        ),
+        patch.object(
+            tfl_service,
+            "fetch_stop_types",
+            new_callable=AsyncMock,
+            return_value=[StopType(type_name="NaptanMetroStation", description="Metro station", last_updated=now)],
+        ),
+    ):
+        # Should not raise exception when no changes
+        counts = await tfl_service.refresh_metadata_with_change_detection()
+
+        assert counts == (1, 1, 1)  # 1 of each type
+
+
+@pytest.mark.asyncio
+async def test_refresh_metadata_with_change_detection_severity_codes_changed(
+    db_session: AsyncSession,
+) -> None:
+    """Test refresh detects when severity codes change."""
+    now = datetime.now(UTC)
+
+    # Create initial metadata
+    severity_code_before = SeverityCode(
+        mode_id="tube",
+        severity_level=10,
+        description="Severe Delays",
+        last_updated=now,
+    )
+    category = DisruptionCategory(
+        category_name="RealTime",
+        description="Real-time disruption",
+        last_updated=now,
+    )
+    stop_type = StopType(
+        type_name="NaptanMetroStation",
+        description="Metro station",
+        last_updated=now,
+    )
+
+    db_session.add_all([severity_code_before, category, stop_type])
+    await db_session.commit()
+
+    # Create service
+    tfl_service = TfLService(db=db_session)
+
+    # Mock fetch methods - severity codes have NEW item
+    # Return fresh instances to avoid session conflicts
+    with (
+        patch.object(
+            tfl_service,
+            "fetch_severity_codes",
+            new_callable=AsyncMock,
+            return_value=[
+                SeverityCode(mode_id="tube", severity_level=10, description="Severe Delays", last_updated=now),
+                SeverityCode(
+                    mode_id="tube", severity_level=6, description="Minor Delays", last_updated=now
+                ),  # Added item
+            ],
+        ),
+        patch.object(
+            tfl_service,
+            "fetch_disruption_categories",
+            new_callable=AsyncMock,
+            return_value=[
+                DisruptionCategory(category_name="RealTime", description="Real-time disruption", last_updated=now)
+            ],
+        ),
+        patch.object(
+            tfl_service,
+            "fetch_stop_types",
+            new_callable=AsyncMock,
+            return_value=[StopType(type_name="NaptanMetroStation", description="Metro station", last_updated=now)],
+        ),
+    ):
+        # Should raise exception when changes detected
+        with pytest.raises(MetadataChangeDetectedError) as exc_info:
+            await tfl_service.refresh_metadata_with_change_detection()
+
+        # Check exception details
+        error = exc_info.value
+        assert "severity_codes" in str(error)
+        assert "changed_types" in error.details
+        assert "severity_codes" in error.details["changed_types"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_metadata_with_change_detection_categories_changed(
+    db_session: AsyncSession,
+) -> None:
+    """Test refresh detects when disruption categories change."""
+    now = datetime.now(UTC)
+
+    # Create initial metadata
+    severity_code = SeverityCode(
+        mode_id="tube",
+        severity_level=10,
+        description="Severe Delays",
+        last_updated=now,
+    )
+    category_before = DisruptionCategory(
+        category_name="RealTime",
+        description="Real-time disruption",
+        last_updated=now,
+    )
+    stop_type = StopType(
+        type_name="NaptanMetroStation",
+        description="Metro station",
+        last_updated=now,
+    )
+
+    db_session.add_all([severity_code, category_before, stop_type])
+    await db_session.commit()
+
+    # Create service
+    tfl_service = TfLService(db=db_session)
+
+    # Mock fetch methods - categories have NEW item
+    # Return fresh instances to avoid session conflicts
+    with (
+        patch.object(
+            tfl_service,
+            "fetch_severity_codes",
+            new_callable=AsyncMock,
+            return_value=[
+                SeverityCode(mode_id="tube", severity_level=10, description="Severe Delays", last_updated=now)
+            ],
+        ),
+        patch.object(
+            tfl_service,
+            "fetch_disruption_categories",
+            new_callable=AsyncMock,
+            return_value=[
+                DisruptionCategory(category_name="RealTime", description="Real-time disruption", last_updated=now),
+                DisruptionCategory(
+                    category_name="PlannedWork", description="Planned work", last_updated=now
+                ),  # Added item
+            ],
+        ),
+        patch.object(
+            tfl_service,
+            "fetch_stop_types",
+            new_callable=AsyncMock,
+            return_value=[StopType(type_name="NaptanMetroStation", description="Metro station", last_updated=now)],
+        ),
+    ):
+        # Should raise exception when changes detected
+        with pytest.raises(MetadataChangeDetectedError) as exc_info:
+            await tfl_service.refresh_metadata_with_change_detection()
+
+        error = exc_info.value
+        assert "disruption_categories" in str(error)
+        assert "disruption_categories" in error.details["changed_types"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_metadata_with_change_detection_multiple_changes(
+    db_session: AsyncSession,
+) -> None:
+    """Test refresh detects when multiple metadata types change."""
+    now = datetime.now(UTC)
+
+    # Create initial metadata
+    severity_code_before = SeverityCode(
+        mode_id="tube",
+        severity_level=10,
+        description="Severe Delays",
+        last_updated=now,
+    )
+    category_before = DisruptionCategory(
+        category_name="RealTime",
+        description="Real-time disruption",
+        last_updated=now,
+    )
+    stop_type_before = StopType(
+        type_name="NaptanMetroStation",
+        description="Metro station",
+        last_updated=now,
+    )
+
+    db_session.add_all([severity_code_before, category_before, stop_type_before])
+    await db_session.commit()
+
+    # Create service
+    tfl_service = TfLService(db=db_session)
+
+    # Mock fetch methods - ALL have changes
+    with (
+        patch.object(
+            tfl_service,
+            "fetch_severity_codes",
+            new_callable=AsyncMock,
+            return_value=[
+                SeverityCode(mode_id="tube", severity_level=10, description="Severe Delays", last_updated=now),
+                SeverityCode(mode_id="tube", severity_level=6, description="Minor", last_updated=now),
+            ],
+        ),
+        patch.object(
+            tfl_service,
+            "fetch_disruption_categories",
+            new_callable=AsyncMock,
+            return_value=[
+                DisruptionCategory(category_name="RealTime", description="Real-time disruption", last_updated=now),
+                DisruptionCategory(category_name="Planned", description="Planned", last_updated=now),
+            ],
+        ),
+        patch.object(
+            tfl_service,
+            "fetch_stop_types",
+            new_callable=AsyncMock,
+            return_value=[
+                StopType(type_name="NaptanMetroStation", description="Metro station", last_updated=now),
+                StopType(type_name="NaptanRail", description="Rail", last_updated=now),
+            ],
+        ),
+    ):
+        # Should raise exception with all changes listed
+        with pytest.raises(MetadataChangeDetectedError) as exc_info:
+            await tfl_service.refresh_metadata_with_change_detection()
+
+        error = exc_info.value
+        assert len(error.details["changed_types"]) == 3
+        assert "severity_codes" in error.details["changed_types"]
+        assert "disruption_categories" in error.details["changed_types"]
+        assert "stop_types" in error.details["changed_types"]
+
+
+@pytest.mark.asyncio
+async def test_refresh_metadata_with_change_detection_empty_database(
+    db_session: AsyncSession,
+) -> None:
+    """Test refresh when database is initially empty."""
+    now = datetime.now(UTC)
+
+    # No initial data in database
+
+    # Create service
+    tfl_service = TfLService(db=db_session)
+
+    # Mock fetch methods to return data
+    with (
+        patch.object(
+            tfl_service,
+            "fetch_severity_codes",
+            new_callable=AsyncMock,
+            return_value=[SeverityCode(mode_id="tube", severity_level=10, description="Severe", last_updated=now)],
+        ),
+        patch.object(
+            tfl_service,
+            "fetch_disruption_categories",
+            new_callable=AsyncMock,
+            return_value=[DisruptionCategory(category_name="RealTime", description="Real-time", last_updated=now)],
+        ),
+        patch.object(
+            tfl_service,
+            "fetch_stop_types",
+            new_callable=AsyncMock,
+            return_value=[StopType(type_name="NaptanMetroStation", description="Metro", last_updated=now)],
+        ),
+    ):
+        # Should raise exception because empty -> populated is a change
+        with pytest.raises(MetadataChangeDetectedError) as exc_info:
+            await tfl_service.refresh_metadata_with_change_detection()
+
+        error = exc_info.value
+        # All three types changed (empty to populated)
+        assert len(error.details["changed_types"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_refresh_metadata_with_change_detection_preserves_commit_on_exception(
+    db_session: AsyncSession,
+) -> None:
+    """Test that fetch methods still commit data even when exception is raised."""
+    now = datetime.now(UTC)
+
+    # Create initial metadata
+    severity_code_before = SeverityCode(
+        mode_id="tube",
+        severity_level=10,
+        description="Severe Delays",
+        last_updated=now,
+    )
+
+    db_session.add(severity_code_before)
+    await db_session.commit()
+
+    # Count records before
+    count_before = (await db_session.execute(select(SeverityCode))).scalars().all()
+    assert len(count_before) == 1
+
+    # Create service
+    tfl_service = TfLService(db=db_session)
+
+    # Mock fetch methods to return DIFFERENT data (will cause exception)
+    # BUT fetch_severity_codes internally commits to database
+
+    async def mock_fetch_severity_codes(use_cache: bool = True) -> list[SeverityCode]:
+        # Simulate fetch method adding to database
+        new_code = SeverityCode(
+            mode_id="tube",
+            severity_level=6,
+            description="Minor Delays",
+            last_updated=now,
+        )
+        db_session.add(new_code)
+        await db_session.commit()
+        # Return both old and new
+        return [
+            SeverityCode(mode_id="tube", severity_level=10, description="Severe Delays", last_updated=now),
+            new_code,
+        ]
+
+    with (
+        patch.object(
+            tfl_service,
+            "fetch_severity_codes",
+            side_effect=mock_fetch_severity_codes,
+        ),
+        patch.object(
+            tfl_service,
+            "fetch_disruption_categories",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch.object(
+            tfl_service,
+            "fetch_stop_types",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        pytest.raises(MetadataChangeDetectedError),
+    ):
+        # Should raise exception
+        await tfl_service.refresh_metadata_with_change_detection()
+
+    # Check that new data WAS committed (fetch methods commit independently)
+    count_after = (await db_session.execute(select(SeverityCode))).scalars().all()
+    assert len(count_after) == 2, "Fetch method should have committed new data"
+
+
+@pytest.mark.asyncio
+async def test_refresh_metadata_with_change_detection_http_exception(
+    db_session: AsyncSession,
+) -> None:
+    """Test refresh handles HTTPException from fetch methods."""
+    now = datetime.now(UTC)
+
+    # Create initial metadata
+    severity_code = SeverityCode(
+        mode_id="tube",
+        severity_level=10,
+        description="Severe Delays",
+        last_updated=now,
+    )
+
+    db_session.add(severity_code)
+    await db_session.commit()
+
+    # Create service
+    tfl_service = TfLService(db=db_session)
+
+    # Mock fetch_severity_codes to raise HTTPException
+    with (
+        patch.object(
+            tfl_service,
+            "fetch_severity_codes",
+            new_callable=AsyncMock,
+            side_effect=HTTPException(status_code=503, detail="TfL API unavailable"),
+        ),
+    ):
+        # Should re-raise HTTPException
+        with pytest.raises(HTTPException) as exc_info:
+            await tfl_service.refresh_metadata_with_change_detection()
+
+        assert exc_info.value.status_code == 503
+        assert "TfL API unavailable" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_refresh_metadata_with_change_detection_generic_exception(
+    db_session: AsyncSession,
+) -> None:
+    """Test refresh handles generic exceptions from fetch methods."""
+    now = datetime.now(UTC)
+
+    # Create initial metadata
+    severity_code = SeverityCode(
+        mode_id="tube",
+        severity_level=10,
+        description="Severe Delays",
+        last_updated=now,
+    )
+
+    db_session.add(severity_code)
+    await db_session.commit()
+
+    # Create service
+    tfl_service = TfLService(db=db_session)
+
+    # Mock fetch_severity_codes to raise generic exception
+    with (
+        patch.object(
+            tfl_service,
+            "fetch_severity_codes",
+            new_callable=AsyncMock,
+            side_effect=ValueError("Unexpected error"),
+        ),
+    ):
+        # Should wrap in HTTPException
+        with pytest.raises(HTTPException) as exc_info:
+            await tfl_service.refresh_metadata_with_change_detection()
+
+        assert exc_info.value.status_code == 503
+        assert "Failed to refresh TfL metadata" in exc_info.value.detail


### PR DESCRIPTION
resolves #218

## Summary by Sourcery

Implement scheduled daily refresh of TfL metadata and network graph with strict change detection. Introduce hash‐based comparison in TflService, custom exception for unexpected metadata changes, new Celery tasks and schedules, worker startup hooks for initial data population, ADR documentation updates, and comprehensive tests.

New Features:
- Schedule daily TfL metadata refresh and network graph rebuild tasks via Celery beat
- Trigger initial metadata and graph population on Celery worker startup

Enhancements:
- Add `_compute_metadata_hash` helper and implement `refresh_metadata_with_change_detection` in `TflService` with `MetadataChangeDetectedError`
- Update Celery schedules and task implementations for strict change detection and graph rebuild workflows

Documentation:
- Document the scheduled TfL data refresh and network graph rebuild strategy in ADR

Tests:
- Add tests for metadata hash computation, change detection logic, and Celery metadata/graph tasks