### PR TITLE
fix: implement soft delete pattern for StationConnection to eliminate 503 window during network graph rebuilds

### DIFF
--- a/backend/alembic/versions/9888a309ff57_add_partial_unique_index_to_station_.py
+++ b/backend/alembic/versions/9888a309ff57_add_partial_unique_index_to_station_.py
@@ -1,0 +1,66 @@
+"""add_partial_unique_index_to_station_connections
+
+Revision ID: 9888a309ff57
+Revises: 7df10ab411af
+Create Date: 2025-11-21 10:38:01.489060
+
+Fix for Issue #230: Replace standard unique constraint with partial unique index
+to enable atomic soft delete operations without flush().
+
+The partial unique index only applies WHERE deleted_at IS NULL, allowing:
+- Soft delete (UPDATE) and INSERT operations in same transaction
+- Atomic commit without intermediate flush()
+- Zero downtime during network graph rebuilds
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import text
+
+# revision identifiers, used by Alembic.
+revision: str = "9888a309ff57"
+down_revision: str | Sequence[str] | None = "7df10ab411af"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Replace standard unique constraint with partial unique index on station_connections.
+    This allows soft-deleted records to accumulate while maintaining uniqueness for
+    active records only.
+    """
+    # Drop the existing unique constraint
+    op.drop_constraint("uq_station_connection", "station_connections", type_="unique")
+
+    # Create partial unique index (only applies WHERE deleted_at IS NULL)
+    # This allows multiple soft-deleted records with same (from, to, line)
+    # but enforces uniqueness for active records
+    op.create_index(
+        "uq_station_connection_active",
+        "station_connections",
+        ["from_station_id", "to_station_id", "line_id"],
+        unique=True,
+        postgresql_where=text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Restore original unique constraint. Note: This will fail if there are
+    multiple soft-deleted records with the same (from, to, line) combination.
+    """
+    # Drop the partial unique index
+    op.drop_index("uq_station_connection_active", table_name="station_connections")
+
+    # Recreate the original unique constraint
+    # WARNING: This will fail if soft-deleted duplicates exist
+    op.create_unique_constraint(
+        "uq_station_connection",
+        "station_connections",
+        ["from_station_id", "to_station_id", "line_id"],
+    )

--- a/backend/app/celery/app.py
+++ b/backend/app/celery/app.py
@@ -104,6 +104,7 @@ def trigger_startup_tasks(
 
         # Trigger network graph rebuild immediately
         # This populates lines, stations, connections tables
+        # Re-enabled after fixing #230 - now uses soft delete to eliminate 503 window
         celery_app.send_task("app.celery.tasks.rebuild_network_graph")
         logger.info("worker_startup_graph_rebuild_triggered")
 

--- a/backend/app/services/tfl_service.py
+++ b/backend/app/services/tfl_service.py
@@ -2579,9 +2579,7 @@ class TfLService:
             # Use soft delete instead of hard delete to eliminate 503 window during rebuild.
             # Old connections remain visible until new connections are committed (issue #230).
             await self.db.execute(
-                update(StationConnection)
-                .where(StationConnection.deleted_at.is_(None))
-                .values(deleted_at=datetime.now(UTC))
+                update(StationConnection).where(StationConnection.deleted_at.is_(None)).values(deleted_at=func.now())
             )
             # No flush() needed! Partial unique index (WHERE deleted_at IS NULL) allows
             # soft-deleted and new records to coexist until commit. This enables atomic

--- a/backend/app/services/tfl_service.py
+++ b/backend/app/services/tfl_service.py
@@ -40,7 +40,7 @@ from pydantic_tfl_api.models import (
     Line as TflLine,
 )
 from redis.exceptions import RedisError
-from sqlalchemy import delete, func, or_, select
+from sqlalchemy import delete, func, or_, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -2265,6 +2265,7 @@ class TfLService:
                 StationConnection.from_station_id == from_station_id,
                 StationConnection.to_station_id == to_station_id,
                 StationConnection.line_id == line_id,
+                StationConnection.deleted_at.is_(None),  # Only check active connections
             )
         )
         return result.scalar_one_or_none() is not None
@@ -2574,12 +2575,18 @@ class TfLService:
 
             logger.info("stations_validated", station_count=station_count)
 
-            # Clear existing connections (within transaction - will rollback if building fails)
-            await self.db.execute(delete(StationConnection))
-            # Required: flush prevents unique constraint violations when rebuilding connections.
-            # Without this, SQLAlchemy may reorder operations causing duplicate key errors.
-            await self.db.flush()
-            logger.info("existing_connections_cleared")
+            # Soft delete existing connections (within transaction - will rollback if building fails)
+            # Use soft delete instead of hard delete to eliminate 503 window during rebuild.
+            # Old connections remain visible until new connections are committed (issue #230).
+            await self.db.execute(
+                update(StationConnection)
+                .where(StationConnection.deleted_at.is_(None))
+                .values(deleted_at=datetime.now(UTC))
+            )
+            # No flush() needed! Partial unique index (WHERE deleted_at IS NULL) allows
+            # soft-deleted and new records to coexist until commit. This enables atomic
+            # transition with zero downtime.
+            logger.info("existing_connections_soft_deleted")
 
             stations_set: set[str] = set()
             pending_connections: set[tuple[uuid.UUID, uuid.UUID, uuid.UUID]] = set()
@@ -2683,8 +2690,10 @@ class TfLService:
         logger.info("fetching_network_graph")
 
         try:
-            # Check if graph exists
-            result = await self.db.execute(select(StationConnection).limit(1))
+            # Check if graph exists (filter out soft-deleted connections)
+            result = await self.db.execute(
+                select(StationConnection).where(StationConnection.deleted_at.is_(None)).limit(1)
+            )
             if not result.scalar_one_or_none():
                 raise HTTPException(
                     status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -2692,6 +2701,7 @@ class TfLService:
                 )
 
             # Get all connections with from_station, to_station, and line data using aliased joins
+            # Filter out soft-deleted connections
             from_station_alias = aliased(Station)
             to_station_alias = aliased(Station)
 
@@ -2700,6 +2710,7 @@ class TfLService:
                 .join(from_station_alias, from_station_alias.id == StationConnection.from_station_id)
                 .join(to_station_alias, to_station_alias.id == StationConnection.to_station_id)
                 .join(Line, Line.id == StationConnection.line_id)
+                .where(StationConnection.deleted_at.is_(None))
             )
             connections = result.all()
 

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -344,7 +344,8 @@ class TestTfLModels:
         db_session.add_all([line, station1, station2, connection])
         await db_session.commit()
 
-        result = await db_session.execute(select(StationConnection))
+        # Query for active connection (filter out soft-deleted)
+        result = await db_session.execute(select(StationConnection).where(StationConnection.deleted_at.is_(None)))
         saved_connection = result.scalar_one()
 
         assert saved_connection.from_station_id == station1.id

--- a/backend/tests/test_network_graph_rebuild_isolation.py
+++ b/backend/tests/test_network_graph_rebuild_isolation.py
@@ -1,0 +1,215 @@
+"""
+Tests for network graph rebuild isolation using soft delete pattern.
+
+These tests verify that the soft delete pattern eliminates the 503 window during
+network graph rebuilds (Issue #230). The key scenarios tested are:
+
+1. get_network_graph() correctly filters soft-deleted connections
+2. Soft-deleted records are properly marked with deleted_at timestamp
+3. _connection_exists() only considers active connections
+"""
+
+from datetime import UTC, datetime
+
+import pytest
+from app.models.tfl import Line, Station, StationConnection
+from app.services.tfl_service import TfLService
+from fastapi import HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Helper Functions
+
+
+async def create_test_line(db_session: AsyncSession, tfl_id: str = "victoria", name: str = "Victoria") -> Line:
+    """Create a test line in the database."""
+    line = Line(tfl_id=tfl_id, name=name, mode="tube", last_updated=datetime.now(UTC))
+    db_session.add(line)
+    await db_session.commit()
+    await db_session.refresh(line)
+    return line
+
+
+async def create_test_station(
+    db_session: AsyncSession,
+    tfl_id: str = "940GZZLUVIC",
+    name: str = "Victoria Underground Station",
+    latitude: float = 51.4963,
+    longitude: float = -0.1441,
+) -> Station:
+    """Create a test station in the database."""
+    station = Station(
+        tfl_id=tfl_id,
+        name=name,
+        latitude=latitude,
+        longitude=longitude,
+        lines=[],
+        last_updated=datetime.now(UTC),
+    )
+    db_session.add(station)
+    await db_session.commit()
+    await db_session.refresh(station)
+    return station
+
+
+async def create_test_connection(
+    db_session: AsyncSession,
+    from_station: Station,
+    to_station: Station,
+    line: Line,
+) -> StationConnection:
+    """Create a test station connection in the database."""
+    connection = StationConnection(
+        from_station_id=from_station.id,
+        to_station_id=to_station.id,
+        line_id=line.id,
+    )
+    db_session.add(connection)
+    await db_session.commit()
+    await db_session.refresh(connection)
+    return connection
+
+
+async def count_active_connections(db_session: AsyncSession) -> int:
+    """Count active (non-deleted) station connections."""
+    result = await db_session.execute(select(StationConnection).where(StationConnection.deleted_at.is_(None)))
+    return len(result.scalars().all())
+
+
+async def count_deleted_connections(db_session: AsyncSession) -> int:
+    """Count soft-deleted station connections."""
+    result = await db_session.execute(select(StationConnection).where(StationConnection.deleted_at.isnot(None)))
+    return len(result.scalars().all())
+
+
+async def count_all_connections(db_session: AsyncSession) -> int:
+    """Count all station connections (active + deleted)."""
+    result = await db_session.execute(select(StationConnection))
+    return len(result.scalars().all())
+
+
+# Test Fixtures
+
+
+@pytest.fixture
+async def setup_initial_graph(db_session: AsyncSession) -> tuple[Line, Station, Station, StationConnection]:
+    """Set up an initial graph with one line, two stations, and one connection."""
+    line = await create_test_line(db_session, tfl_id="victoria", name="Victoria")
+    station1 = await create_test_station(db_session, tfl_id="940GZZLUVIC", name="Victoria")
+    station2 = await create_test_station(db_session, tfl_id="940GZZLUGPK", name="Green Park")
+    connection = await create_test_connection(db_session, station1, station2, line)
+
+    return line, station1, station2, connection
+
+
+# Tests
+
+
+@pytest.mark.asyncio
+async def test_get_network_graph_filters_soft_deleted_connections(
+    db_session: AsyncSession,
+    setup_initial_graph: tuple[Line, Station, Station, StationConnection],
+) -> None:
+    """Test that get_network_graph() filters out soft-deleted connections."""
+    _line, station1, station2, connection = setup_initial_graph
+
+    # Create TfL service
+    tfl_service = TfLService(db=db_session)
+
+    # Get network graph - should return the active connection
+    graph = await tfl_service.get_network_graph()
+    assert station1.tfl_id in graph
+    assert len(graph[station1.tfl_id]) == 1
+    assert graph[station1.tfl_id][0].station_tfl_id == station2.tfl_id
+
+    # Soft delete the connection
+    connection.deleted_at = datetime.now(UTC)
+    await db_session.commit()
+
+    # Get network graph again - should raise 503 (no active connections)
+    with pytest.raises(HTTPException) as exc_info:
+        await tfl_service.get_network_graph()
+    assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+
+
+@pytest.mark.asyncio
+async def test_soft_deleted_connections_behavior(
+    db_session: AsyncSession,
+    setup_initial_graph: tuple[Line, Station, Station, StationConnection],
+) -> None:
+    """
+    Test that soft-deleted connections accumulate and can be queried separately.
+
+    This verifies the database behavior for soft delete - connections are marked
+    with deleted_at timestamp but remain in the table.
+    """
+    line, _station1, station2, initial_connection = setup_initial_graph
+
+    # Verify initial state
+    assert await count_active_connections(db_session) == 1
+    assert await count_deleted_connections(db_session) == 0
+
+    # Soft delete the connection manually (simulating what build_station_graph does)
+    initial_connection.deleted_at = datetime.now(UTC)
+    await db_session.commit()
+
+    # Verify soft delete worked
+    assert await count_active_connections(db_session) == 0  # No active connections
+    assert await count_deleted_connections(db_session) == 1  # One deleted connection
+    assert await count_all_connections(db_session) == 1  # Still exists in table
+
+    # Create a new connection with different endpoints (simulating rebuild creating new connections)
+    # Note: We use different stations because the partial unique index on (from, to, line)
+    # WHERE deleted_at IS NULL allows this (soft-deleted connections excluded from index)
+    station3 = await create_test_station(db_session, tfl_id="940GZZLUOXC", name="Oxford Circus")
+    await create_test_connection(db_session, station2, station3, line)
+
+    # Verify we now have both old (deleted) and new (active) connections
+    assert await count_active_connections(db_session) == 1  # New connection
+    assert await count_deleted_connections(db_session) == 1  # Old connection still there
+    assert await count_all_connections(db_session) == 2  # Total: 1 active + 1 deleted
+
+
+@pytest.mark.asyncio
+async def test_connection_exists_ignores_soft_deleted(
+    db_session: AsyncSession,
+    setup_initial_graph: tuple[Line, Station, Station, StationConnection],
+) -> None:
+    """Test that _connection_exists() only checks active connections."""
+    line, station1, station2, connection = setup_initial_graph
+
+    tfl_service = TfLService(db=db_session)
+
+    # Verify connection exists when active
+    exists = await tfl_service._connection_exists(station1.id, station2.id, line.id)
+    assert exists is True
+
+    # Soft delete the connection
+    connection.deleted_at = datetime.now(UTC)
+    await db_session.commit()
+
+    # Verify connection does NOT exist after soft delete
+    exists = await tfl_service._connection_exists(station1.id, station2.id, line.id)
+    assert exists is False
+
+
+@pytest.mark.asyncio
+async def test_new_connections_have_null_deleted_at(
+    db_session: AsyncSession,
+    setup_initial_graph: tuple[Line, Station, Station, StationConnection],
+) -> None:
+    """Test that newly created connections have deleted_at=NULL by default."""
+    line, _station1, station2, _initial_connection = setup_initial_graph
+
+    # Create a new connection (simulating what build_station_graph does)
+    station3 = await create_test_station(db_session, tfl_id="940GZZLUOXC", name="Oxford Circus")
+    new_connection = await create_test_connection(db_session, station2, station3, line)
+
+    # Verify the new connection has deleted_at=NULL
+    assert new_connection.deleted_at is None
+
+    # Verify we can query it as an active connection
+    result = await db_session.execute(select(StationConnection).where(StationConnection.deleted_at.is_(None)))
+    active_connections = result.scalars().all()
+    assert len(active_connections) == 2  # Initial + new connection
+    assert new_connection.id in {conn.id for conn in active_connections}

--- a/backend/tests/test_tfl_integration.py
+++ b/backend/tests/test_tfl_integration.py
@@ -241,8 +241,8 @@ async def test_integration_build_station_graph(db_session: AsyncSession, setting
     assert result["stations_count"] > 0, "Should find at least one station"
     assert result["connections_count"] > 0, "Should create at least one connection"
 
-    # Verify database has connections
-    db_result = await db_session.execute(select(StationConnection))
+    # Verify database has connections (filter out soft-deleted)
+    db_result = await db_session.execute(select(StationConnection).where(StationConnection.deleted_at.is_(None)))
     db_connections = db_result.scalars().all()
     assert len(db_connections) > 0, "Connections should be persisted to database"
     assert len(db_connections) == result["connections_count"], "Connection count should match"

--- a/backend/tests/test_tfl_service.py
+++ b/backend/tests/test_tfl_service.py
@@ -3853,8 +3853,10 @@ async def test_build_station_graph(
         stations = stations_result.scalars().all()
         assert len(stations) == 3
 
-        # Verify connections were created in database
-        connections_result = await db_session.execute(select(StationConnection))
+        # Verify connections were created in database (filter out soft-deleted)
+        connections_result = await db_session.execute(
+            select(StationConnection).where(StationConnection.deleted_at.is_(None))
+        )
         connections = connections_result.scalars().all()
         assert len(connections) == 4
 
@@ -4059,8 +4061,10 @@ async def test_build_station_graph_no_duplicate_connections(
         assert result["stations_count"] == 3
         assert result["connections_count"] == 4, "Should create exactly 4 connections, not duplicates"
 
-        # Verify in database - should have exactly 4 connections
-        connections_result = await db_session.execute(select(StationConnection))
+        # Verify in database - should have exactly 4 connections (filter out soft-deleted)
+        connections_result = await db_session.execute(
+            select(StationConnection).where(StationConnection.deleted_at.is_(None))
+        )
         connections = connections_result.scalars().all()
         assert len(connections) == 4, "Database should have exactly 4 connections"
 

--- a/docs/adr/07-external-apis.md
+++ b/docs/adr/07-external-apis.md
@@ -407,7 +407,7 @@ During rebuild:
 - All `StationConnection` queries must filter `deleted_at.is_(None)` for correctness
 - Slightly larger table size (mitigated: daily rebuilds = ~365 old graphs per year = minimal)
 - Requires partial index migration (PostgreSQL-specific feature)
-- Future cleanup task may be needed if growth becomes issue (deferred as YAGNI)
+- Future cleanup task may be needed if growth becomes an issue (deferred as YAGNI)
 
 ### Related Decisions
 - Builds on "Admin Endpoint for Graph Building" (scheduled rebuilds via Celery)


### PR DESCRIPTION
resolves #230

## Summary by Sourcery

Implement a soft delete strategy for station network connections to avoid downtime during network graph rebuilds and document the new approach.

Bug Fixes:
- Eliminate the 503 error window during network graph rebuilds by keeping existing station connections visible until new ones are committed.

Enhancements:
- Adopt a partial unique index on active station connections to support atomic soft deletes and rebuilds.
- Ensure all station connection queries and helpers only consider non-deleted records for network graph operations.
- Re-enable the startup Celery task that rebuilds the network graph now that rebuilds are zero-downtime.

Build:
- Add an Alembic migration to replace the station connection unique constraint with a partial unique index scoped to non-deleted records.

Documentation:
- Document the soft delete pattern with a partial unique index for network graph rebuilds in the external APIs ADR, including rationale and consequences.

Tests:
- Add dedicated tests to verify isolation behavior during network graph rebuilds and correct handling of soft-deleted connections.
- Update existing unit and integration tests to assert against active (non-deleted) station connections only.