### PR TITLE
fix: replace delete-all with upsert in fetch_lines to prevent FK violations (#272)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,8 @@ repos:
       - id: check-added-large-files
         args: ['--maxkb=500']
       - id: forbid-new-submodules
+      - id: no-commit-to-branch
+        args: ['--branch', 'main']
 
   # Prevent .env files in root directory
   - repo: local

--- a/backend/alembic/versions/cf589f9baac2_add_line_change_logs_table.py
+++ b/backend/alembic/versions/cf589f9baac2_add_line_change_logs_table.py
@@ -1,0 +1,106 @@
+"""add_line_change_logs_table
+
+Revision ID: cf589f9baac2
+Revises: 237745010854
+Create Date: 2025-11-28 09:52:28.770124
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "cf589f9baac2"
+down_revision: str | Sequence[str] | None = "237745010854"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "line_change_logs",
+        sa.Column(
+            "tfl_id",
+            sa.String(length=50),
+            nullable=False,
+            comment="TfL line ID (e.g., 'victoria', 'northern')",
+        ),
+        sa.Column(
+            "change_type",
+            sa.String(length=20),
+            nullable=False,
+            comment="Type of change: 'created', 'updated'",
+        ),
+        sa.Column(
+            "changed_fields",
+            sa.JSON(),
+            nullable=False,
+            comment="List of fields that changed: ['name', 'mode', 'route_variants']",
+        ),
+        sa.Column(
+            "old_values",
+            sa.JSON(),
+            nullable=True,
+            comment="Previous values of changed fields (NULL for 'created')",
+        ),
+        sa.Column(
+            "new_values",
+            sa.JSON(),
+            nullable=False,
+            comment="New values of changed fields",
+        ),
+        sa.Column(
+            "detected_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            comment="When this change was detected",
+        ),
+        sa.Column(
+            "trace_id",
+            sa.String(length=32),
+            nullable=True,
+            comment="OpenTelemetry trace ID for correlation with distributed traces",
+        ),
+        sa.Column("id", sa.UUID(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    # Create indexes
+    op.create_index(
+        "ix_line_change_logs_tfl_detected",
+        "line_change_logs",
+        ["tfl_id", "detected_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_line_change_logs_tfl_id"),
+        "line_change_logs",
+        ["tfl_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_line_change_logs_detected_at"),
+        "line_change_logs",
+        ["detected_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_line_change_logs_trace_id"),
+        "line_change_logs",
+        ["trace_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_line_change_logs_trace_id"), table_name="line_change_logs")
+    op.drop_index(op.f("ix_line_change_logs_detected_at"), table_name="line_change_logs")
+    op.drop_index(op.f("ix_line_change_logs_tfl_id"), table_name="line_change_logs")
+    op.drop_index("ix_line_change_logs_tfl_detected", table_name="line_change_logs")
+    op.drop_table("line_change_logs")

--- a/backend/app/models/tfl.py
+++ b/backend/app/models/tfl.py
@@ -365,7 +365,6 @@ class LineChangeLog(BaseModel):
     tfl_id: Mapped[str] = mapped_column(
         String(50),
         nullable=False,
-        index=True,
         comment="TfL line ID (e.g., 'victoria', 'northern')",
     )
     change_type: Mapped[str] = mapped_column(
@@ -391,13 +390,11 @@ class LineChangeLog(BaseModel):
     detected_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
-        index=True,
         comment="When this change was detected",
     )
     trace_id: Mapped[str | None] = mapped_column(
         String(32),
         nullable=True,
-        index=True,
         comment="OpenTelemetry trace ID for correlation with distributed traces",
     )
 

--- a/backend/tests/test_tfl_service.py
+++ b/backend/tests/test_tfl_service.py
@@ -6093,15 +6093,17 @@ async def test_store_line_routes_regular_service(db_session: AsyncSession) -> No
     routes = line.route_variants["routes"]
     assert len(routes) == 2
 
+    # Find routes by direction (order is deterministic but based on station sorting)
+    inbound = next(r for r in routes if r["direction"] == "inbound")
+    outbound = next(r for r in routes if r["direction"] == "outbound")
+
     # Check inbound route
-    inbound = routes[0]
     assert inbound["name"] == "Walthamstow Central → Brixton"
     assert inbound["service_type"] == "Regular"
     assert inbound["direction"] == "inbound"
     assert inbound["stations"] == ["940GZZLUWAC", "940GZZLUVIC", "940GZZLUBXN"]
 
     # Check outbound route
-    outbound = routes[1]
     assert outbound["name"] == "Brixton → Walthamstow Central"
     assert outbound["service_type"] == "Regular"
     assert outbound["direction"] == "outbound"


### PR DESCRIPTION
## Summary

Fixes #272 by replacing the destructive `DELETE FROM lines` pattern with an upsert approach, preventing FK violations when user routes reference lines. Additionally implements comprehensive change logging for line metadata and performance optimization to eliminate N+1 queries.

## Changes

### Core Fix (Commit 1: fb1b832)
- **Replaced delete-all with upsert**: Changed `fetch_lines()` from `DELETE FROM lines` followed by `INSERT` to `INSERT ... ON CONFLICT DO UPDATE`
- **Added LineChangeLog model**: New table to track line metadata changes (name, mode, route_variants)
- **Implemented change detection**: Logs when line properties change with old/new values
- **Added OpenTelemetry correlation**: Stores trace_id with each change for distributed tracing
- **Deterministic route_variants**: Sorts route variants to prevent false change detection
- **Migration**: Created `cf589f9baac2_add_line_change_logs_table.py`

### Bug Fix (Commit 2: 7b8630e)
- **Fixed route_variants storage**: Corrected normalization to preserve full route metadata instead of just station IDs
- **Fixed test compatibility**: Updated test to find routes by direction instead of assuming order
- **Fixed OTEL test mocks**: Updated mock_db_session to handle new upsert query pattern

### Performance Optimization (Commit 3: ee41a36)
- **Eliminated N+1 queries**: Batch fetch existing lines per mode using `WHERE IN` instead of individual SELECTs
- **Order preservation**: Use dict lookup to maintain original processing order after batch query
- **Reduced query count**: From ~3N queries (per line) to ~3 queries per mode
- **Updated OTEL mocks**: Added `scalars().all()` support for batch query pattern

## Technical Details

**Before:**
- Per line: 1 SELECT (check exists) + 1 INSERT/UPDATE + 1 SELECT (fetch back)
- Total: ~3N queries for N lines
- Risk of FK violations when user routes exist

**After:**
- Per mode: 1 batch SELECT all lines
- Per line: 1 INSERT ON CONFLICT DO UPDATE
- After commit: 1 batch SELECT with populate_existing
- Total: ~3 queries per mode
- No FK violations, stable line UUIDs

## Testing

- All 1413 tests pass
- Added 3 new tests for fetch_lines behavior:
  - `test_fetch_lines_preserves_ids_on_update` - Verifies UUIDs remain stable
  - `test_fetch_lines_with_existing_route_references` - Confirms no FK violations
  - `test_fetch_lines_logs_changes` - Validates change logging
- Added 3 telemetry tests for trace_id extraction

## Files Changed

- `backend/app/models/tfl.py` - Added LineChangeLog model
- `backend/app/services/tfl_service.py` - Upsert implementation, change logging, performance optimization
- `backend/app/core/telemetry.py` - Added get_current_trace_id() helper
- `backend/alembic/versions/cf589f9baac2_add_line_change_logs_table.py` - New migration
- `backend/tests/test_tfl_service.py` - Added tests for new functionality
- `backend/tests/test_telemetry.py` - Added tests and fixture
- `backend/tests/services/test_tfl_otel.py` - Updated mocks

## Migration

```bash
cd backend
uv run alembic upgrade head
```

Closes #272

## Summary by Sourcery

Switch line fetching to an upsert-based, telemetry-aware flow that preserves existing references, logs line metadata changes, and improves performance while tightening pre-commit safeguards.

New Features:
- Add a LineChangeLog model and migration to track line metadata and route variant changes with timestamps and trace IDs for observability.
- Expose a get_current_trace_id helper to retrieve the active OpenTelemetry trace ID for correlating application behavior with traces.

Bug Fixes:
- Update fetch_lines to preserve line IDs and avoid foreign key violations when user routes reference existing lines.
- Normalize and store route variants deterministically so downstream consumers and change detection see stable data ordering.
- Adjust tests to locate routes by direction rather than assuming list order from the TfL API.

Enhancements:
- Refactor fetch_lines to batch-load and upsert lines by TfL ID, significantly reducing query count and eliminating N+1 lookups.
- Add structured logging for line route variant changes to aid debugging and data quality analysis.
- Improve telemetry utilities and tests to align with OpenTelemetry behavior when no span is active and when spans are active.

Build:
- Enable the no-commit-to-branch pre-commit hook to prevent direct commits to the main branch.

Tests:
- Add new tests covering line ID stability, behavior with existing route references, and line change logging during fetch_lines.
- Extend telemetry tests to cover current span semantics and trace ID extraction.
- Update OTEL service tests and database session mocks to support the new upsert and batch query patterns used by fetch_lines.