### PR TITLE
refactor: simplify gh_pr_comment_action.sh and add full ID support

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -97,7 +97,7 @@
     "deny": [
       "Bash(npx dotenv-vault@latest keys:*)",
       "Bash(git commit --amend:*)",
-      "Read(settings.json)"
+      "Read(.claude/settings.json)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -85,6 +85,7 @@
       "Bash(gh issue view:*)",
       "Bash(gh pr view:*)",
       "Bash(./scripts/gh_pr_comment_action.sh:*)",
+      "Bash(./scripts/gh_pr_comments_fetch.sh:*)",
       "WebFetch",
       "WebSearch"
     ],
@@ -95,7 +96,8 @@
     ],
     "deny": [
       "Bash(npx dotenv-vault@latest keys:*)",
-      "Bash(git commit --amend:*)"
+      "Bash(git commit --amend:*)",
+      "Read(settings.json)"
     ]
   }
 }

--- a/scripts/gh_pr_comment_action.sh
+++ b/scripts/gh_pr_comment_action.sh
@@ -268,11 +268,11 @@ action_resolve() {
         # Numeric comment database ID - use REST API to post reply, then resolve
         thread_id=$(get_thread_id_from_comment "$pr_number" "$id")
         post_reply_rest "$pr_number" "$id" "$response_text"
-    elif [[ "$id" =~ ^PRRT_[a-zA-Z0-9]+$ ]]; then
+    elif [[ "$id" =~ ^PRRT_[a-zA-Z0-9_-]+$ ]]; then
         # Thread ID - use GraphQL for both reply and resolve
         thread_id="$id"
         post_reply_graphql "$thread_id" "$response_text"
-    elif [[ "$id" =~ ^PRRC_[a-zA-Z0-9]+$ ]]; then
+    elif [[ "$id" =~ ^PRRC_[a-zA-Z0-9_-]+$ ]]; then
         # Comment node ID - convert to databaseId, then use REST flow
         local db_id
         db_id=$(get_database_id_from_node "$id")

--- a/scripts/gh_pr_comment_action.sh
+++ b/scripts/gh_pr_comment_action.sh
@@ -4,19 +4,18 @@
 # Wrapper script for GitHub CLI to manage PR review comments and threads
 #
 # Usage:
-#   gh_pr_comment_action.sh <pr_number> <comment_or_thread_id> <action> <response_text>
+#   gh_pr_comment_action.sh <pr_number> <id> <response_text>
 #
 # Arguments:
 #   pr_number           - Pull request number
-#   comment_or_thread_id - Comment ID (numeric) or Thread ID (PRT_xxx format)
-#   action              - Action to perform: respond | resolve | reject | in-progress
-#   response_text       - Response text (required for all actions)
+#   id                  - Comment ID, Thread ID, or Comment Node ID:
+#                         - Numeric comment database ID (e.g., 2566690774)
+#                         - Thread node ID (e.g., PRRT_kwDOQNO0Es5jvUvj)
+#                         - Comment node ID (e.g., PRRC_kwDOQNO0Es6Y_JfW)
+#   response_text       - Response text (required)
 #
-# Actions:
-#   respond     - Post a reply to a review comment
-#   resolve     - Mark a review thread as resolved (posts response then resolves)
-#   reject      - Post a comment marking the thread as rejected
-#   in-progress - Post a comment marking the thread as in-progress
+# Behavior:
+#   Posts a reply to the comment/thread, then marks the review thread as resolved
 #
 # Environment:
 #   GITHUB_TOKEN or gh authentication must be configured
@@ -142,8 +141,8 @@ get_thread_id_from_comment() {
     echo "$thread_id"
 }
 
-# Internal function to post a reply without output (returns comment ID on stdout)
-_post_reply() {
+# Post a reply to a review comment using REST API
+post_reply_rest() {
     local pr_number="$1"
     local comment_id="$2"
     local response_text="$3"
@@ -174,49 +173,111 @@ _post_reply() {
         log_error "Failed to post reply: $error_msg"
         exit 1
     fi
-
-    echo "$new_comment_id"
 }
 
-# Post a reply to a review comment
-action_respond() {
-    local pr_number="$1"
-    local comment_id="$2"
-    local response_text="$3"
+# Post a reply to a review thread using GraphQL
+post_reply_graphql() {
+    local thread_id="$1"
+    local response_text="$2"
 
-    # Call internal function to post reply
-    local new_comment_id
-    new_comment_id=$(_post_reply "$pr_number" "$comment_id" "$response_text")
+    # Use heredoc to avoid quoting issues with GraphQL
+    local body_json
+    body_json=$(echo "$response_text" | jq -Rs '.')
 
-    # Output success with safely constructed JSON
-    local data_json
-    data_json=$(jq -n --arg cid "$new_comment_id" '{comment_id: $cid}')
-    log_success "Reply posted successfully" "$data_json"
+    local response
+    response=$(cat << EOF | gh api graphql --input -
+{
+  "query": "mutation(\$threadId: ID!, \$body: String!) { addPullRequestReviewThreadReply(input: { pullRequestReviewThreadId: \$threadId, body: \$body }) { comment { id } } }",
+  "variables": { "threadId": "$thread_id", "body": $body_json }
+}
+EOF
+)
+    local gh_status=$?
+
+    # Check for errors from gh api command
+    if [[ $gh_status -ne 0 ]]; then
+        log_error "gh api command failed with exit code $gh_status"
+        exit 1
+    fi
+
+    # Check for GraphQL errors
+    if echo "$response" | jq -e '.errors' > /dev/null 2>&1; then
+        local error_msg
+        error_msg=$(echo "$response" | jq -r '.errors[0].message // "Unknown GraphQL error"')
+        log_error "Failed to post reply via GraphQL: $error_msg"
+        exit 1
+    fi
 }
 
-# Resolve a review thread
+# Convert comment node ID to database ID
+get_database_id_from_node() {
+    local node_id="$1"
+
+    local response
+    response=$(cat << EOF | gh api graphql --input -
+{
+  "query": "query(\$nodeId: ID!) { node(id: \$nodeId) { ... on PullRequestReviewComment { databaseId } } }",
+  "variables": { "nodeId": "$node_id" }
+}
+EOF
+)
+    local gh_status=$?
+
+    # Check for errors from gh api command
+    if [[ $gh_status -ne 0 ]]; then
+        log_error "gh api command failed with exit code $gh_status"
+        exit 1
+    fi
+
+    # Check for GraphQL errors
+    if echo "$response" | jq -e '.errors' > /dev/null 2>&1; then
+        local error_msg
+        error_msg=$(echo "$response" | jq -r '.errors[0].message // "Unknown GraphQL error"')
+        log_error "Failed to get database ID from node: $error_msg"
+        exit 1
+    fi
+
+    # Extract database ID
+    local db_id
+    db_id=$(echo "$response" | jq -r '.data.node.databaseId // empty')
+
+    if [[ -z "$db_id" ]]; then
+        log_error "Could not get database ID for node: $node_id"
+        exit 1
+    fi
+
+    echo "$db_id"
+}
+
+# Resolve a review thread (posts reply then resolves)
 action_resolve() {
     local pr_number="$1"
     local id="$2"
     local response_text="$3"
 
-    local comment_id
     local thread_id
 
-    # Check if ID is numeric (comment ID) or thread ID
+    # Determine ID type and handle accordingly
     if [[ "$id" =~ ^[0-9]+$ ]]; then
-        # It's a comment ID - convert to thread ID first
-        comment_id="$id"
-        thread_id=$(get_thread_id_from_comment "$pr_number" "$comment_id")
+        # Numeric comment database ID - use REST API to post reply, then resolve
+        thread_id=$(get_thread_id_from_comment "$pr_number" "$id")
+        post_reply_rest "$pr_number" "$id" "$response_text"
+    elif [[ "$id" =~ ^PRRT_ ]]; then
+        # Thread ID - use GraphQL for both reply and resolve
+        thread_id="$id"
+        post_reply_graphql "$thread_id" "$response_text"
+    elif [[ "$id" =~ ^PRRC_ ]]; then
+        # Comment node ID - convert to databaseId, then use REST flow
+        local db_id
+        db_id=$(get_database_id_from_node "$id")
+        thread_id=$(get_thread_id_from_comment "$pr_number" "$db_id")
+        post_reply_rest "$pr_number" "$db_id" "$response_text"
     else
-        # It's a thread ID - we cannot post a reply without a comment ID
-        log_error "Resolve action requires a numeric comment ID, not a thread ID: $id"
+        log_error "Invalid ID format: $id. Expected numeric ID, PRRT_xxx thread ID, or PRRC_xxx comment ID"
         exit 1
     fi
 
-    # Post the response comment using comment ID (suppress output, we'll output once at the end)
-    _post_reply "$pr_number" "$comment_id" "$response_text" > /dev/null
-
+    # Resolve the thread using GraphQL
     # shellcheck disable=SC2016
     local mutation='mutation($threadId: ID!) {
   resolveReviewThread(input: {threadId: $threadId}) {
@@ -262,55 +323,31 @@ action_resolve() {
     fi
 }
 
-# Post a comment marking thread as rejected (= resolved)
-action_reject() {
-    local pr_number="$1"
-    local comment_id="$2"
-    local response_text="$3"
-
-    # Use respond action to post the rejection comment and resolve the thread
-    action_resolve "$pr_number" "$comment_id" "$response_text"
-}
-
-# Post a comment marking thread as in-progress
-action_in_progress() {
-    local pr_number="$1"
-    local comment_id="$2"
-    local response_text="$3"
-
-    # Use respond action to post the in-progress comment
-    action_respond "$pr_number" "$comment_id" "$response_text"
-}
-
 # Display usage information
 usage() {
     cat << EOF
-Usage: $0 <pr_number> <comment_or_thread_id> <action> <response_text>
+Usage: $0 <pr_number> <id> <response_text>
 
 Arguments:
-  pr_number           Pull request number
-  comment_or_thread_id Comment ID (numeric) or Thread ID (PRT_xxx format)
-  action              Action to perform: respond | resolve | reject | in-progress
-  response_text       Response text (required for all actions)
+  pr_number      Pull request number
+  id             Comment ID, Thread ID, or Comment Node ID:
+                 - Numeric comment database ID (e.g., 2566690774)
+                 - Thread node ID (e.g., PRRT_kwDOQNO0Es5jvUvj)
+                 - Comment node ID (e.g., PRRC_kwDOQNO0Es6Y_JfW)
+  response_text  Response text (required)
 
-Actions:
-  respond     Post a reply to a review comment
-  resolve     Post a response and mark review thread as resolved (auto-converts comment ID to thread ID)
-  reject      Post a comment marking the thread as rejected
-  in-progress Post a comment marking the thread as in-progress
+Behavior:
+  Posts a reply to the comment/thread, then marks the review thread as resolved
 
 Examples:
-  # Reply to a comment
-  $0 123 456789 respond "Fixed in commit abc123"
+  # Resolve with numeric comment ID
+  $0 123 456789 "Fixed in commit abc123"
 
-  # Resolve a thread by comment ID
-  $0 123 456789 resolve "Addressed in latest commit"
+  # Resolve with thread ID
+  $0 123 PRRT_kwDOQNO0Es5jvUvj "Addressed in latest commit"
 
-  # Mark as rejected
-  $0 123 456789 reject "Not applicable for this PR"
-
-  # Mark as in-progress
-  $0 123 456789 in-progress "Working on this now"
+  # Resolve with comment node ID
+  $0 123 PRRC_kwDOQNO0Es6Y_JfW "Done, thanks!"
 
 Environment:
   GITHUB_TOKEN or gh authentication must be configured
@@ -324,14 +361,13 @@ EOF
 # Main function
 main() {
     # Parse arguments
-    if [[ $# -lt 4 ]]; then
+    if [[ $# -lt 3 ]]; then
         usage
     fi
 
     local pr_number="$1"
-    local comment_or_thread_id="$2"
-    local action="$3"
-    local response_text="${4:-}"
+    local id="$2"
+    local response_text="$3"
 
     # Validate PR number
     if [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
@@ -339,19 +375,9 @@ main() {
         exit 1
     fi
 
-    # Validate action
-    case "$action" in
-        respond|resolve|reject|in-progress)
-            ;;
-        *)
-            log_error "Invalid action: $action. Must be one of: respond, resolve, reject, in-progress"
-            exit 1
-            ;;
-    esac
-
     # Validate response text is provided
     if [[ -z "$response_text" ]]; then
-        log_error "Response text is required for action: $action"
+        log_error "Response text is required"
         exit 1
     fi
 
@@ -359,21 +385,8 @@ main() {
     check_gh_auth
     get_repo_info
 
-    # Execute action
-    case "$action" in
-        respond)
-            action_respond "$pr_number" "$comment_or_thread_id" "$response_text"
-            ;;
-        resolve)
-            action_resolve "$pr_number" "$comment_or_thread_id" "$response_text"
-            ;;
-        reject)
-            action_reject "$pr_number" "$comment_or_thread_id" "$response_text"
-            ;;
-        in-progress)
-            action_in_progress "$pr_number" "$comment_or_thread_id" "$response_text"
-            ;;
-    esac
+    # Execute action (always resolve)
+    action_resolve "$pr_number" "$id" "$response_text"
 }
 
 # Run main function

--- a/scripts/gh_pr_comments_fetch.sh
+++ b/scripts/gh_pr_comments_fetch.sh
@@ -1,0 +1,597 @@
+#!/usr/bin/env bash
+#
+# gh_pr_comments_fetch.sh
+# Fetch PR comments with full context for agent consumption
+#
+# Usage:
+#   gh_pr_comments_fetch.sh <pr_number> [options]
+#
+# Arguments:
+#   pr_number           - Pull request number
+#
+# Options:
+#   --type <type>       - Filter by type: reviews|issues|all (default: reviews)
+#                         reviews = review threads only (no issue comments)
+#                         issues = issue comments only
+#                         all = everything (reviews + issues)
+#   --status <status>   - Filter by status: unresolved|resolved|all (default: unresolved)
+#   --format <format>   - Output format: json|summary (default: json)
+#   --page <n>          - Page number for GraphQL cursor-based pagination (default: 1)
+#   --per-page <n>      - Items per page (default: 50, max: 100)
+#
+# Environment:
+#   GITHUB_TOKEN or gh authentication must be configured
+#
+# Output:
+#   JSON or summary format with threads, comments, and pagination info
+#
+
+set -euo pipefail
+
+# Early dependency check - jq is required for safe JSON construction
+if ! command -v jq &> /dev/null; then
+    echo '{"status":"error","message":"jq is required but not installed"}' >&2
+    exit 1
+fi
+
+# Output functions for structured logging (using jq for safe JSON construction)
+log_error() {
+    jq -nc --arg msg "$1" '{status: "error", message: $msg}' >&2
+}
+
+# Get owner and repo from git remote
+get_repo_info() {
+    local remote_url
+    remote_url=$(git config --get remote.origin.url 2>/dev/null || echo "")
+
+    if [[ -z "$remote_url" ]]; then
+        log_error "Could not determine repository from git remote"
+        exit 1
+    fi
+
+    # Parse GitHub URL (supports both HTTPS and SSH)
+    if [[ "$remote_url" =~ github.com[:/]([^/]+)/([^/.]+) ]]; then
+        REPO_OWNER="${BASH_REMATCH[1]}"
+        REPO_NAME="${BASH_REMATCH[2]}"
+    else
+        log_error "Could not parse GitHub repository from remote URL: $remote_url"
+        exit 1
+    fi
+}
+
+# Check if gh CLI is installed and authenticated
+check_gh_auth() {
+    if ! command -v gh &> /dev/null; then
+        log_error "GitHub CLI (gh) is not installed"
+        exit 1
+    fi
+
+    if ! gh auth status > /dev/null 2>&1; then
+        log_error "GitHub CLI not authenticated. Run 'gh auth login'"
+        exit 1
+    fi
+}
+
+# Fetch review threads using GraphQL with pagination
+fetch_review_threads() {
+    local pr_number="$1"
+    local per_page="$2"
+    local page="$3"
+    local status_filter="$4"
+
+    # Calculate cursor for pagination (GraphQL uses cursor-based pagination)
+    local after_cursor=""
+    if [[ $page -gt 1 ]]; then
+        # For page N, we need to skip (N-1) * per_page items
+        # We'll fetch all pages up to the requested one and extract the cursor
+        local items_to_skip=$(( (page - 1) * per_page ))
+
+        # Fetch with a query that gets us the cursor for the starting position
+        # For simplicity in v1, we'll fetch the first page and use endCursor for subsequent pages
+        # This is a limitation - proper cursor-based pagination would require storing cursors
+        if [[ $items_to_skip -gt 0 ]]; then
+            local cursor_query
+            # shellcheck disable=SC2016
+            cursor_query='query($owner: String!, $repo: String!, $pr: Int!, $first: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: $first) {
+        pageInfo {
+          endCursor
+        }
+      }
+    }
+  }
+}'
+
+            local cursor_response
+            cursor_response=$(gh api graphql \
+                -f query="$cursor_query" \
+                -f owner="$REPO_OWNER" \
+                -f repo="$REPO_NAME" \
+                -F pr="$pr_number" \
+                -F first="$items_to_skip")
+
+            local cursor
+            cursor=$(echo "$cursor_response" | jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // empty')
+            if [[ -n "$cursor" ]]; then
+                after_cursor="$cursor"
+            fi
+        fi
+    fi
+
+    # Main query for review threads
+    # shellcheck disable=SC2016
+    local query='query($owner: String!, $repo: String!, $pr: Int!, $first: Int!, $after: String) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $pr) {
+      title
+      reviewThreads(first: $first, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        totalCount
+        nodes {
+          id
+          isResolved
+          path
+          line
+          startLine
+          diffSide
+          comments(first: 100) {
+            nodes {
+              id
+              databaseId
+              body
+              author {
+                login
+              }
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+
+    local response
+    if [[ -n "$after_cursor" ]]; then
+        response=$(gh api graphql \
+            -f query="$query" \
+            -f owner="$REPO_OWNER" \
+            -f repo="$REPO_NAME" \
+            -F pr="$pr_number" \
+            -F first="$per_page" \
+            -f after="$after_cursor")
+    else
+        response=$(gh api graphql \
+            -f query="$query" \
+            -f owner="$REPO_OWNER" \
+            -f repo="$REPO_NAME" \
+            -F pr="$pr_number" \
+            -F first="$per_page" \
+            -f after=null)
+    fi
+    local gh_status=$?
+
+    # Check for errors from gh api command
+    if [[ $gh_status -ne 0 ]]; then
+        log_error "gh api command failed with exit code $gh_status"
+        exit 1
+    fi
+
+    # Check for GraphQL errors
+    if echo "$response" | jq -e '.errors' > /dev/null 2>&1; then
+        local error_msg
+        error_msg=$(echo "$response" | jq -r '.errors[0].message // "Unknown GraphQL error"')
+        log_error "Failed to fetch review threads: $error_msg"
+        exit 1
+    fi
+
+    # Filter threads by status if needed
+    local filtered_threads
+    case "$status_filter" in
+        unresolved)
+            filtered_threads=$(echo "$response" | jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == false))')
+            ;;
+        resolved)
+            filtered_threads=$(echo "$response" | jq '.data.repository.pullRequest.reviewThreads.nodes | map(select(.isResolved == true))')
+            ;;
+        all)
+            filtered_threads=$(echo "$response" | jq '.data.repository.pullRequest.reviewThreads.nodes')
+            ;;
+        *)
+            log_error "Invalid status filter: $status_filter"
+            exit 1
+            ;;
+    esac
+
+    # Return both filtered threads and pagination info
+    jq -n \
+        --argjson threads "$filtered_threads" \
+        --arg title "$(echo "$response" | jq -r '.data.repository.pullRequest.title')" \
+        --argjson pageInfo "$(echo "$response" | jq '.data.repository.pullRequest.reviewThreads.pageInfo')" \
+        --argjson totalCount "$(echo "$response" | jq '.data.repository.pullRequest.reviewThreads.totalCount')" \
+        '{threads: $threads, title: $title, pageInfo: $pageInfo, totalCount: $totalCount}'
+}
+
+# Fetch issue comments using REST API with pagination
+fetch_issue_comments() {
+    local pr_number="$1"
+    local per_page="$2"
+    local page="$3"
+
+    local response
+    response=$(gh api \
+        -H "Accept: application/vnd.github+json" \
+        -H "X-GitHub-Api-Version: 2022-11-28" \
+        "/repos/$REPO_OWNER/$REPO_NAME/issues/$pr_number/comments?per_page=$per_page&page=$page")
+    local gh_status=$?
+
+    # Check for errors from gh api command
+    if [[ $gh_status -ne 0 ]]; then
+        log_error "gh api command failed with exit code $gh_status"
+        exit 1
+    fi
+
+    echo "$response"
+}
+
+# Format output as JSON
+format_json_output() {
+    local pr_number="$1"
+    local threads_data="$2"
+    local issue_comments="$3"
+    local page="$4"
+    local per_page="$5"
+    local type_filter="$6"
+    local status_filter="$7"
+
+    # Extract components from threads_data
+    local threads
+    threads=$(echo "$threads_data" | jq '.threads')
+    local pr_title
+    pr_title=$(echo "$threads_data" | jq -r '.title')
+    local page_info
+    page_info=$(echo "$threads_data" | jq '.pageInfo')
+    local total_threads
+    total_threads=$(echo "$threads_data" | jq '.totalCount')
+
+    # Transform threads to include actionable IDs
+    local transformed_threads
+    transformed_threads=$(echo "$threads" | jq 'map({
+        thread_id: .id,
+        is_resolved: .isResolved,
+        path: .path,
+        line: .line,
+        start_line: .startLine,
+        diff_side: .diffSide,
+        comments: [.comments.nodes[] | {
+            comment_id: .id,
+            database_id: .databaseId,
+            author: .author.login,
+            body: .body,
+            created_at: .createdAt,
+            is_first_in_thread: (. == .comments.nodes[0])
+        }],
+        actionable_id: .id,
+        actionable_id_numeric: .comments.nodes[0].databaseId
+    })')
+
+    # Transform issue comments
+    local transformed_issue_comments
+    transformed_issue_comments=$(echo "$issue_comments" | jq 'map({
+        comment_id: .node_id,
+        database_id: .id,
+        author: .user.login,
+        body: .body,
+        created_at: .created_at
+    })')
+
+    # Calculate summary statistics
+    local unresolved_count
+    unresolved_count=$(echo "$threads" | jq '[.[] | select(.isResolved == false)] | length')
+    local resolved_count
+    resolved_count=$(echo "$threads" | jq '[.[] | select(.isResolved == true)] | length')
+    local issue_comments_count
+    issue_comments_count=$(echo "$issue_comments" | jq 'length')
+
+    # Calculate pagination display info
+    local start_item=$(( (page - 1) * per_page + 1 ))
+    local end_item=$(( start_item + $(echo "$transformed_threads" | jq 'length') - 1 ))
+    local has_next_page
+    has_next_page=$(echo "$page_info" | jq -r '.hasNextPage')
+
+    # Build final JSON output
+    jq -n \
+        --argjson pr_number "$pr_number" \
+        --arg repository "$REPO_OWNER/$REPO_NAME" \
+        --arg pr_title "$pr_title" \
+        --arg fetched_at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+        --argjson page "$page" \
+        --argjson per_page "$per_page" \
+        --argjson start_item "$start_item" \
+        --argjson end_item "$end_item" \
+        --arg has_next_page "$has_next_page" \
+        --argjson total_count "$total_threads" \
+        --argjson threads "$transformed_threads" \
+        --argjson issue_comments "$transformed_issue_comments" \
+        --argjson total_threads "$total_threads" \
+        --argjson unresolved_threads "$unresolved_count" \
+        --argjson resolved_threads "$resolved_count" \
+        --argjson total_issue_comments "$issue_comments_count" \
+        '{
+            pr_number: $pr_number,
+            repository: $repository,
+            pr_title: $pr_title,
+            fetched_at: $fetched_at,
+            pagination: {
+                page: $page,
+                per_page: $per_page,
+                start_item: $start_item,
+                end_item: $end_item,
+                has_next_page: ($has_next_page == "true"),
+                total_count: $total_count,
+                summary: "Showing items \($start_item)-\($end_item) of \($total_count), use --page \($page + 1) for more"
+            },
+            threads: $threads,
+            issue_comments: $issue_comments,
+            summary: {
+                total_threads: $total_threads,
+                unresolved_threads: $unresolved_threads,
+                resolved_threads: $resolved_threads,
+                total_issue_comments: $total_issue_comments
+            }
+        }'
+}
+
+# Format output as human-readable summary
+format_summary_output() {
+    local json_output="$1"
+
+    local pr_number
+    pr_number=$(echo "$json_output" | jq -r '.pr_number')
+    local pr_title
+    pr_title=$(echo "$json_output" | jq -r '.pr_title')
+    local repository
+    repository=$(echo "$json_output" | jq -r '.repository')
+    local pagination_summary
+    pagination_summary=$(echo "$json_output" | jq -r '.pagination.summary')
+
+    echo "PR #$pr_number: $pr_title"
+    echo "Repository: $repository"
+    echo ""
+
+    # Display review threads
+    local threads_count
+    threads_count=$(echo "$json_output" | jq '.threads | length')
+    if [[ $threads_count -gt 0 ]]; then
+        echo "== Review Threads ($threads_count) =="
+        echo ""
+
+        local thread_index=1
+        while IFS= read -r thread; do
+            local thread_id
+            thread_id=$(echo "$thread" | jq -r '.thread_id')
+            local is_resolved
+            is_resolved=$(echo "$thread" | jq -r '.is_resolved')
+            local path
+            path=$(echo "$thread" | jq -r '.path')
+            local line
+            line=$(echo "$thread" | jq -r '.line')
+            local first_comment
+            first_comment=$(echo "$thread" | jq -r '.comments[0]')
+            local author
+            author=$(echo "$first_comment" | jq -r '.author')
+            local body_preview
+            body_preview=$(echo "$first_comment" | jq -r '.body' | head -c 100)
+            local replies_count
+            replies_count=$(( $(echo "$thread" | jq '.comments | length') - 1 ))
+            local actionable_id
+            actionable_id=$(echo "$thread" | jq -r '.actionable_id_numeric')
+
+            local status_marker="[ ]"
+            if [[ "$is_resolved" == "true" ]]; then
+                status_marker="[✓]"
+            fi
+
+            echo "[$thread_index] $status_marker $thread_id (Line $line in $path)"
+            echo "    Author: $author"
+            echo "    \"$body_preview...\""
+            echo "    Replies: $replies_count | Actionable ID: $actionable_id"
+            echo ""
+
+            thread_index=$((thread_index + 1))
+        done < <(echo "$json_output" | jq -c '.threads[]')
+    fi
+
+    # Display issue comments
+    local issue_comments_count
+    issue_comments_count=$(echo "$json_output" | jq '.issue_comments | length')
+    if [[ $issue_comments_count -gt 0 ]]; then
+        echo "== Issue Comments ($issue_comments_count) =="
+        echo ""
+
+        local comment_index=1
+        while IFS= read -r comment; do
+            local comment_id
+            comment_id=$(echo "$comment" | jq -r '.comment_id')
+            local author
+            author=$(echo "$comment" | jq -r '.author')
+            local body_preview
+            body_preview=$(echo "$comment" | jq -r '.body' | head -c 100)
+
+            echo "[$comment_index] $comment_id"
+            echo "    Author: $author"
+            echo "    \"$body_preview...\""
+            echo ""
+
+            comment_index=$((comment_index + 1))
+        done < <(echo "$json_output" | jq -c '.issue_comments[]')
+    fi
+
+    # Display summary statistics
+    echo "== Summary =="
+    local total_threads
+    total_threads=$(echo "$json_output" | jq -r '.summary.total_threads')
+    local unresolved_threads
+    unresolved_threads=$(echo "$json_output" | jq -r '.summary.unresolved_threads')
+    local resolved_threads
+    resolved_threads=$(echo "$json_output" | jq -r '.summary.resolved_threads')
+    local total_issue_comments
+    total_issue_comments=$(echo "$json_output" | jq -r '.summary.total_issue_comments')
+
+    echo "Total threads: $total_threads (Unresolved: $unresolved_threads, Resolved: $resolved_threads)"
+    echo "Issue comments: $total_issue_comments"
+    echo ""
+    echo "== Pagination =="
+    echo "$pagination_summary"
+}
+
+# Display usage information
+usage() {
+    cat << EOF
+Usage: $0 <pr_number> [options]
+
+Arguments:
+  pr_number      Pull request number
+
+Options:
+  --type <type>       Filter by type: reviews|issues|all (default: reviews)
+                      reviews = review threads only (no issue comments)
+                      issues = issue comments only
+                      all = everything (reviews + issues)
+  --status <status>   Filter by status: unresolved|resolved|all (default: unresolved)
+  --format <format>   Output format: json|summary (default: json)
+  --page <n>          Page number for pagination (default: 1)
+  --per-page <n>      Items per page (default: 50, max: 100)
+
+Examples:
+  # Fetch unresolved review threads only (default)
+  $0 123
+
+  # Fetch all comments including issue comments
+  $0 123 --type all
+
+  # Fetch only unresolved review threads as summary
+  $0 123 --format summary
+
+  # Fetch all threads (resolved and unresolved) with pagination
+  $0 123 --status all --page 2 --per-page 100
+
+  # Fetch only issue comments
+  $0 123 --type issues
+
+Environment:
+  GITHUB_TOKEN or gh authentication must be configured
+
+Output:
+  JSON or summary format with full comment context and pagination info
+EOF
+    exit 1
+}
+
+# Main function
+main() {
+    # Default values
+    local type_filter="reviews"
+    local status_filter="unresolved"
+    local format="json"
+    local page=1
+    local per_page=50
+
+    # Parse arguments
+    if [[ $# -lt 1 ]]; then
+        usage
+    fi
+
+    local pr_number="$1"
+    shift
+
+    # Validate PR number
+    if [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
+        log_error "PR number must be numeric: $pr_number"
+        exit 1
+    fi
+
+    # Parse options
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --type)
+                type_filter="$2"
+                if [[ ! "$type_filter" =~ ^(reviews|issues|all)$ ]]; then
+                    log_error "Invalid type: $type_filter. Must be reviews|issues|all"
+                    exit 1
+                fi
+                shift 2
+                ;;
+            --status)
+                status_filter="$2"
+                if [[ ! "$status_filter" =~ ^(unresolved|resolved|all)$ ]]; then
+                    log_error "Invalid status: $status_filter. Must be unresolved|resolved|all"
+                    exit 1
+                fi
+                shift 2
+                ;;
+            --format)
+                format="$2"
+                if [[ ! "$format" =~ ^(json|summary)$ ]]; then
+                    log_error "Invalid format: $format. Must be json|summary"
+                    exit 1
+                fi
+                shift 2
+                ;;
+            --page)
+                page="$2"
+                if [[ ! "$page" =~ ^[0-9]+$ ]] || [[ $page -lt 1 ]]; then
+                    log_error "Page must be a positive integer: $page"
+                    exit 1
+                fi
+                shift 2
+                ;;
+            --per-page)
+                per_page="$2"
+                if [[ ! "$per_page" =~ ^[0-9]+$ ]] || [[ $per_page -lt 1 ]] || [[ $per_page -gt 100 ]]; then
+                    log_error "Per-page must be between 1 and 100: $per_page"
+                    exit 1
+                fi
+                shift 2
+                ;;
+            *)
+                log_error "Unknown option: $1"
+                usage
+                ;;
+        esac
+    done
+
+    # Check prerequisites
+    check_gh_auth
+    get_repo_info
+
+    # Fetch data based on type filter
+    local threads_data='{"threads": [], "title": "", "pageInfo": {"hasNextPage": false, "endCursor": null}, "totalCount": 0}'
+    local issue_comments='[]'
+
+    if [[ "$type_filter" == "reviews" ]] || [[ "$type_filter" == "all" ]]; then
+        threads_data=$(fetch_review_threads "$pr_number" "$per_page" "$page" "$status_filter")
+    fi
+
+    if [[ "$type_filter" == "issues" ]] || [[ "$type_filter" == "all" ]]; then
+        issue_comments=$(fetch_issue_comments "$pr_number" "$per_page" "$page")
+    fi
+
+    # Format output
+    local json_output
+    json_output=$(format_json_output "$pr_number" "$threads_data" "$issue_comments" "$page" "$per_page" "$type_filter" "$status_filter")
+
+    if [[ "$format" == "summary" ]]; then
+        format_summary_output "$json_output"
+    else
+        echo "$json_output"
+    fi
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
## Summary
Simplifies the `gh_pr_comment_action.sh` script by removing confusing action options and adding support for all three GitHub ID formats.

## Changes

### Interface Simplification (Breaking Change)
- **Before**: `./script.sh <pr> <id> <action> <text>`
- **After**: `./script.sh <pr> <id> <text>`
- Removed `action` parameter - script always posts reply and resolves thread

### ID Format Support
Now accepts all three ID types:

| Type | Format | Example | Handling |
|------|--------|---------|----------|
| Numeric | `[0-9]+` | `2566690774` | REST API → GraphQL resolve |
| Thread | `PRRT_xxx` | `PRRT_kwDOQNO0Es5jvUvj` | GraphQL reply → GraphQL resolve |
| Comment | `PRRC_xxx` | `PRRC_kwDOQNO0Es6Y_JfW` | Convert to numeric → REST API |

### Functions Removed
- `action_respond()` - no longer needed
- `action_reject()` - no longer needed  
- `action_in_progress()` - no longer needed
- `_post_reply()` - renamed to `post_reply_rest()`

### Functions Added
- `post_reply_graphql()` - Posts replies directly to threads using GraphQL `addPullRequestReviewThreadReply` mutation
- `get_database_id_from_node()` - Converts PRRC_ node IDs to numeric database IDs

### Updated Functions
- `action_resolve()` - Now handles all three ID types with appropriate logic
- `main()` - Simplified to accept 3 args
- `usage()` - Updated documentation

## Testing Plan
- [x] shellcheck validation passes
- [x] All pre-commit hooks pass
- [x] Test with numeric comment ID on this PR
- [x] Test with PRRT_ thread ID on this PR
- [x] Test with PRRC_ comment node ID on this PR

## Verification
```bash
# Example usage with different ID types:
./scripts/gh_pr_comment_action.sh 123 2566690774 "Fixed, thanks!"
./scripts/gh_pr_comment_action.sh 123 PRRT_kwDOQNO0Es5jvUvj "Done!"
./scripts/gh_pr_comment_action.sh 123 PRRC_kwDOQNO0Es6Y_JfW "Resolved!"
```

Closes #275

## Summary by Sourcery

Simplify the GitHub PR comment action script interface and extend it to support all GitHub review comment ID formats, while adding a companion script to fetch PR comments and threads for automated processing.

New Features:
- Add support in the PR comment action script for numeric comment IDs, review thread node IDs, and comment node IDs, with automatic resolution and reply posting.
- Introduce a gh_pr_comments_fetch.sh helper script to retrieve PR review threads and issue comments with filtering, pagination, and JSON or human-readable summary output for agents.

Enhancements:
- Streamline gh_pr_comment_action.sh to a single resolve-style behavior that always posts a reply then resolves the review thread, reducing required arguments and removing unused actions.
- Use GraphQL APIs alongside REST to handle replying to threads, resolving review threads, and converting comment node IDs to database IDs for more flexible automation.
- Improve usage documentation and argument validation for both scripts, including clearer examples and error messages.