### PR TITLE
test: use InMemorySpanExporter for OTEL test isolation (#278)

### DIFF
--- a/backend/tests/test_otel_integration.py
+++ b/backend/tests/test_otel_integration.py
@@ -11,6 +11,7 @@ import pytest
 from app.core.config import settings
 from app.models.user import User
 from httpx import AsyncClient
+from opentelemetry import trace
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from sqlalchemy import text
@@ -301,7 +302,8 @@ def test_otel_enabled_provider_uses_in_memory_exporter(
     """Verify otel_enabled_provider uses InMemorySpanExporter (no network calls).
 
     This test ensures that OTEL-enabled tests never send telemetry to production
-    collectors by verifying the fixture uses an in-memory exporter.
+    collectors by verifying the fixture uses an in-memory exporter and that the
+    global tracer provider is correctly wired to use it.
     """
     provider, exporter = otel_enabled_provider
 
@@ -310,14 +312,24 @@ def test_otel_enabled_provider_uses_in_memory_exporter(
         "otel_enabled_provider must use InMemorySpanExporter to prevent network calls to production collectors"
     )
 
-    # Create a span and verify it's captured in memory
-    tracer = provider.get_tracer(__name__)
-    with tracer.start_as_current_span("test-safeguard-span") as span:
+    # Verify that the global tracer provider is the same instance as the fixture's provider
+    global_provider = trace.get_tracer_provider()
+    assert global_provider is provider, (
+        "Global tracer provider must match fixture provider to prevent accidental use of wrong provider"
+    )
+
+    # Ensure exporter starts clean for this test
+    exporter.clear()
+
+    # Create a span via the global tracer API (not provider.get_tracer) to verify global state is correct
+    tracer = trace.get_tracer(__name__)
+    span_name = "test-safeguard-span"
+    with tracer.start_as_current_span(span_name) as span:
         # Add some attributes to make the test more realistic
         span.set_attribute("test.attribute", "value")
 
     # Verify span was captured in memory (not sent to network)
     spans = exporter.get_finished_spans()
     assert len(spans) == 1, "Span should be captured in memory"
-    assert spans[0].name == "test-safeguard-span"
+    assert spans[0].name == span_name
     assert spans[0].attributes["test.attribute"] == "value"  # type: ignore[index]

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -6,6 +6,7 @@ import pytest
 from app.core import telemetry
 from app.core.config import settings
 from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 
 def test_get_tracer_provider_returns_none_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -220,10 +221,14 @@ def test_get_current_trace_id_when_no_span_active() -> None:
     assert trace_id is None
 
 
-def test_get_current_trace_id_with_active_span(otel_enabled_provider: TracerProvider) -> None:
+def test_get_current_trace_id_with_active_span(
+    otel_enabled_provider: tuple[TracerProvider, InMemorySpanExporter],
+) -> None:
     """Test get_current_trace_id returns trace ID when span is active."""
+    provider, _exporter = otel_enabled_provider
+
     # Create a tracer and start a span
-    tracer = otel_enabled_provider.get_tracer(__name__)
+    tracer = provider.get_tracer(__name__)
     with tracer.start_as_current_span("test_span") as span:
         # Should return a valid trace ID
         trace_id = telemetry.get_current_trace_id()


### PR DESCRIPTION
## Summary
Ensures OTEL-enabled tests never send telemetry to production collectors by using in-memory span exporters with zero network capabilities.

Fixes #278

## Changes
- ✅ Update `otel_enabled_provider` fixture to use `InMemorySpanExporter`
- ✅ Fixture now returns tuple of `(TracerProvider, InMemorySpanExporter)` for optional span verification
- ✅ Update 2 existing tests to accept new tuple signature
- ✅ Add safeguard test `test_otel_enabled_provider_uses_in_memory_exporter`
- ✅ Document decision in ADR 10 (Testing Strategy)

## Investigation Results
The current implementation was already safe (no network calls), but this improvement:
- Makes safety explicit with clear documentation
- Enables optional span verification in tests
- Aligns with pattern already used in `test_tfl_otel.py`

## Test Results
- ✅ All 1416 tests pass
- ✅ Coverage: 95.63% (exceeds 95% requirement)
- ✅ New safeguard test verifies InMemorySpanExporter usage
- ✅ All pre-commit hooks pass

## Files Modified
- `backend/tests/fixtures/otel.py` - Updated fixture
- `backend/tests/test_telemetry.py` - Updated test signature
- `backend/tests/test_tfl_service.py` - Updated test signature  
- `backend/tests/test_otel_integration.py` - Added safeguard test
- `docs/adr/10-testing.md` - Documented decision

## Summary by Sourcery

Ensure OpenTelemetry-enabled tests use an in-memory span exporter for safe, isolated telemetry testing and span inspection.

Enhancements:
- Update the otel_enabled_provider fixture to create a TracerProvider with InMemorySpanExporter and SimpleSpanProcessor and return both for use in tests.
- Adjust existing telemetry-related tests to consume the new (TracerProvider, InMemorySpanExporter) fixture contract and rely on the provider for tracer access.

Documentation:
- Document the OTEL test isolation strategy and rationale in ADR 10, describing the use of InMemorySpanExporter in tests.

Tests:
- Add a safeguard test that verifies otel_enabled_provider uses InMemorySpanExporter and captures spans in memory only.