### PR TITLE
fix: remove redundant shred calls in deploy workflow (#286)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -193,7 +193,6 @@ jobs:
             echo "Attempt $i/3: Testing SSH connection to ${{ steps.vm-ip.outputs.ip }}..."
             if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -i "$SSH_KEY_FILE" deployuser@${{ steps.vm-ip.outputs.ip }} "whoami"; then
               echo "✓ SSH connection established"
-              shred -u "$SSH_KEY_FILE"
               exit 0
             fi
             if [ "$i" -lt 3 ]; then
@@ -202,7 +201,6 @@ jobs:
             fi
           done
           echo "✗ SSH connection failed after 3 attempts (90s total)"
-          shred -u "$SSH_KEY_FILE"
           exit 1
 
       - name: Deploy via SSH


### PR DESCRIPTION
The SSH connectivity test was failing with "shred: failed to open for
writing: No such file or directory" despite successful SSH connection.

Root cause: Double-deletion of SSH key file. Both manual shred calls and the trap EXIT handler tried to delete the same file.

Fix: Remove redundant manual shred calls on lines 196 and 205. The trap 'shred -u "$SSH_KEY_FILE"' EXIT already handles cleanup for all exit paths (success and failure).

Fixes #286