### PR TITLE
Release: Bug fixes and testing improvements

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -193,7 +193,6 @@ jobs:
             echo "Attempt $i/3: Testing SSH connection to ${{ steps.vm-ip.outputs.ip }}..."
             if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=10 -i "$SSH_KEY_FILE" deployuser@${{ steps.vm-ip.outputs.ip }} "whoami"; then
               echo "✓ SSH connection established"
-              shred -u "$SSH_KEY_FILE"
               exit 0
             fi
             if [ "$i" -lt 3 ]; then
@@ -202,7 +201,6 @@ jobs:
             fi
           done
           echo "✗ SSH connection failed after 3 attempts (90s total)"
-          shred -u "$SSH_KEY_FILE"
           exit 1
 
       - name: Deploy via SSH

--- a/backend/tests/test_telemetry.py
+++ b/backend/tests/test_telemetry.py
@@ -6,6 +6,7 @@ import pytest
 from app.core import telemetry
 from app.core.config import settings
 from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 
 def test_get_tracer_provider_returns_none_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -220,10 +221,14 @@ def test_get_current_trace_id_when_no_span_active() -> None:
     assert trace_id is None
 
 
-def test_get_current_trace_id_with_active_span(otel_enabled_provider: TracerProvider) -> None:
+def test_get_current_trace_id_with_active_span(
+    otel_enabled_provider: tuple[TracerProvider, InMemorySpanExporter],
+) -> None:
     """Test get_current_trace_id returns trace ID when span is active."""
+    provider, _exporter = otel_enabled_provider
+
     # Create a tracer and start a span
-    tracer = otel_enabled_provider.get_tracer(__name__)
+    tracer = provider.get_tracer(__name__)
     with tracer.start_as_current_span("test_span") as span:
         # Should return a valid trace ID
         trace_id = telemetry.get_current_trace_id()

--- a/scripts/gh_pr_comments_fetch.sh
+++ b/scripts/gh_pr_comments_fetch.sh
@@ -14,7 +14,7 @@
 #                         reviews = review threads only (no issue comments)
 #                         issues = issue comments only
 #                         all = everything (reviews + issues)
-#   --status <status>   - Filter by status: unresolved|resolved|all (default: unresolved)
+#   --status <status>   - Filter by status: unresolved|resolved|all (default: all)
 #   --format <format>   - Output format: json|summary (default: json)
 #   --page <n>          - Page number for GraphQL cursor-based pagination (default: 1)
 #   --per-page <n>      - Items per page (default: 50, max: 100)
@@ -117,8 +117,7 @@ fetch_review_threads() {
                     -f owner="$REPO_OWNER" \
                     -f repo="$REPO_NAME" \
                     -F pr="$pr_number" \
-                    -F first="$per_page" \
-                    -f after=null)
+                    -F first="$per_page")
             fi
 
             # Extract the endCursor for the next iteration
@@ -196,8 +195,7 @@ fetch_review_threads() {
             -f owner="$REPO_OWNER" \
             -f repo="$REPO_NAME" \
             -F pr="$pr_number" \
-            -F first="$per_page" \
-            -f after=null)
+            -F first="$per_page")
     fi
     local gh_status=$?
 
@@ -556,23 +554,26 @@ Options:
                       reviews = review threads only (no issue comments)
                       issues = issue comments only
                       all = everything (reviews + issues)
-  --status <status>   Filter by status: unresolved|resolved|all (default: unresolved)
+  --status <status>   Filter by status: unresolved|resolved|all (default: all)
   --format <format>   Output format: json|summary (default: json)
   --page <n>          Page number for pagination (default: 1)
   --per-page <n>      Items per page (default: 50, max: 100)
 
 Examples:
-  # Fetch unresolved review threads only (default)
+  # Fetch all review threads (default)
   $0 123
+
+  # Fetch only unresolved review threads
+  $0 123 --status unresolved
 
   # Fetch all comments including issue comments
   $0 123 --type all
 
-  # Fetch only unresolved review threads as summary
+  # Fetch all review threads as summary
   $0 123 --format summary
 
-  # Fetch all threads (resolved and unresolved) with pagination
-  $0 123 --status all --page 2 --per-page 100
+  # Fetch resolved threads only with pagination
+  $0 123 --status resolved --page 2 --per-page 100
 
   # Fetch only issue comments
   $0 123 --type issues
@@ -590,7 +591,7 @@ EOF
 main() {
     # Default values
     local type_filter="reviews"
-    local status_filter="unresolved"
+    local status_filter="all"
     local format="json"
     local page=1
     local per_page=50


### PR DESCRIPTION
## Summary

This release includes critical bug fixes and testing improvements that enhance deployment reliability and test isolation.

## Changes in This Release

### 🐛 Bug Fixes

#### 1. Fix deploy workflow SSH key cleanup (#287)
**Issue:** Deploy workflow failed with `shred: failed to open for writing: No such file or directory` despite successful SSH connection.

**Root Cause:** Double-deletion of SSH key file - both manual `shred` calls and the `trap EXIT` handler tried to delete the same file.

**Fix:** Removed redundant manual `shred` calls. The `trap 'shred -u "$SSH_KEY_FILE"' EXIT` already handles cleanup for all exit paths.

**Impact:** Deployment workflow now completes successfully without false errors.

**Fixes:** #286

---

#### 2. Fix gh_pr_comments_fetch.sh null cursor pagination bug (#285)
**Issue:** Script returned empty comment threads despite threads existing in PRs.

**Root Cause:** Script passed `-f after=null` to `gh api graphql`, sending the literal string `"null"` instead of JSON null, causing GraphQL cursor-based pagination to fail silently.

**Changes:**
- Remove `-f after=null` from GraphQL calls (lines 121, 200)
- Change default status filter from "unresolved" to "all"
- Update documentation to reflect new default behavior

**Impact:** PR comment fetching now works correctly for all pagination scenarios.

**Fixes:** #275

---

### ✅ Testing Improvements

#### 3. Use InMemorySpanExporter for OTEL test isolation (#284)
**Purpose:** Ensure OTEL-enabled tests never send telemetry to production collectors.

**Changes:**
- Updated `otel_enabled_provider` fixture to use `InMemorySpanExporter`
- Fixture now returns tuple of `(TracerProvider, InMemorySpanExporter)` for optional span verification
- Updated 2 existing tests to accept new tuple signature
- Added safeguard test `test_otel_enabled_provider_uses_in_memory_exporter`
- Documented decision in ADR 10 (Testing Strategy)

**Benefits:**
- Makes test safety explicit with clear documentation
- Enables optional span verification in tests
- Zero network calls during testing

**Test Results:**
- ✅ All 1416 tests pass
- ✅ Coverage: 95.63% (exceeds 95% requirement)

**Fixes:** #278

---

## Test Results

All tests passing with 95.63% coverage.

## Deployment Notes

This release fixes the deployment workflow itself, so the deployment should now complete cleanly without the SSH key cleanup error.