### PR TITLE
feat: add explicit span status pattern for OTEL traces (#289)

### DIFF
--- a/backend/app/core/telemetry.py
+++ b/backend/app/core/telemetry.py
@@ -280,12 +280,16 @@ def set_logger_provider() -> None:
         otel_set_logger_provider(provider)
 
 
+# OpenTelemetry attribute values can be primitives or lists of primitives
+AttributeValue = str | int | float | bool | list[str] | list[int] | list[float] | list[bool]
+
+
 @contextmanager
 def service_span(
     name: str,
     service: str,
     kind: SpanKind = SpanKind.INTERNAL,
-    **attributes: str | int | float | bool,
+    **attributes: AttributeValue,
 ) -> Generator["Span"]:
     """Context manager for service operation spans with explicit status.
 

--- a/backend/app/services/tfl_service.py
+++ b/backend/app/services/tfl_service.py
@@ -239,7 +239,7 @@ def tfl_api_span(
                 span.set_attribute("http.status_code", response.http_status_code)
     """
     # Import service_span from telemetry
-    from app.core.telemetry import service_span  # noqa: PLC0415  # Avoid circular import
+    from app.core.telemetry import service_span  # noqa: PLC0415  # Local import for deferred dependency
 
     # Delegate to service_span with TfL-specific conventions
     with service_span(

--- a/backend/app/services/tfl_service.py
+++ b/backend/app/services/tfl_service.py
@@ -219,13 +219,10 @@ def tfl_api_span(
 ) -> Generator[trace.Span]:
     """Context manager for TfL API call spans with standard attributes.
 
-    Creates an OpenTelemetry span with consistent attributes for TfL API calls.
-    The SDK automatically records exceptions and sets error status if an
-    exception occurs within the span context.
-
-    Note: The tracer is acquired at call time (not module import time) to ensure
-    it uses the TracerProvider set during application startup. This enables proper
-    trace context propagation from parent spans (e.g., FastAPI HTTP requests).
+    Wrapper around service_span with TfL-specific conventions. Creates spans with:
+    - Explicit StatusCode.OK on success
+    - Automatic StatusCode.ERROR on exceptions (via SDK)
+    - Consistent TfL API attributes
 
     Args:
         endpoint: API endpoint name (e.g., "MetaModes", "GetByModeByPathModes")
@@ -241,18 +238,15 @@ def tfl_api_span(
             if hasattr(response, "http_status_code"):
                 span.set_attribute("http.status_code", response.http_status_code)
     """
-    # Get tracer at call time to use the correct TracerProvider (set in FastAPI lifespan)
-    tracer = trace.get_tracer(__name__)
-    attributes = {
-        "tfl.api.endpoint": endpoint,
-        "tfl.api.client": client,
-        "peer.service": "api.tfl.gov.uk",
-        **extra_attrs,
-    }
-    with tracer.start_as_current_span(
-        f"tfl.api.{endpoint}",
+    # Import service_span from telemetry
+    from app.core.telemetry import service_span  # noqa: PLC0415  # Avoid circular import
+
+    # Delegate to service_span with TfL-specific conventions
+    with service_span(
+        name=f"tfl.api.{endpoint}",
+        service="api.tfl.gov.uk",
         kind=trace.SpanKind.CLIENT,
-        attributes=attributes,
+        **{"tfl.api.endpoint": endpoint, "tfl.api.client": client, **extra_attrs},
     ) as span:
         yield span
 

--- a/backend/tests/core/test_telemetry.py
+++ b/backend/tests/core/test_telemetry.py
@@ -9,13 +9,12 @@ from tests.helpers.otel import assert_span_status, get_recorded_spans
 class TestServiceSpan:
     """Tests for service_span context manager."""
 
-    @pytest.mark.asyncio
-    async def test_service_span_sets_ok_status_on_success(
+    def test_service_span_sets_ok_status_on_success(
         self,
         otel_enabled_provider: tuple,
     ) -> None:
         """Test that service_span sets OK status on successful completion."""
-        _provider, exporter = otel_enabled_provider
+        _, exporter = otel_enabled_provider
 
         # Execute operation that succeeds
         with service_span("test.operation", "test-service"):
@@ -29,13 +28,12 @@ class TestServiceSpan:
         assert span.name == "test.operation"
         assert_span_status(span, StatusCode.OK)
 
-    @pytest.mark.asyncio
-    async def test_service_span_sets_error_status_on_exception(
+    def test_service_span_sets_error_status_on_exception(
         self,
         otel_enabled_provider: tuple,
     ) -> None:
         """Test that SDK sets ERROR status when exception occurs in span."""
-        _provider, exporter = otel_enabled_provider
+        _, exporter = otel_enabled_provider
 
         # Execute operation that raises exception
         error_msg = "Test error"
@@ -53,13 +51,12 @@ class TestServiceSpan:
         assert span.name == "test.operation"
         assert_span_status(span, StatusCode.ERROR, check_exception=True)
 
-    @pytest.mark.asyncio
-    async def test_service_span_propagates_exception(
+    def test_service_span_propagates_exception(
         self,
         otel_enabled_provider: tuple,
     ) -> None:
         """Test that service_span propagates exceptions (doesn't swallow them)."""
-        _provider, _exporter = otel_enabled_provider
+        _ = otel_enabled_provider
 
         # Verify exception propagates out of context manager
         error_msg = "Intentional test error"
@@ -69,13 +66,12 @@ class TestServiceSpan:
         ):
             raise RuntimeError(error_msg)
 
-    @pytest.mark.asyncio
-    async def test_service_span_sets_attributes(
+    def test_service_span_sets_attributes(
         self,
         otel_enabled_provider: tuple,
     ) -> None:
         """Test that service_span sets attributes correctly."""
-        _provider, exporter = otel_enabled_provider
+        _, exporter = otel_enabled_provider
 
         # Create span with various attribute types
         with service_span(
@@ -102,13 +98,12 @@ class TestServiceSpan:
         assert span.attributes["latency_ms"] == 12.5
         assert span.attributes["is_cached"] is True
 
-    @pytest.mark.asyncio
-    async def test_service_span_allows_additional_attributes(
+    def test_service_span_allows_additional_attributes(
         self,
         otel_enabled_provider: tuple,
     ) -> None:
         """Test that additional attributes can be set on yielded span."""
-        _provider, exporter = otel_enabled_provider
+        _, exporter = otel_enabled_provider
 
         # Create span and add attribute during execution
         with service_span("test.operation", "test-service") as span:
@@ -122,13 +117,12 @@ class TestServiceSpan:
         assert span.attributes["peer.service"] == "test-service"
         assert span.attributes["dynamic.attribute"] == "added-during-execution"
 
-    @pytest.mark.asyncio
-    async def test_service_span_default_span_kind_is_internal(
+    def test_service_span_default_span_kind_is_internal(
         self,
         otel_enabled_provider: tuple,
     ) -> None:
         """Test that default span kind is INTERNAL."""
-        _provider, exporter = otel_enabled_provider
+        _, exporter = otel_enabled_provider
 
         # Create span without explicit kind
         with service_span("test.operation", "test-service"):
@@ -139,13 +133,12 @@ class TestServiceSpan:
         assert len(spans) == 1
         assert spans[0].kind == SpanKind.INTERNAL
 
-    @pytest.mark.asyncio
-    async def test_service_span_with_client_kind(
+    def test_service_span_with_client_kind(
         self,
         otel_enabled_provider: tuple,
     ) -> None:
         """Test service_span with CLIENT span kind for external calls."""
-        _provider, exporter = otel_enabled_provider
+        _, exporter = otel_enabled_provider
 
         # Create span with CLIENT kind (for external API calls)
         with service_span("external.api.call", "external-api", kind=SpanKind.CLIENT):

--- a/backend/tests/core/test_telemetry.py
+++ b/backend/tests/core/test_telemetry.py
@@ -1,0 +1,157 @@
+"""Tests for OpenTelemetry telemetry module."""
+
+import pytest
+from app.core.telemetry import service_span
+from opentelemetry.trace import SpanKind, StatusCode
+from tests.helpers.otel import assert_span_status, get_recorded_spans
+
+
+class TestServiceSpan:
+    """Tests for service_span context manager."""
+
+    @pytest.mark.asyncio
+    async def test_service_span_sets_ok_status_on_success(
+        self,
+        otel_enabled_provider: tuple,
+    ) -> None:
+        """Test that service_span sets OK status on successful completion."""
+        _provider, exporter = otel_enabled_provider
+
+        # Execute operation that succeeds
+        with service_span("test.operation", "test-service"):
+            pass  # Successful completion
+
+        # Verify span was created with OK status
+        spans = get_recorded_spans(exporter)
+        assert len(spans) == 1
+
+        span = spans[0]
+        assert span.name == "test.operation"
+        assert_span_status(span, StatusCode.OK)
+
+    @pytest.mark.asyncio
+    async def test_service_span_sets_error_status_on_exception(
+        self,
+        otel_enabled_provider: tuple,
+    ) -> None:
+        """Test that SDK sets ERROR status when exception occurs in span."""
+        _provider, exporter = otel_enabled_provider
+
+        # Execute operation that raises exception
+        error_msg = "Test error"
+        with (
+            pytest.raises(ValueError, match=error_msg),
+            service_span("test.operation", "test-service"),
+        ):
+            raise ValueError(error_msg)
+
+        # Verify span was created with ERROR status
+        spans = get_recorded_spans(exporter)
+        assert len(spans) == 1
+
+        span = spans[0]
+        assert span.name == "test.operation"
+        assert_span_status(span, StatusCode.ERROR, check_exception=True)
+
+    @pytest.mark.asyncio
+    async def test_service_span_propagates_exception(
+        self,
+        otel_enabled_provider: tuple,
+    ) -> None:
+        """Test that service_span propagates exceptions (doesn't swallow them)."""
+        _provider, _exporter = otel_enabled_provider
+
+        # Verify exception propagates out of context manager
+        error_msg = "Intentional test error"
+        with (
+            pytest.raises(RuntimeError, match=error_msg),
+            service_span("test.operation", "test-service"),
+        ):
+            raise RuntimeError(error_msg)
+
+    @pytest.mark.asyncio
+    async def test_service_span_sets_attributes(
+        self,
+        otel_enabled_provider: tuple,
+    ) -> None:
+        """Test that service_span sets attributes correctly."""
+        _provider, exporter = otel_enabled_provider
+
+        # Create span with various attribute types
+        with service_span(
+            "test.operation",
+            "test-service",
+            kind=SpanKind.CLIENT,
+            user_id="user123",
+            request_count=42,
+            latency_ms=12.5,
+            is_cached=True,
+        ):
+            pass
+
+        # Verify span attributes
+        spans = get_recorded_spans(exporter)
+        assert len(spans) == 1
+
+        span = spans[0]
+        assert span.name == "test.operation"
+        assert span.kind == SpanKind.CLIENT
+        assert span.attributes["peer.service"] == "test-service"
+        assert span.attributes["user_id"] == "user123"
+        assert span.attributes["request_count"] == 42
+        assert span.attributes["latency_ms"] == 12.5
+        assert span.attributes["is_cached"] is True
+
+    @pytest.mark.asyncio
+    async def test_service_span_allows_additional_attributes(
+        self,
+        otel_enabled_provider: tuple,
+    ) -> None:
+        """Test that additional attributes can be set on yielded span."""
+        _provider, exporter = otel_enabled_provider
+
+        # Create span and add attribute during execution
+        with service_span("test.operation", "test-service") as span:
+            span.set_attribute("dynamic.attribute", "added-during-execution")
+
+        # Verify both initial and dynamic attributes
+        spans = get_recorded_spans(exporter)
+        assert len(spans) == 1
+
+        span = spans[0]
+        assert span.attributes["peer.service"] == "test-service"
+        assert span.attributes["dynamic.attribute"] == "added-during-execution"
+
+    @pytest.mark.asyncio
+    async def test_service_span_default_span_kind_is_internal(
+        self,
+        otel_enabled_provider: tuple,
+    ) -> None:
+        """Test that default span kind is INTERNAL."""
+        _provider, exporter = otel_enabled_provider
+
+        # Create span without explicit kind
+        with service_span("test.operation", "test-service"):
+            pass
+
+        # Verify default SpanKind.INTERNAL
+        spans = get_recorded_spans(exporter)
+        assert len(spans) == 1
+        assert spans[0].kind == SpanKind.INTERNAL
+
+    @pytest.mark.asyncio
+    async def test_service_span_with_client_kind(
+        self,
+        otel_enabled_provider: tuple,
+    ) -> None:
+        """Test service_span with CLIENT span kind for external calls."""
+        _provider, exporter = otel_enabled_provider
+
+        # Create span with CLIENT kind (for external API calls)
+        with service_span("external.api.call", "external-api", kind=SpanKind.CLIENT):
+            pass
+
+        # Verify SpanKind.CLIENT
+        spans = get_recorded_spans(exporter)
+        assert len(spans) == 1
+        assert spans[0].kind == SpanKind.CLIENT

--- a/backend/tests/helpers/otel.py
+++ b/backend/tests/helpers/otel.py
@@ -68,4 +68,4 @@ def assert_span_status(
 
     if check_exception and expected_status == StatusCode.ERROR:
         exception_events = [e for e in span.events if e.name == "exception"]
-        assert len(exception_events) >= 1, "Expected exception event in ERROR span"
+        assert exception_events, "Expected exception event in ERROR span"

--- a/backend/tests/helpers/otel.py
+++ b/backend/tests/helpers/otel.py
@@ -2,6 +2,8 @@
 
 from typing import TYPE_CHECKING
 
+from opentelemetry.trace import StatusCode
+
 if TYPE_CHECKING:
     from opentelemetry.sdk.trace import ReadableSpan
     from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -37,3 +39,33 @@ def clear_recorded_spans(exporter: "InMemorySpanExporter") -> None:
         exporter: InMemorySpanExporter to clear
     """
     exporter.clear()
+
+
+def assert_span_status(
+    span: "ReadableSpan",
+    expected_status: StatusCode,
+    *,
+    check_exception: bool = False,
+) -> None:
+    """
+    Assert span status and optionally verify exception event.
+
+    Helper for consistent span status assertions across tests.
+
+    Args:
+        span: ReadableSpan to check
+        expected_status: Expected StatusCode (OK or ERROR)
+        check_exception: If True, verify exception event exists when status is ERROR
+
+    Example:
+        >>> span = spans[0]
+        >>> assert_span_status(span, StatusCode.OK)
+        >>> assert_span_status(span, StatusCode.ERROR, check_exception=True)
+    """
+    assert span.status.status_code == expected_status, (
+        f"Expected span status {expected_status}, got {span.status.status_code}"
+    )
+
+    if check_exception and expected_status == StatusCode.ERROR:
+        exception_events = [e for e in span.events if e.name == "exception"]
+        assert len(exception_events) >= 1, "Expected exception event in ERROR span"


### PR DESCRIPTION
Fixes issue where most traces show "unset" status in Grafana instead of explicit OK/ERROR status.

Changes:
- Add service_span() helper in telemetry.py for all services
- Sets StatusCode.OK on success, ERROR on exceptions
- Refactor tfl_api_span to use service_span helper
- Add assert_span_status() test helper
- Add 7 tests for service_span
- Add 2 tests for success status verification
- Document explicit span status pattern in ADR-12

All 11 TfL API spans now have explicit status instead of UNSET.

Follow-up issues created:
- #290 High priority instrumentation (5 operations)
- #291 Medium priority instrumentation (6 operations)
- #292 Low priority instrumentation (6 operations)

Tests: 1425 passed, 95.62% coverage

closes #289, follow ons #290, #291, #292

## Summary by Sourcery

Introduce a shared telemetry span helper to ensure explicit OpenTelemetry span statuses and apply it to TfL API tracing, with supporting tests and documentation updates.

New Features:
- Add a generic service_span context manager to create service operation spans with explicit OK/ERROR status handling.
- Provide a reusable assert_span_status test helper for validating span status and exception events.

Enhancements:
- Refactor the TfL API span helper to delegate to the new service_span helper while standardising TfL-specific span attributes.

Documentation:
- Document the explicit span status pattern and usage of the service_span helper in ADR-12, including testing guidance and affected files.

Tests:
- Add comprehensive tests for the service_span helper covering status, attributes, and span kind behaviour.
- Add tests to verify TfL API spans report StatusCode.OK on successful operations.