### PR TITLE
fix: address PR #298 review comments on OTEL instrumentation

### DIFF
--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -97,7 +97,7 @@ class AdminService:
             span.set_attribute("admin.operation", "get_users_paginated")
             span.set_attribute("admin.limit", limit)
             span.set_attribute("admin.offset", offset)
-            span.set_attribute("admin.search_enabled", search is not None)
+            span.set_attribute("admin.search_enabled", bool(search))
             span.set_attribute("admin.include_deleted", include_deleted)
             # Build count query (separate from main query to avoid cartesian product)
             count_query = select(func.count(func.distinct(User.id)))

--- a/backend/app/services/alert_service.py
+++ b/backend/app/services/alert_service.py
@@ -459,6 +459,7 @@ class AlertService:
                     error=str(e),
                     exc_info=e,
                 )
+                span.record_exception(e)
                 await self.db.rollback()
                 span.set_attribute("alert.logged_count", 0)
                 # Don't raise - logging failures shouldn't block alert processing

--- a/backend/tests/services/test_admin_otel.py
+++ b/backend/tests/services/test_admin_otel.py
@@ -223,7 +223,7 @@ class TestAdminServiceOtelSpans:
         # Create admin service
         admin_svc = AdminService(db=mock_db)
 
-        _users, _total = await admin_svc.get_users_paginated(limit=10, offset=0, search="test")
+        await admin_svc.get_users_paginated(limit=10, offset=0, search="test")
 
         # Verify span was created with OK status
         spans = exporter.get_finished_spans()

--- a/backend/tests/services/test_notification_otel.py
+++ b/backend/tests/services/test_notification_otel.py
@@ -69,7 +69,8 @@ class TestNotificationServiceOtelSpans:
         assert notif_span.attributes is not None
         assert notif_span.attributes["peer.service"] == "notification-service"
         assert notif_span.attributes["notification.type"] == "email"
-        assert notif_span.attributes["notification.recipient"] == "test@example.com"
+        assert "notification.recipient_hash" in notif_span.attributes
+        assert len(notif_span.attributes["notification.recipient_hash"]) == 12
         assert notif_span.attributes["notification.route_name"] == "Home to Work"
         assert notif_span.attributes["notification.disruption_count"] == 2
 
@@ -158,7 +159,8 @@ class TestNotificationServiceOtelSpans:
         assert sms_span.attributes is not None
         assert sms_span.attributes["peer.service"] == "notification-service"
         assert sms_span.attributes["notification.type"] == "sms"
-        assert sms_span.attributes["notification.recipient"] == "+447700900000"
+        assert "notification.recipient_hash" in sms_span.attributes
+        assert len(sms_span.attributes["notification.recipient_hash"]) == 12
         assert sms_span.attributes["notification.route_name"] == "Home to Work"
         assert sms_span.attributes["notification.disruption_count"] == 1
         # Message length should be set after message construction


### PR DESCRIPTION
## Summary

Addresses review comments from PR #298 that were made after the PR was merged.

## Changes

- ✅ Use `bool(search)` for `admin.search_enabled` attribute consistency  
- ✅ Hash recipient email/phone in notification spans (PII protection)  
  - Changed `notification.recipient` → `notification.recipient_hash` (12-char SHA256)
- ✅ Record exceptions in alert service swallowed catch blocks (`span.record_exception`)
- ✅ Remove unused test variables in admin OTEL tests

## Review Comments Addressed

Resolves comments from:
- sourcery-ai: admin search logic, email PII, phone PII, exception recording
- copilot-pull-request-reviewer: unused test variables

All review threads on PR #298 have been resolved.

## Test Plan

- [x] All 1484 backend tests passing
- [x] Coverage: 95.66% (above 95% requirement)
- [x] Pre-commit hooks passing (ruff, mypy, prettier, eslint, tsc)
- [x] OTEL tests verify hashed recipient attributes

## Notes

This PR contains the fix commit that was made locally after PR #298 was merged. The fix addresses all outstanding review comments.

Related: #298, #291