### PR TITLE
fix: expand VARCHAR(1000) columns to TEXT for disruption descriptions (#297) (#304)

### DIFF
--- a/backend/alembic/versions/cea4031bd399_expand_text_columns_for_disruption_.py
+++ b/backend/alembic/versions/cea4031bd399_expand_text_columns_for_disruption_.py
@@ -1,0 +1,66 @@
+"""expand text columns for disruption descriptions
+
+Revision ID: cea4031bd399
+Revises: cf589f9baac2
+Create Date: 2025-11-30 20:11:08.529441
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "cea4031bd399"
+down_revision: str | Sequence[str] | None = "cf589f9baac2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema - expand VARCHAR(1000) columns to TEXT for disruption descriptions."""
+    # Expand LineDisruptionStateLog.reason (primary fix for issue #297)
+    # TfL API can return disruption reasons exceeding 1000 characters
+    op.alter_column(
+        "line_disruption_state_logs",
+        "reason",
+        existing_type=sa.String(length=1000),
+        type_=sa.Text(),
+        existing_nullable=True,
+    )
+
+    # Expand StationDisruption.description (preventative fix)
+    # TfL API station disruption descriptions may also exceed 1000 characters
+    op.alter_column(
+        "station_disruptions",
+        "description",
+        existing_type=sa.String(length=1000),
+        type_=sa.Text(),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema - revert TEXT columns to VARCHAR(1000).
+
+    Note: If any existing values exceed 1000 characters, this downgrade may fail
+    (or behave differently) depending on the database backend and its settings.
+    """
+    # NOTE: Downgrade may fail if any values exceed 1000 characters, or behave
+    # differently depending on the database backend and configuration.
+    op.alter_column(
+        "line_disruption_state_logs",
+        "reason",
+        existing_type=sa.Text(),
+        type_=sa.String(length=1000),
+        existing_nullable=True,
+    )
+
+    op.alter_column(
+        "station_disruptions",
+        "description",
+        existing_type=sa.Text(),
+        type_=sa.String(length=1000),
+        existing_nullable=False,
+    )

--- a/backend/app/models/tfl.py
+++ b/backend/app/models/tfl.py
@@ -11,6 +11,7 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     String,
+    Text,
     UniqueConstraint,
     text,
 )
@@ -318,7 +319,7 @@ class LineDisruptionStateLog(BaseModel):
         comment="Disruption status (e.g., 'Good Service', 'Minor Delays', 'Severe Delays')",
     )
     reason: Mapped[str | None] = mapped_column(
-        String(1000),
+        Text,
         nullable=True,
         comment="Full disruption reason text (nullable for good service)",
     )
@@ -457,7 +458,7 @@ class StationDisruption(BaseModel):
         comment="Disruption type from TfL API (e.g., 'Information', 'Interchange Message')",
     )
     description: Mapped[str] = mapped_column(
-        String(1000),
+        Text,
         nullable=False,
     )
     appearance: Mapped[str | None] = mapped_column(


### PR DESCRIPTION
included in this release:
- (#297) (#304) fix for TfL API disruption reasons exceeding 1000 characters