### PR TITLE
refactor: use explicit field mapping for Response→Request conversion

### DIFF
--- a/frontend/src/components/routes/SegmentBuilder/hooks/useSegmentBuilderState.ts
+++ b/frontend/src/components/routes/SegmentBuilder/hooks/useSegmentBuilderState.ts
@@ -16,6 +16,7 @@ import type {
   StationResponse,
   SegmentRequest,
 } from '../../../../lib/api'
+import { segmentResponseToRequest } from '../../../../lib/segment-utils'
 import type { Step, CoreSegmentBuilderState } from '../types'
 import {
   MAX_ROUTE_SEGMENTS,
@@ -123,8 +124,7 @@ export function useSegmentBuilderState({
 
   // Local state for segments being built
   const [localSegments, setLocalSegments] = useState<SegmentRequest[]>(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    initialSegments.map(({ id: _id, ...rest }) => rest)
+    initialSegments.map(segmentResponseToRequest)
   )
 
   // State for building current segment
@@ -501,10 +501,7 @@ export function useSegmentBuilderState({
    */
   const handleCancel = useCallback(
     (onCancel: () => void) => {
-      setLocalSegments(
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        initialSegments.map(({ id: _id, ...rest }) => rest)
-      )
+      setLocalSegments(initialSegments.map(segmentResponseToRequest))
 
       // Reset state using transition function
       const newState = transitionToSelectStation()

--- a/frontend/src/lib/segment-utils.ts
+++ b/frontend/src/lib/segment-utils.ts
@@ -1,0 +1,23 @@
+/**
+ * Utility functions for segment type conversions
+ */
+
+import type { SegmentRequest, SegmentResponse } from '@/types'
+
+/**
+ * Convert SegmentResponse to SegmentRequest by extracting only request fields.
+ *
+ * This prevents response-only fields (id, created_at, etc.) from leaking into requests.
+ * Uses explicit field mapping rather than spread/destructuring to ensure only the
+ * intended request fields are included, even if the backend adds new response-only fields.
+ *
+ * @param response - The segment response from the backend
+ * @returns A segment request object suitable for API calls
+ */
+export function segmentResponseToRequest(response: SegmentResponse): SegmentRequest {
+  return {
+    sequence: response.sequence,
+    station_tfl_id: response.station_tfl_id,
+    line_tfl_id: response.line_tfl_id,
+  }
+}

--- a/frontend/src/pages/RouteDetails.tsx
+++ b/frontend/src/pages/RouteDetails.tsx
@@ -14,6 +14,7 @@ import { ScheduleCard } from '../components/routes/ScheduleCard'
 import { NotificationDisplay } from '../components/routes/NotificationDisplay'
 import { useTflData } from '../hooks/useTflData'
 import { useContacts } from '../hooks/useContacts'
+import { segmentResponseToRequest } from '../lib/segment-utils'
 import {
   type RouteResponse,
   type SegmentRequest,
@@ -103,10 +104,7 @@ export function RouteDetails() {
     if (!route) return
     setEditName(route.name)
     setEditDescription(route.description || '')
-    setEditSegments(
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      route.segments.map(({ id: _id, ...rest }) => rest)
-    )
+    setEditSegments(route.segments.map(segmentResponseToRequest))
     setEditSchedules([...route.schedules])
     setEditNotifications([...notifications])
     setIsEditing(true)


### PR DESCRIPTION
Replace destructuring pattern with explicit utility function for converting SegmentResponse to SegmentRequest. This prevents response-only fields (id, created_at, etc.) from leaking into request payloads.

Changes:
- Create segmentResponseToRequest utility function in lib/segment-utils.ts
- Update RouteDetails.tsx to use utility function
- Update useSegmentBuilderState.ts (2 locations) to use utility function
- Keep spread operator in CreateRoute.tsx and SegmentBuilder.tsx (Request→Display)

The hybrid approach balances forward compatibility with type safety:
- Request→Display: Spread operator preserves all fields (safe)
- Response→Request: Explicit mapping prevents field leakage (correct)

Addresses code review feedback from PR #320 (comments by copilot-pull-request-reviewer).