### PR TITLE
feat: add ESLint rule to prevent type imports from @/lib/api (#328)

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -25,6 +25,21 @@ export default defineConfig([
         'warn',
         { allowConstantExport: true },
       ],
+      // Enforce importing types from @/types, not @/lib/api
+      // See api.ts header comment for details
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@/lib/api'],
+              importNamePattern: '^(?!ApiError$)[A-Z]',
+              message:
+                "Import types from '@/types' instead of '@/lib/api'. Only functions and ApiError should be imported from here.",
+            },
+          ],
+        },
+      ],
     },
     languageOptions: {
       ecmaVersion: 2020,


### PR DESCRIPTION
## Summary

Adds ESLint rule to enforce the convention that types should be imported from `@/types`, not from `@/lib/api`.

## Context

- TypeScript allows importing types from modules that use them in function signatures (even if not explicitly re-exported)
- This was causing maintenance issues where developers could import types from `@/lib/api` instead of `@/types`
- PR #326 had multiple instances that were manually fixed (commits b9a9a98, abe0e2b)
- Previously only enforced by a warning comment in api.ts header

## Changes

Added `no-restricted-imports` rule to `frontend/eslint.config.js`:
- Blocks all PascalCase imports from `@/lib/api` except `ApiError` (error handling class)
- Allows all function imports (lowercase start)
- Provides clear error message directing developers to `@/types`

### Rule Behavior

| Import | Result |
|--------|--------|
| `import type { DisruptionResponse } from '@/lib/api'` | ❌ Blocked with error |
| `import { HealthResponse } from '@/lib/api'` | ❌ Blocked |
| `import { ApiError } from '@/lib/api'` | ✅ Allowed (exception) |
| `import { getCurrentUser } from '@/lib/api'` | ✅ Allowed (function) |

## Testing

- ✅ ESLint passes on all existing code (0 errors)
- ✅ Pre-commit hooks pass (all checks green)
- ✅ All existing imports are valid (functions + ApiError only)

## Test plan

- [ ] Verify PR build passes
- [ ] Verify ESLint catches violations in CI

Closes #328