### PR TITLE
fix: ensure venv binaries have execute permissions in Docker image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -56,6 +56,9 @@ RUN groupadd -r -g 1000 appuser && \
 # Copy the virtual environment from the builder
 COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
 
+# Ensure .venv/bin scripts have execute permissions
+RUN chmod -R +x /app/.venv/bin/*
+
 # Copy application code
 COPY --chown=appuser:appuser . .
 


### PR DESCRIPTION
The migrations container was failing with EACCES when trying to execute alembic. This was caused by the COPY --from=builder --chown command not preserving execute permissions on the virtualenv binaries.

Add explicit chmod +x command after copying .venv to ensure all scripts in .venv/bin have execute permissions.

Fixes production deployment failure where migrations container exits with: "Command failed with EACCES: /app/.venv/bin/alembic upgrade head"