### PR TITLE
fix: repair broken Python symlinks in multi-stage Docker build (#341)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -56,7 +56,15 @@ RUN groupadd -r -g 1000 appuser && \
 # Copy the virtual environment from the builder
 COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
 
-# Ensure .venv/bin scripts have execute permissions (skip symlinks to avoid dangling symlink errors)
+# Fix broken Python symlinks created by uv in builder stage
+# The builder stage symlinks point to /root/.local/share/uv/python which doesn't exist in runtime stage
+# Recreate symlinks to point to system Python
+RUN rm -f /app/.venv/bin/python /app/.venv/bin/python3 /app/.venv/bin/python3.14 && \
+    ln -s /usr/local/bin/python3.14 /app/.venv/bin/python3.14 && \
+    ln -s python3.14 /app/.venv/bin/python3 && \
+    ln -s python3 /app/.venv/bin/python
+
+# Ensure .venv/bin scripts have execute permissions (only files, not symlinks)
 RUN find /app/.venv/bin -type f -exec chmod +x {} \;
 
 # Copy application code


### PR DESCRIPTION
## Summary
- Fix EACCES error in production migrations container by repairing broken Python symlinks
- This supersedes PR #337 and #339 which attempted to fix via chmod but missed the root cause

## Root Cause Analysis
The issue was **broken Python symlinks**, not permission problems:

1. When `uv` creates the virtualenv in the builder stage, it creates symlinks pointing to:
   ``` /app/.venv/bin/python →
/root/.local/share/uv/python/cpython-3.14.0-linux-aarch64-gnu/bin/python3.14
   ```

2. When we copy `.venv` to the runtime stage with `COPY --from=builder`, this path doesn't exist → broken symlink

3. When `dotenvx` tries to spawn `/app/.venv/bin/alembic` (which has shebang `#!/app/.venv/bin/python`), the broken symlink causes **EACCES**

## Solution
After copying `.venv` from builder stage:
1. Remove broken Python symlinks
2. Recreate symlinks pointing to system Python (`/usr/local/bin/python3.14`)
3. Keep the `find ... chmod` for actual script files (not symlinks)

## Testing
Verified on production server (4.250.195.144):
- ✅ `alembic current` works
- ✅ `alembic upgrade head` works  
- ✅ No more EACCES errors
- ✅ dotenvx can successfully spawn alembic

## Changes
- `backend/Dockerfile`: Add symlink recreation after copying .venv from builder

## Context
This issue appeared after commit 2cb48a3 which added dotenvx wrapper around commands. The wrapper uses Node's `spawn()` which properly detects broken symlinks, whereas the previous direct execution didn't expose this issue.