### PR TITLE
feat: add build commit tracking and fix Docker symlinks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_COMMIT=${{ github.sha }}
           cache-from: type=registry,ref=${{ env.BACKEND_IMAGE }}:buildcache
           cache-to: type=registry,ref=${{ env.BACKEND_IMAGE }}:buildcache,mode=max
 
@@ -102,6 +104,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_COMMIT=${{ github.sha }}
           cache-from: type=registry,ref=${{ env.FRONTEND_IMAGE }}:buildcache
           cache-to: type=registry,ref=${{ env.FRONTEND_IMAGE }}:buildcache,mode=max
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,20 +3,13 @@
 # See: https://docs.astral.sh/uv/guides/integration/docker/
 
 # Stage 1: Build dependencies
-FROM python:3.14-slim AS builder
-
-# Install build dependencies for compiling Python packages
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    gcc \
-    libc6-dev \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install uv
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+# Use uv's official image with Python 3.14 pre-installed
+FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim AS builder
 
 # Enable bytecode compilation for faster startup
-ENV UV_COMPILE_BYTECODE=1
+# Copy files instead of symlinking to avoid broken links in multi-stage builds
+# Use system Python from the base image instead of downloading a new one
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy UV_PYTHON_DOWNLOADS=0
 
 # Change the working directory to the `app` directory
 WORKDIR /app
@@ -35,7 +28,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-editable
 
 # Stage 2: Production runtime
-FROM python:3.14-slim
+# Use matching Python version from official Python images
+FROM python:3.14-slim-bookworm
+
+# Accept build commit hash as build arg (defaults to "unknown" for local builds)
+ARG BUILD_COMMIT=unknown
+ENV BUILD_COMMIT=${BUILD_COMMIT}
 
 WORKDIR /app
 
@@ -53,22 +51,9 @@ RUN groupadd -r -g 1000 appuser && \
     useradd -r -u 1000 -g appuser -m -d /home/appuser -s /sbin/nologin -c "Application user" appuser && \
     chown -R appuser:appuser /app
 
-# Copy the virtual environment from the builder
-COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
-
-# Fix broken Python symlinks created by uv in builder stage
-# The builder stage symlinks point to /root/.local/share/uv/python which doesn't exist in runtime stage
-# Recreate symlinks to point to system Python
-RUN rm -f /app/.venv/bin/python /app/.venv/bin/python3 /app/.venv/bin/python3.14 && \
-    ln -s /usr/local/bin/python3.14 /app/.venv/bin/python3.14 && \
-    ln -s python3.14 /app/.venv/bin/python3 && \
-    ln -s python3 /app/.venv/bin/python
-
-# Ensure .venv/bin scripts have execute permissions (only files, not symlinks)
-RUN find /app/.venv/bin -type f -exec chmod +x {} \;
-
-# Copy application code
-COPY --chown=appuser:appuser . .
+# Copy the application and virtual environment from builder
+# Both stages use system Python 3.14, so symlinks in .venv/bin work correctly
+COPY --from=builder --chown=appuser:appuser /app /app
 
 # Set environment variables
 ENV PYTHONPATH=/app

--- a/backend/app/celery/app.py
+++ b/backend/app/celery/app.py
@@ -82,6 +82,9 @@ def init_beat_otel(
             # Initialize LoggerProvider for log export
             set_logger_provider()
             logger.info("beat_otel_logger_provider_initialized")
+
+            # Log build commit for version tracking
+            logger.info("beat_init_completed", build_commit=settings.BUILD_COMMIT)
         except Exception:
             logger.exception("beat_otel_initialization_failed")
             # Continue without OTEL - graceful degradation

--- a/backend/app/celery/app.py
+++ b/backend/app/celery/app.py
@@ -82,12 +82,13 @@ def init_beat_otel(
             # Initialize LoggerProvider for log export
             set_logger_provider()
             logger.info("beat_otel_logger_provider_initialized")
-
-            # Log build commit for version tracking
-            logger.info("beat_init_completed", build_commit=settings.BUILD_COMMIT)
         except Exception:
             logger.exception("beat_otel_initialization_failed")
             # Continue without OTEL - graceful degradation
+
+    # Log build commit for version tracking
+    # Always log regardless of OTEL status for diagnostic purposes
+    logger.info("beat_init_completed", build_commit=settings.BUILD_COMMIT)
 
 
 @worker_ready.connect

--- a/backend/app/celery/database.py
+++ b/backend/app/celery/database.py
@@ -85,7 +85,7 @@ def init_worker_resources(
         set_logger_provider()
         logger.info("worker_otel_logger_provider_initialized")
 
-    logger.info("worker_process_init_completed")
+    logger.info("worker_process_init_completed", build_commit=settings.BUILD_COMMIT)
 
 
 @worker_process_shutdown.connect

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -20,6 +20,7 @@ class Settings(BaseSettings):
     API_V1_PREFIX: str = "/api/v1"
     PROJECT_NAME: str = "IsTheTubeRunning"
     DEBUG: bool = False
+    BUILD_COMMIT: str = "unknown"  # Git commit hash injected at Docker build time
     ALLOWED_ORIGINS: str
 
     @field_validator("ALLOWED_ORIGINS", mode="after")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -217,7 +217,7 @@ async def root() -> dict[str, str]:
 @app.get("/health")
 async def health_check() -> dict[str, str]:
     """Health check endpoint."""
-    return {"status": "healthy"}
+    return {"status": "healthy", "version": __version__, "build_commit": settings.BUILD_COMMIT}
 
 
 @app.get("/ready")

--- a/backend/tests/test_beat_otel.py
+++ b/backend/tests/test_beat_otel.py
@@ -91,10 +91,13 @@ class TestBeatOtelInitialization:
             # Call the signal handler
             celery_app_module.init_beat_otel()
 
-            # Verify logging was called for both providers
-            assert mock_logger_info.call_count == 2
+            # Verify logging was called for both providers and build_commit
+            assert mock_logger_info.call_count == 3
             mock_logger_info.assert_any_call("beat_otel_tracer_provider_initialized")
             mock_logger_info.assert_any_call("beat_otel_logger_provider_initialized")
+            mock_logger_info.assert_any_call(
+                "beat_init_completed", build_commit=celery_app_module.settings.BUILD_COMMIT
+            )
 
     def test_beat_init_handles_get_tracer_provider_exception(self) -> None:
         """Test that beat_init handles exception from get_tracer_provider gracefully."""

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -15,6 +15,10 @@ RUN npm ci --include dev --include optional
 # Copy source code
 COPY . .
 
+# Accept build commit hash as build arg (defaults to "unknown" for local builds)
+ARG BUILD_COMMIT=unknown
+ENV VITE_BUILD_COMMIT=${BUILD_COMMIT}
+
 # Build the application (no environment-specific config - loaded at runtime)
 RUN npm run build
 

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -20,7 +20,12 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
           <p className="text-sm text-muted-foreground">
             © {currentYear} TfL Alerts. Not affiliated with Transport for London.
           </p>
-          <p className="text-sm text-muted-foreground">Powered by TfL Open Data</p>
+          <div className="flex flex-col items-center gap-2 md:items-end">
+            <p className="text-sm text-muted-foreground">Powered by TfL Open Data</p>
+            <p className="text-xs text-muted-foreground/50">
+              Build: {__BUILD_COMMIT__.substring(0, 7)}
+            </p>
+          </div>
         </div>
       </footer>
       <Toaster />

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -23,7 +23,8 @@ export const AppLayout = ({ children }: AppLayoutProps) => {
           <div className="flex flex-col items-center gap-2 md:items-end">
             <p className="text-sm text-muted-foreground">Powered by TfL Open Data</p>
             <p className="text-xs text-muted-foreground/50">
-              Build: {__BUILD_COMMIT__.substring(0, 7)}
+              Build:{' '}
+              {(typeof __BUILD_COMMIT__ === 'string' ? __BUILD_COMMIT__ : 'dev').substring(0, 7)}
             </p>
           </div>
         </div>

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite/client" />
+
+// Build-time constants injected by Vite
+declare const __BUILD_COMMIT__: string

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,9 @@ import { fileURLToPath } from 'url'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [tailwindcss(), react()],
+  define: {
+    __BUILD_COMMIT__: JSON.stringify(process.env.VITE_BUILD_COMMIT || 'dev'),
+  },
   resolve: {
     alias: {
       '@': fileURLToPath(new URL('./src', import.meta.url)),


### PR DESCRIPTION
## Summary

This PR addresses issues #343 and #345:

### Issue #343: Build ID Tracking
- Added git commit hash to `/health` endpoint response (`version` and `build_commit` fields)
- Display 7-character commit hash in frontend footer
- Log build commit on Celery worker and beat scheduler startup for debugging
- Pass `BUILD_COMMIT` via Docker build args in CI/CD pipeline

### Issue #345: Docker Symlink Fix
- Replaced manual symlink handling with official uv multi-stage Docker pattern
- Use `ghcr.io/astral-sh/uv:python3.14-bookworm-slim` as builder base image
- Set `UV_PYTHON_DOWNLOADS=0` to use system Python from both stages
- Both builder and runtime stages use matching Python 3.14, eliminating broken symlinks

## Technical Details

**Backend Changes:**
- `backend/Dockerfile`: Refactored to follow [official uv multi-stage pattern](https://docs.astral.sh/uv/guides/integration/docker/)
- `backend/app/core/config.py`: Added `BUILD_COMMIT` setting
- `backend/app/main.py`: Updated `/health` endpoint to include `build_commit`
- `backend/app/celery/app.py`: Log build commit on beat initialization
- `backend/app/celery/database.py`: Log build commit on worker initialization
- `backend/tests/test_beat_otel.py`: Updated test expectations for new log line

**Frontend Changes:**
- `frontend/Dockerfile`: Added `BUILD_COMMIT` build arg
- `frontend/vite.config.ts`: Added `__BUILD_COMMIT__` define block
- `frontend/src/vite-env.d.ts`: Added TypeScript type declaration for build constant
- `frontend/src/components/layout/AppLayout.tsx`: Display short hash in footer

**Infrastructure:**
- `.github/workflows/deploy.yml`: Pass `BUILD_COMMIT=${{ github.sha }}` to Docker builds

## Test Plan

- [x] Backend Docker build succeeds with no symlink errors
- [x] `alembic` command works in Docker container (verifies symlinks fixed)
- [x] Backend tests pass: **1535 passed** (95.69% coverage)
- [x] Frontend tests pass: **659 passed**
- [x] Pre-commit hooks pass
- [ ] Verify `/health` endpoint returns `build_commit` in deployed environment
- [ ] Verify frontend footer displays commit hash in production
- [ ] Verify Celery worker logs show `build_commit` on startup
- [ ] Verify Celery beat logs show `build_commit` on startup

## Related Issues

Closes #343
Closes #345

## Summary by Sourcery

Track build commit metadata across backend, frontend, and worker processes and update Docker images to use the official uv-based pattern with reliable Python symlinks.

New Features:
- Expose application version and build commit hash via the backend /health endpoint.
- Display the current build commit hash in the frontend footer using a build-time constant.
- Log the build commit hash on Celery worker and beat initialization for improved observability.

Enhancements:
- Refactor backend Dockerfile to use the official uv multi-stage image and configuration, eliminating manual Python symlink fixes.
- Propagate the build commit hash into backend and frontend containers via build arguments and environment configuration.

CI:
- Update deployment workflow to pass the current Git commit SHA as a build argument to backend and frontend Docker builds.

Tests:
- Adjust Celery beat initialization test expectations to cover the new build commit log entry.