### PR TITLE
docs: add references to ADRs and fork-safety.md in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ If you want to run a local OTEL collector:
 1. Set `OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:4318/v1/traces"`
 2. Run `{projectroot}/scripts/otelcol --config {projectroot}/scripts/otel-config.yaml`
 3. Watch the output
+`InMemorySpanExporter` is probably a better idea. Check `conftest.py`.
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,10 @@
 ## Principles
 
 - This is a hobby project - prefer KISS, DRY, YAGNI over enterprise patterns
-- Read relevant ADRs in `docs/adr/` before starting work
+- **Read relevant ADRs before starting work:**
+  - Start with `docs/adr/README.md` for the full index
+  - Testing work? Read `docs/adr/10-testing.md`
+  - Background jobs/Celery? Read `docs/adr/08-background-jobs.md`
 - Consider whether your changes warrant updating the ADRs; include this as a task if needed
 
 ---
@@ -115,6 +118,8 @@ Start these as background bash processes (never detached/nohup):
 - Celery worker
 - Celery beat
 - Frontend dev server
+
+**Note:** If working on Celery workers or uvicorn multi-worker deployment, read `docs/fork-safety.md` for critical fork safety patterns (SQLAlchemy AsyncEngine, OpenTelemetry, Redis client).
 
 ### Secrets & Environment
 - In `/backend`, always use `dotenvx run -- uv run` (never naked `python`)


### PR DESCRIPTION
## Summary
Add explicit references to key documentation files to improve discoverability for agents working on the codebase.

## Changes

### Principles Section
Expand ADR guidance with specific examples:
- Link to `docs/adr/README.md` as starting point
- Direct reference to `docs/adr/10-testing.md` for testing work
- Direct reference to `docs/adr/08-background-jobs.md` for Celery work

### Development Environment Section
Add note about fork safety documentation:
- Reference `docs/fork-safety.md` for Celery worker or uvicorn multi-worker development
- Mentions critical patterns: SQLAlchemy AsyncEngine, OpenTelemetry, Redis client

## Rationale
The ADRs (Architecture Decision Records) and fork-safety documentation contain critical context that agents need when working on specific areas of the codebase. Making these references explicit in AGENTS.md helps ensure agents read the relevant docs before starting work, reducing errors and improving code quality.

This is a small, focused change addressing the feedback to include these documentation references.

## Related
- Follows up on PR #348 (guidelines reorganization)
- Addresses missing references to `docs/fork-safety.md` and specific ADRs