### PR TITLE
fix: ensure frontend volume updates on deployment

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -201,8 +201,9 @@ services:
       - frontend_static:/www
       # No config mount needed - config.json contains all environments
       # and auto-detects based on hostname (isthetube.cynexia.com → production)
-    # Override CMD to just copy files and exit (no need to run httpd)
-    command: sh -c "echo 'Frontend assets built and ready in volume' && sleep 1"
+    # Override CMD to clear old files, copy fresh assets from image, and exit
+    # This ensures stale files are removed (similar to rsync --delete behavior)
+    command: sh -c "rm -rf /www/* && cp -a /www-build/. /www/ && echo 'Frontend assets copied to volume'"
     deploy:
       resources:
         limits:

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -201,9 +201,10 @@ services:
       - frontend_static:/www
       # No config mount needed - config.json contains all environments
       # and auto-detects based on hostname (isthetube.cynexia.com → production)
-    # Override CMD to clear old files, copy fresh assets from image, and exit
-    # This ensures stale files are removed (similar to rsync --delete behavior)
-    command: sh -c "rm -rf /www/* && cp -a /www-build/. /www/ && echo 'Frontend assets copied to volume'"
+    # Override CMD to clear ALL files (including dotfiles), copy fresh assets, and exit
+    # Using 'find -delete' to remove dotfiles; 'set -e' ensures nginx waits on copy failure
+    # Echo only runs if copy succeeds, providing confirmation in logs
+    command: sh -c "set -e && find /www -mindepth 1 -delete && cp -a /www-build/. /www/ && echo 'Frontend assets copied to volume'"
     deploy:
       resources:
         limits:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -41,10 +41,11 @@ USER www
 # Expose port 8080 (non-privileged port)
 EXPOSE 8080
 
-# Copy assets from staging to runtime dir, then serve (removes stale files on each start)
+# Copy assets from staging to runtime dir, then serve (removes ALL files including dotfiles)
 # Production: command is overridden in docker-compose to just copy and exit
 # Standalone/test: copies then runs httpd
-CMD ["sh", "-c", "rm -rf /www/* && cp -a /www-build/. /www/ && busybox httpd -f -p 8080 -h /www"]
+# Using 'find -delete' to remove dotfiles; 'set -e' ensures copy failures are detected
+CMD ["sh", "-c", "set -e && find /www -mindepth 1 -delete && cp -a /www-build/. /www/ && busybox httpd -f -p 8080 -h /www"]
 
 # Security labels for container runtime
 LABEL security.readonly_rootfs="true" \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -28,11 +28,12 @@ FROM busybox:1.36-musl
 # Create non-root user
 RUN adduser -D -u 1000 -g 1000 -s /sbin/nologin www
 
-# Create web directory with proper permissions
-RUN mkdir -p /www && chown -R www:www /www
+# Copy built assets from builder stage to staging directory
+# Files are copied from /www-build to /www at runtime to ensure fresh deployments
+COPY --from=builder --chown=www:www /app/dist /www-build
 
-# Copy built assets from builder stage
-COPY --from=builder --chown=www:www /app/dist /www
+# Create runtime directory (volume mount point in production)
+RUN mkdir -p /www && chown www:www /www
 
 # Switch to non-root user
 USER www
@@ -40,9 +41,10 @@ USER www
 # Expose port 8080 (non-privileged port)
 EXPOSE 8080
 
-# Run busybox httpd as non-root with minimal permissions
-# -f: foreground, -p: port, -h: home directory, -u: user
-CMD ["busybox", "httpd", "-f", "-p", "8080", "-h", "/www"]
+# Copy assets from staging to runtime dir, then serve (removes stale files on each start)
+# Production: command is overridden in docker-compose to just copy and exit
+# Standalone/test: copies then runs httpd
+CMD ["sh", "-c", "rm -rf /www/* && cp -a /www-build/. /www/ && busybox httpd -f -p 8080 -h /www"]
 
 # Security labels for container runtime
 LABEL security.readonly_rootfs="true" \


### PR DESCRIPTION
## Problem
Frontend static files were not updating on deployment because:
- Docker volumes persist data across container recreations
- Docker only auto-populates volumes when they are empty (first run)
- Subsequent deployments had old files in the volume shadowing new files from the image

This caused:
- Build commit ID not showing in production UI (reported in #350)
- Live status features missing (old code being served)

## Root Cause
The frontend container command was:
```sh
sh -c "echo 'Frontend assets built and ready in volume' && sleep 1"
```

This did nothing to refresh files. Docker's one-time volume population only works on empty volumes, so old files persisted indefinitely.

## Solution
Modified frontend deployment to explicitly copy files from staging directory to volume on every deployment:

### 1. `frontend/Dockerfile`
- Build assets to `/www-build` (staging) instead of `/www`
- Default CMD: `rm -rf /www/* && cp -a /www-build/. /www/ && busybox httpd ...`
- Ensures stale files are removed (similar to `rsync --delete`)
- Works for both standalone containers and production deployment

### 2. `deploy/docker-compose.prod.yml`
- Override command to: `rm -rf /www/* && cp -a /www-build/. /www/ && echo ...`
- Frontend container acts as init container
- Clears old files, copies fresh assets, then exits
- Nginx waits for `service_completed_successfully` before serving

## Why This Works
- **Every deployment**: Fresh files replace entire volume content
- **Stale files removed**: `rm -rf /www/*` before copy removes obsolete assets
- **No downtime**: nginx waits for init container completion
- **No CI/CD changes**: Build process stays the same
- **Atomic**: Files are copied before nginx starts serving
- **Test compatible**: Default CMD works for standalone container tests

## Testing
- ✅ Local Docker build verified
- ✅ Files in `/www-build` confirmed
- ✅ Default CMD copies to `/www` and serves HTML
- ✅ Test script passes (`scripts/test-docker-builds.sh`)
- ✅ All pre-commit hooks passed

## Test Plan
After merge to `release` and deployment:
- [ ] Verify build commit shows in production footer
- [ ] Verify live status displays correctly
- [ ] Verify no console errors in browser
- [ ] Verify frontend container exits successfully after copy
- [ ] Verify nginx serves updated files

## Related
Fixes #350

## Summary by Sourcery

Ensure frontend static assets in the shared volume are refreshed on every deployment instead of persisting stale files.

Bug Fixes:
- Force-copy freshly built frontend assets into the runtime web directory on container start to prevent old files from shadowing new ones in the Docker volume.

Enhancements:
- Refine the frontend Docker image to separate built assets into a staging directory and copy them into the runtime directory on startup, removing stale files first.

Build:
- Update production docker-compose configuration so the frontend container clears the web volume, copies fresh assets from the image, and exits after preparing files for nginx.