### PR TITLE
feat: notify users when previously-alerted disruptions clear (#361)

### DIFF
--- a/backend/alembic/versions/1025d77921da_add_is_cleared_state_to_alert_disabled_.py
+++ b/backend/alembic/versions/1025d77921da_add_is_cleared_state_to_alert_disabled_.py
@@ -1,0 +1,85 @@
+"""add_is_cleared_state_to_alert_disabled_severities
+
+Adds is_cleared_state column to alert_disabled_severities table to distinguish
+between cleared states (Good Service, No Issues) and suppressed states (Service Closed).
+
+This enables issue #361: Alert if disruption clears during notification window.
+
+Revision ID: 1025d77921da
+Revises: 1f4d6532d88a
+Create Date: 2025-12-08 08:40:18.392507
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "1025d77921da"
+down_revision: str | Sequence[str] | None = "1f4d6532d88a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Step 1: Add is_cleared_state column with default False
+    op.add_column(
+        "alert_disabled_severities",
+        sa.Column("is_cleared_state", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+    # Step 2: Update existing "Good Service" (severity 10) rows to is_cleared_state=True
+    op.execute(
+        sa.text(
+            """
+            UPDATE alert_disabled_severities
+            SET is_cleared_state = true
+            WHERE severity_level = 10
+            """
+        )
+    )
+
+    # Step 3: Add "No Issues" (severity 18) for each mode with is_cleared_state=True
+    # List of TfL modes that support severity level 18 (No Issues)
+    tfl_modes = [
+        "tube",
+        "dlr",
+        "overground",
+        "elizabeth-line",
+        "tram",
+        "cable-car",
+        "river-bus",
+        "bus",
+        "cycle-hire",
+        "river-tour",
+    ]
+
+    for mode in tfl_modes:
+        op.execute(
+            sa.text(
+                """
+                INSERT INTO alert_disabled_severities (id, mode_id, severity_level, is_cleared_state, created_at, updated_at)
+                VALUES (gen_random_uuid(), :mode_id, 18, true, now(), now())
+                ON CONFLICT DO NOTHING
+                """
+            ).bindparams(mode_id=mode)
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Remove "No Issues" (severity 18) entries that were added in upgrade
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM alert_disabled_severities
+            WHERE severity_level = 18 AND is_cleared_state = true
+            """
+        )
+    )
+
+    # Drop the is_cleared_state column
+    op.drop_column("alert_disabled_severities", "is_cleared_state")

--- a/backend/alembic/versions/1025d77921da_add_is_cleared_state_to_alert_disabled_.py
+++ b/backend/alembic/versions/1025d77921da_add_is_cleared_state_to_alert_disabled_.py
@@ -63,7 +63,8 @@ def upgrade() -> None:
                 """
                 INSERT INTO alert_disabled_severities (id, mode_id, severity_level, is_cleared_state, created_at, updated_at)
                 VALUES (gen_random_uuid(), :mode_id, 18, true, now(), now())
-                ON CONFLICT DO NOTHING
+                ON CONFLICT (mode_id, severity_level)
+                DO UPDATE SET is_cleared_state = true, updated_at = now()
                 """
             ).bindparams(mode_id=mode)
         )

--- a/backend/app/core/redis.py
+++ b/backend/app/core/redis.py
@@ -33,6 +33,10 @@ class RedisClientProtocol(Protocol):
         """Set the value at key name with expiration time."""
         ...
 
+    async def delete(self, *names: str) -> int:
+        """Delete one or more keys."""
+        ...
+
     async def ping(self) -> bool:
         """Ping the Redis server to check connectivity."""
         ...

--- a/backend/app/models/tfl.py
+++ b/backend/app/models/tfl.py
@@ -236,7 +236,14 @@ class AlertDisabledSeverity(BaseModel):
     excluded from alert processing. The default behavior is to alert for all
     severities unless they appear in this table.
 
-    Example: Good Service (severity_level=10) should not trigger alerts.
+    The is_cleared_state flag distinguishes between:
+    - Cleared states (is_cleared_state=True): e.g., Good Service, No Issues
+      These indicate a disruption has cleared and users should be notified.
+    - Suppressed states (is_cleared_state=False): e.g., Service Closed
+      These are still problematic but we don't alert on them.
+
+    Example: Good Service (severity_level=10, is_cleared_state=True) should not
+    trigger disruption alerts, but should trigger "cleared" notifications.
     """
 
     __tablename__ = "alert_disabled_severities"
@@ -251,6 +258,11 @@ class AlertDisabledSeverity(BaseModel):
         nullable=False,
         index=True,
     )
+    is_cleared_state: Mapped[bool] = mapped_column(
+        nullable=False,
+        server_default="false",
+        comment="True if this state represents a cleared disruption (Good Service, No Issues)",
+    )
 
     __table_args__ = (
         UniqueConstraint(
@@ -262,7 +274,10 @@ class AlertDisabledSeverity(BaseModel):
 
     def __repr__(self) -> str:
         """String representation of the alert disabled severity."""
-        return f"<AlertDisabledSeverity(id={self.id}, mode={self.mode_id}, level={self.severity_level})>"
+        return (
+            f"<AlertDisabledSeverity(id={self.id}, mode={self.mode_id}, "
+            f"level={self.severity_level}, cleared={self.is_cleared_state})>"
+        )
 
 
 class DisruptionCategory(BaseModel):

--- a/backend/app/schemas/tfl.py
+++ b/backend/app/schemas/tfl.py
@@ -84,6 +84,21 @@ class DisruptionResponse(BaseModel):
     affected_routes: list[AffectedRouteInfo] | None = None  # Affected route segments with station sequences
 
 
+class ClearedLineInfo(BaseModel):
+    """Information about a line that has returned to normal service.
+
+    Used to track which lines have cleared from disrupted state during a notification window.
+    """
+
+    line_id: str  # TfL line ID
+    line_name: str
+    mode: str  # Transport mode
+    previous_severity: int  # What severity it was (e.g., 6 = Severe Delays)
+    previous_status: str  # What status it was (e.g., "Severe Delays")
+    current_severity: int  # What severity it is now (e.g., 10 = Good Service)
+    current_status: str  # What status it is now (e.g., "Good Service")
+
+
 class LineStatusInfo(BaseModel):
     """Individual status for a line (used in grouped API response).
 

--- a/backend/app/services/alert_service.py
+++ b/backend/app/services/alert_service.py
@@ -1725,8 +1725,8 @@ class AlertService:
                 route, disabled_severity_pairs
             )
 
-            # Skip if no disruptions
-            if not disruptions:
+            # Skip if no disruptions at all (need to check cleared lines even if no alertable disruptions)
+            if not disruptions and not all_route_disruptions:
                 logger.debug(
                     "no_disruptions_for_route",
                     route_id=str(route.id),
@@ -1734,12 +1734,13 @@ class AlertService:
                 )
                 return 0, error_occurred
 
-            logger.info(
-                "disruptions_found_for_route",
-                route_id=str(route.id),
-                route_name=route.name,
-                disruption_count=len(disruptions),
-            )
+            if disruptions:
+                logger.info(
+                    "disruptions_found_for_route",
+                    route_id=str(route.id),
+                    route_name=route.name,
+                    disruption_count=len(disruptions),
+                )
 
             # Check if we should send alert (per-line cooldown deduplication)
             should_send, filtered_disruptions, stored_lines = await self._should_send_alert(

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -7,7 +7,7 @@ import structlog
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from app.core.telemetry import service_span
-from app.schemas.tfl import DisruptionResponse
+from app.schemas.tfl import ClearedLineInfo, DisruptionResponse
 from app.services.email_service import EmailService
 from app.services.sms_service import SmsService
 from app.utils.pii import hash_pii
@@ -196,6 +196,182 @@ This is an automated alert from IsTheTubeRunning.
             except Exception as e:
                 logger.error(
                     "disruption_sms_failed",
+                    recipient_hash=recipient_hash,
+                    route_name=route_name,
+                    error=str(e),
+                    exc_info=e,
+                )
+                raise
+
+    async def send_status_update_email(
+        self,
+        email: str,
+        route_name: str,
+        cleared_lines: list[ClearedLineInfo],
+        still_disrupted: list[DisruptionResponse],
+        user_name: str | None = None,
+    ) -> None:
+        """
+        Send a status update email when previously-alerted lines clear.
+
+        Args:
+            email: Recipient email address
+            route_name: Name of the route
+            cleared_lines: Lines that have returned to normal service
+            still_disrupted: Lines that remain disrupted (for context)
+            user_name: User's name for personalized greeting (defaults to "there")
+
+        Raises:
+            Exception: If email sending fails
+        """
+        recipient_hash = hash_pii(email)
+
+        with service_span(
+            "notification.send_status_update_email",
+            "notification-service",
+        ) as span:
+            span.set_attribute("notification.type", "email")
+            span.set_attribute("notification.recipient_hash", recipient_hash)
+            span.set_attribute("notification.route_name", route_name)
+            span.set_attribute("notification.cleared_count", len(cleared_lines))
+            span.set_attribute("notification.still_disrupted_count", len(still_disrupted))
+
+            try:
+                # Build email subject
+                subject = f"✅ Service Restored: {route_name}"
+
+                # Render the HTML template
+                html_content = self._render_email_template(
+                    "email/status_update.html",
+                    {
+                        "route_name": route_name,
+                        "user_name": user_name,
+                        "cleared_lines": cleared_lines,
+                        "still_disrupted": still_disrupted,
+                        "tfl_status_url": "https://tfl.gov.uk/tube-dlr-overground/status/",
+                    },
+                )
+
+                # Create plain text fallback
+                text_content = f"""
+Service Restored: {route_name}
+
+Service has been restored on the following lines:
+
+"""
+                for cleared in cleared_lines:
+                    text_content += (
+                        f"- {cleared.line_name}: {cleared.current_status} (was: {cleared.previous_status})\n"
+                    )
+
+                if still_disrupted:
+                    text_content += "\nStill disrupted:\n"
+                    for disruption in still_disrupted:
+                        text_content += f"- {disruption.line_name}: {disruption.status_severity_description}\n"
+
+                text_content += """
+For the latest updates, visit: https://tfl.gov.uk/tube-dlr-overground/status/
+
+This is an automated alert from IsTheTubeRunning.
+© 2025 IsTheTubeRunning. All rights reserved.
+            """.strip()
+
+                # Send email via EmailService
+                await self.email_service.send_email(email, subject, html_content, text_content)
+
+                logger.info(
+                    "status_update_email_sent",
+                    recipient_hash=recipient_hash,
+                    route_name=route_name,
+                    cleared_count=len(cleared_lines),
+                    still_disrupted_count=len(still_disrupted),
+                )
+
+            except Exception as e:
+                logger.error(
+                    "status_update_email_failed",
+                    recipient_hash=recipient_hash,
+                    route_name=route_name,
+                    error=str(e),
+                    exc_info=e,
+                )
+                raise
+
+    async def send_status_update_sms(
+        self,
+        phone: str,
+        route_name: str,
+        cleared_lines: list[ClearedLineInfo],
+        still_disrupted: list[DisruptionResponse],
+    ) -> None:
+        """
+        Send a status update SMS when previously-alerted lines clear.
+
+        Args:
+            phone: Recipient phone number
+            route_name: Name of the route
+            cleared_lines: Lines that have returned to normal service
+            still_disrupted: Lines that remain disrupted (for context)
+
+        Raises:
+            Exception: If SMS sending fails
+        """
+        recipient_hash = hash_pii(phone)
+
+        with service_span(
+            "notification.send_status_update_sms",
+            "notification-service",
+        ) as span:
+            span.set_attribute("notification.type", "sms")
+            span.set_attribute("notification.recipient_hash", recipient_hash)
+            span.set_attribute("notification.route_name", route_name)
+            span.set_attribute("notification.cleared_count", len(cleared_lines))
+            span.set_attribute("notification.still_disrupted_count", len(still_disrupted))
+
+            try:
+                # Create concise SMS text
+                # Format: "TfL Update: {route_name}. Service restored: {lines}."
+
+                # Build cleared lines text (comma-separated names)
+                cleared_names = ", ".join([cl.line_name for cl in cleared_lines[:3]])  # Limit to 3
+
+                base_msg = f"TfL Update: {route_name}. Service restored: {cleared_names}."
+
+                # Add still disrupted if any and space permits
+                if still_disrupted:
+                    disrupted_names = ", ".join([d.line_name for d in still_disrupted[:2]])
+                    disrupted_msg = f" Still disrupted: {disrupted_names}."
+                else:
+                    disrupted_msg = ""
+
+                # Add URL
+                url = " More: tfl.gov.uk/tube-dlr-overground/status/"
+
+                # Build final message
+                message = f"{base_msg}{disrupted_msg}{url}"
+
+                # If too long, drop the "still disrupted" part
+                if len(message) > SMS_MAX_LENGTH:
+                    message = f"{base_msg}{url}"
+
+                # Set message length as span attribute
+                span.set_attribute("notification.message_length", len(message))
+
+                # Send SMS via SmsService
+                await self.sms_service.send_sms(phone, message)
+
+                logger.info(
+                    "status_update_sms_sent",
+                    recipient_hash=recipient_hash,
+                    route_name=route_name,
+                    cleared_count=len(cleared_lines),
+                    still_disrupted_count=len(still_disrupted),
+                    message_length=len(message),
+                )
+
+            except Exception as e:
+                logger.error(
+                    "status_update_sms_failed",
                     recipient_hash=recipient_hash,
                     route_name=route_name,
                     error=str(e),

--- a/backend/app/templates/email/status_update.html
+++ b/backend/app/templates/email/status_update.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Service Restored - IsTheTubeRunning</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background-color: #f5f5f5;
+        }
+        .container {
+            max-width: 600px;
+            margin: 40px auto;
+            background-color: #ffffff;
+            border-radius: 8px;
+            overflow: hidden;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+        .header {
+            background: #27ae60;
+            padding: 30px 20px;
+            text-align: center;
+            color: #ffffff;
+        }
+        .header h1 {
+            margin: 0 0 10px 0;
+            font-size: 24px;
+            font-weight: 600;
+        }
+        .header .alert-icon {
+            font-size: 36px;
+            margin-bottom: 10px;
+        }
+        .header .route-name {
+            font-size: 18px;
+            font-weight: 400;
+            opacity: 0.95;
+        }
+        .content {
+            padding: 30px 30px 20px;
+        }
+        .content p {
+            color: #333333;
+            line-height: 1.6;
+            margin: 0 0 20px;
+        }
+        .greeting {
+            font-size: 16px;
+            color: #333333;
+            margin-bottom: 20px;
+        }
+        .section-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: #2c3e50;
+            margin: 25px 0 15px;
+        }
+        .cleared-line {
+            border-left: 4px solid #27ae60;
+            padding: 15px;
+            margin: 15px 0;
+            background: #e8f8f5;
+            border-radius: 4px;
+        }
+        .cleared-line .line-name {
+            font-size: 18px;
+            font-weight: 600;
+            color: #2c3e50;
+            margin-bottom: 8px;
+        }
+        .cleared-line .status {
+            font-size: 16px;
+            color: #27ae60;
+            font-weight: 500;
+            margin-bottom: 4px;
+        }
+        .cleared-line .previous-status {
+            font-size: 14px;
+            color: #666666;
+        }
+        .disruption {
+            border-left: 4px solid #e74c3c;
+            padding: 15px;
+            margin: 15px 0;
+            background: #f8f9fa;
+            border-radius: 4px;
+        }
+        .disruption .line-name {
+            font-size: 18px;
+            font-weight: 600;
+            color: #2c3e50;
+            margin-bottom: 8px;
+        }
+        .disruption .status {
+            font-size: 16px;
+            color: #e74c3c;
+            font-weight: 500;
+            margin-bottom: 8px;
+        }
+        .disruption .reason {
+            font-size: 14px;
+            color: #555555;
+            line-height: 1.5;
+            margin-top: 8px;
+        }
+        .cta-button {
+            display: inline-block;
+            background-color: #003366;
+            color: #ffffff;
+            text-decoration: none;
+            padding: 12px 30px;
+            border-radius: 6px;
+            font-weight: 600;
+            margin: 20px 0;
+            text-align: center;
+        }
+        .cta-button:hover {
+            background-color: #00254d;
+        }
+        .footer {
+            background-color: #f8f9fa;
+            padding: 20px 30px;
+            text-align: center;
+            color: #666666;
+            font-size: 12px;
+            line-height: 1.5;
+        }
+        .footer a {
+            color: #003366;
+            text-decoration: none;
+        }
+        @media only screen and (max-width: 600px) {
+            .container {
+                margin: 20px;
+                border-radius: 0;
+            }
+            .header {
+                padding: 20px 15px;
+            }
+            .header h1 {
+                font-size: 20px;
+            }
+            .header .route-name {
+                font-size: 16px;
+            }
+            .content {
+                padding: 20px 15px;
+            }
+            .cleared-line .line-name,
+            .disruption .line-name {
+                font-size: 16px;
+            }
+            .cleared-line .status,
+            .disruption .status {
+                font-size: 14px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <div class="alert-icon">✅</div>
+            <h1>Service Restored</h1>
+            <div class="route-name">{{ route_name }}</div>
+        </div>
+        <div class="content">
+            <p class="greeting">Hello {{ user_name or "there" }},</p>
+
+            <p>Good news! Service has been restored on your route <strong>{{ route_name }}</strong>.</p>
+
+            <div class="section-title">✅ Service Restored:</div>
+            {% for cleared in cleared_lines %}
+            <div class="cleared-line">
+                <div class="line-name">{{ cleared.line_name }}</div>
+                <div class="status">{{ cleared.current_status }}</div>
+                <div class="previous-status">Previously: {{ cleared.previous_status }}</div>
+            </div>
+            {% endfor %}
+
+            {% if still_disrupted %}
+            <div class="section-title">⚠️ Still Disrupted:</div>
+            <p style="font-size: 14px; color: #666666; margin-top: 10px;">
+                The following lines remain disrupted:
+            </p>
+            {% for disruption in still_disrupted %}
+            <div class="disruption">
+                <div class="line-name">{{ disruption.line_name }}</div>
+                <div class="status">{{ disruption.status_severity_description }}</div>
+                {% if disruption.reason %}
+                <div class="reason">{{ disruption.reason }}</div>
+                {% endif %}
+            </div>
+            {% endfor %}
+            {% endif %}
+
+            <div style="text-align: center;">
+                <a href="{{ tfl_status_url }}" class="cta-button">View TfL Status Updates</a>
+            </div>
+
+            <p style="font-size: 14px; color: #666666; margin-top: 20px;">
+                This update was sent based on your notification preferences. You can update your preferences at any time in your account settings.
+            </p>
+        </div>
+        <div class="footer">
+            <p>
+                This is an automated alert from IsTheTubeRunning.<br>
+                © 2025 IsTheTubeRunning. All rights reserved.
+            </p>
+        </div>
+    </div>
+</body>
+</html>

--- a/backend/app/templates/email/status_update.html
+++ b/backend/app/templates/email/status_update.html
@@ -168,7 +168,7 @@
             <div class="route-name">{{ route_name }}</div>
         </div>
         <div class="content">
-            <p class="greeting">Hello {{ user_name or "there" }},</p>
+            <p class="greeting">Hello {{ user_name|default("there") }},</p>
 
             <p>Good news! Service has been restored on your route <strong>{{ route_name }}</strong>.</p>
 

--- a/backend/tests/services/test_alert_otel.py
+++ b/backend/tests/services/test_alert_otel.py
@@ -119,14 +119,15 @@ class TestAlertServiceProcessAllRoutesOtelSpans:
         alert_svc._get_active_routes = AsyncMock(return_value=[successful_route, failing_route])
 
         # Mock _fetch_global_disruption_data (refactored method)
-        alert_svc._fetch_global_disruption_data = AsyncMock(return_value=set())
+        alert_svc._fetch_global_disruption_data = AsyncMock(return_value=(set(), set()))
 
         # Mock _process_single_route: succeed for first route, fail for second
-        # Updated signature includes schedules parameter
+        # Updated signature includes schedules and cleared_states parameters
         async def mock_process_route(
             route: UserRoute,
             schedules: list,
             disabled_severity_pairs: set,
+            cleared_states: set,
         ) -> tuple[int, bool]:
             if route is successful_route:
                 return 3, False  # 3 alerts sent, no error

--- a/backend/tests/services/test_alert_otel.py
+++ b/backend/tests/services/test_alert_otel.py
@@ -643,7 +643,7 @@ class TestAlertServiceShouldSendAlertOtelSpans:
         mock_schedule.id = schedule_id
 
         # Call the method
-        should_send, _filtered = await alert_svc._should_send_alert(
+        should_send, _filtered, _stored_lines = await alert_svc._should_send_alert(
             route=mock_route,
             user_id=user_id,
             schedule=mock_schedule,
@@ -700,7 +700,7 @@ class TestAlertServiceShouldSendAlertOtelSpans:
         mock_schedule.id = schedule_id
 
         # Method handles exception gracefully
-        should_send, _filtered = await alert_svc._should_send_alert(
+        should_send, _filtered, _stored_lines = await alert_svc._should_send_alert(
             route=mock_route,
             user_id=user_id,
             schedule=mock_schedule,


### PR DESCRIPTION
## Summary

Implements issue #361 - Users now receive notifications when previously-alerted disruptions clear, so they can ignore earlier alerts and make informed travel decisions.

### Key Features

- **Status update notifications** sent when lines return to "Good Service" or "No Issues"
  - Email notifications with green "Service Restored" theme
  - SMS notifications with concise format  
  - Both include cleared lines + still-disrupted lines for complete context

- **Smart state tracking** distinguishes cleared vs suppressed states
  - Lines transitioning to cleared states (Good Service, No Issues) → send notification
  - Lines transitioning to suppressed states (e.g., Service Closed) → keep tracking, don't notify yet
  - Cleared lines removed from Redis state after notification sent

- **Future-proofed for #214** via `is_cleared_state` column on `alert_disabled_severities`
  - Cleared states: disruption is over (Good Service, No Issues)
  - Suppressed states: still problematic, just not alerting (Service Closed when implemented)

### Technical Implementation

**Database:**
- Added `is_cleared_state` boolean column to `alert_disabled_severities` table
- Migration sets Good Service (severity 10) and No Issues (severity 18) as cleared states

**Core Logic:**
- New `detect_cleared_lines()` pure function identifies lines that have transitioned to cleared states
- `_process_single_route()` now detects cleared lines and sends status update notifications
- Redis state management updated to remove cleared lines after notification

**Notifications:**
- `NotificationService.send_status_update_email()` - green-themed HTML email
- `NotificationService.send_status_update_sms()` - concise SMS with 160 char limit handling
- New `status_update.html` template

**Testing:**
- 13 new tests covering email/SMS success, errors, Redis state management, edge cases
- All 1578 tests passing
- 95.08% coverage (exceeds 95% threshold)

### Files Changed

- `backend/app/models/tfl.py` - Added `is_cleared_state` column
- `backend/alembic/versions/` - New migration
- `backend/app/schemas/tfl.py` - Added `ClearedLineInfo` schema
- `backend/app/services/alert_service.py` - Detection, notification, state management (+318 lines)
- `backend/app/services/notification_service.py` - Status update methods
- `backend/app/templates/email/status_update.html` - New template
- `backend/app/core/redis.py` - Added `delete()` to RedisClientProtocol
- `backend/tests/test_alert_service.py` - 13 new tests
- `backend/tests/test_notification_service.py` - Updated imports

### Example Notification

**Email Subject:** "Service Restored - [Route Name]"

**Email Body:**
> ✅ Service Restored:
> Victoria - Good Service (Previously: Severe Delays)
>
> ⚠️ Still Disrupted:
> Piccadilly - Minor Delays

This gives users complete context to make informed decisions.

## Test Plan

- [x] All 1578 tests passing
- [x] 95.08% code coverage (exceeds 95% threshold)
- [x] All pre-commit hooks passing (ruff, mypy, etc.)
- [x] Cleared line detection works correctly
- [x] Status update emails sent with correct content
- [x] Status update SMS sent with correct format
- [x] Redis state management removes cleared lines
- [x] Suppressed states (non-cleared) kept in Redis for future tracking

Closes #361

## Summary by Sourcery

Add cleared-disruption detection and status update notifications so users are informed when previously alerted lines return to normal service.

New Features:
- Introduce cleared line tracking via ClearedLineInfo and detection logic to identify previously disrupted lines that reach cleared states.
- Send status update emails and SMS messages summarizing cleared lines and remaining disruptions using a new green-themed email template.
- Track cleared vs suppressed severities using an is_cleared_state flag on alert_disabled_severities, with a migration seeding Good Service and No Issues states.

Enhancements:
- Extend alert processing to fetch both filtered and unfiltered disruptions, use stored Redis state to compute cleared lines, and clean up alert state after status updates.
- Improve alert cooldown and state handling by returning stored line state from _should_send_alert and adding robust Redis state update logic for cleared lines.
- Augment Redis client protocol with delete support and expand alert logging helpers and tests for better resilience and observability.

Tests:
- Add comprehensive unit and integration tests for cleared line detection, cleared state retrieval, status update sending, Redis state cleanup, and error handling in alert and notification services.