### PR TITLE
test: improve backend test coverage to 95.92%

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,9 @@
   - Backend: Use `app.cli` to create users for API calls or assign/remove admin roles
   - Frontend: `frontend/.env` (includes Playwright test credentials)
   - **Don't give up on testing** - credentials exist for API testing and UI testing
+- ⚠️ **ALWAYS** read `backend/tests/conftest.py` to understand existing test fixtures
+  - Use existing fixtures where possible
+  - Add new fixtures to `conftest.py` as needed for new functionality
 
 ---
 

--- a/backend/tests/test_admin_alerts.py
+++ b/backend/tests/test_admin_alerts.py
@@ -1,6 +1,5 @@
 """Tests for admin alert management endpoints."""
 
-from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -8,12 +7,10 @@ from uuid import UUID
 
 import pytest
 from app.core.config import settings
-from app.core.database import get_db
-from app.main import app
 from app.models.notification import NotificationLog, NotificationMethod, NotificationStatus
 from app.models.user import User
 from app.models.user_route import UserRoute
-from httpx import ASGITransport, AsyncClient
+from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tests.helpers.http_assertions import assert_401_unauthorized
@@ -33,22 +30,6 @@ def build_api_url(endpoint: str) -> str:
     prefix = settings.API_V1_PREFIX.rstrip("/")
     path = endpoint if endpoint.startswith("/") else f"/{endpoint}"
     return f"{prefix}{path}"
-
-
-@pytest.fixture
-async def async_client_with_db(db_session: AsyncSession) -> AsyncGenerator[AsyncClient]:
-    """Async HTTP client with database dependency override."""
-
-    async def override_get_db() -> AsyncGenerator[AsyncSession]:
-        yield db_session
-
-    app.dependency_overrides[get_db] = override_get_db
-
-    try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            yield client
-    finally:
-        app.dependency_overrides.clear()
 
 
 # ==================== Authorization Tests ====================

--- a/backend/tests/test_admin_dashboard.py
+++ b/backend/tests/test_admin_dashboard.py
@@ -1,14 +1,11 @@
 """Tests for admin dashboard user management and analytics endpoints."""
 
-from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import uuid4
 
 import pytest
 from app.core.config import settings
-from app.core.database import get_db
-from app.main import app
 from app.models.notification import (
     NotificationLog,
     NotificationMethod,
@@ -23,7 +20,7 @@ from app.models.user import (
 )
 from app.models.user_route import UserRoute
 from app.services.admin_service import calculate_avg_routes, calculate_success_rate
-from httpx import ASGITransport, AsyncClient
+from httpx import AsyncClient
 from sqlalchemy import select as sql_select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -43,24 +40,6 @@ def build_api_url(endpoint: str) -> str:
     prefix = settings.API_V1_PREFIX.rstrip("/")
     path = endpoint if endpoint.startswith("/") else f"/{endpoint}"
     return f"{prefix}{path}"
-
-
-@pytest.fixture
-async def async_client_with_db(
-    db_session: AsyncSession,
-) -> AsyncGenerator[AsyncClient]:
-    """Async HTTP client with database dependency override."""
-
-    async def override_get_db() -> AsyncGenerator[AsyncSession]:
-        yield db_session
-
-    app.dependency_overrides[get_db] = override_get_db
-
-    try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            yield client
-    finally:
-        app.dependency_overrides.clear()
 
 
 # ==================== Authorization Tests ====================

--- a/backend/tests/test_admin_route_index.py
+++ b/backend/tests/test_admin_route_index.py
@@ -1,20 +1,17 @@
 """Tests for admin route index management endpoint."""
 
 import uuid
-from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 from app.core.config import settings
-from app.core.database import get_db
-from app.main import app
 from app.models.tfl import Line, Station
 from app.models.user import User
 from app.models.user_route import UserRoute, UserRouteSegment
 from app.models.user_route_index import UserRouteStationIndex
-from httpx import ASGITransport, AsyncClient
+from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -32,22 +29,6 @@ def build_api_url(endpoint: str) -> str:
     prefix = settings.API_V1_PREFIX.rstrip("/")
     path = endpoint if endpoint.startswith("/") else f"/{endpoint}"
     return f"{prefix}{path}"
-
-
-@pytest.fixture
-async def async_client_with_db(db_session: AsyncSession) -> AsyncGenerator[AsyncClient]:
-    """Async HTTP client with database dependency override."""
-
-    async def override_get_db() -> AsyncGenerator[AsyncSession]:
-        yield db_session
-
-    app.dependency_overrides[get_db] = override_get_db
-
-    try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            yield client
-    finally:
-        app.dependency_overrides.clear()
 
 
 class TestAdminRebuildIndexesEndpoint:

--- a/backend/tests/test_celery_metadata_and_graph_tasks.py
+++ b/backend/tests/test_celery_metadata_and_graph_tasks.py
@@ -7,17 +7,10 @@ import pytest
 from app.celery.tasks import (
     _rebuild_graph_async,
     _refresh_metadata_async,
-    rebuild_network_graph_task,
-    refresh_tfl_metadata_task,
 )
 from app.services.tfl_service import MetadataChangeDetectedError
 
 # ==================== refresh_tfl_metadata_task Tests ====================
-
-
-def test_refresh_metadata_task_registered() -> None:
-    """Test that task function exists."""
-    assert refresh_tfl_metadata_task is not None
 
 
 @pytest.mark.asyncio
@@ -135,11 +128,6 @@ async def test_refresh_metadata_async_ensures_session_cleanup(
 
 
 # ==================== rebuild_network_graph_task Tests ====================
-
-
-def test_rebuild_graph_task_registered() -> None:
-    """Test that task function exists."""
-    assert rebuild_network_graph_task is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -17,12 +17,6 @@ from app.celery.tasks import (
 # ==================== check_disruptions_and_alert Tests ====================
 
 
-def test_check_disruptions_task_registered() -> None:
-    """Test that task function exists."""
-    # This is a simple test to ensure the task exists
-    assert check_disruptions_and_alert is not None
-
-
 @pytest.mark.asyncio
 @patch("app.celery.tasks.AlertService")
 @patch("app.celery.tasks.get_worker_redis_client")
@@ -388,12 +382,6 @@ def test_check_disruptions_task_logs_on_error(mock_run_async_task: MagicMock) ->
 # ==================== rebuild_route_indexes_task Tests ====================
 
 
-def test_rebuild_indexes_task_registered() -> None:
-    """Test that rebuild_route_indexes_task function exists."""
-    # This is a simple test to ensure the task exists
-    assert rebuild_route_indexes_task is not None
-
-
 @pytest.mark.asyncio
 @patch("app.celery.tasks.UserRouteIndexService")
 @patch("app.celery.tasks.get_worker_session")
@@ -677,11 +665,6 @@ def test_rebuild_indexes_task_logs_on_error(mock_run_async_task: MagicMock) -> N
 
 
 # ==================== detect_and_rebuild_stale_routes Tests ====================
-
-
-def test_detect_stale_routes_task_registered() -> None:
-    """Test that detect_and_rebuild_stale_routes task function exists."""
-    assert detect_and_rebuild_stale_routes is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -11,26 +11,25 @@ from app.services.email_service import EmailService, get_tls_settings
 class TestGetTlsSettings:
     """Test cases for get_tls_settings pure function."""
 
-    def test_port_465_implicit_tls(self) -> None:
-        """Port 465 uses implicit TLS regardless of require_tls."""
-        assert get_tls_settings(465, False) == (True, None)
-        assert get_tls_settings(465, True) == (True, None)
-
-    def test_port_587_auto_upgrade(self) -> None:
-        """Port 587 with require_tls=False uses auto-upgrade."""
-        assert get_tls_settings(587, False) == (False, None)
-
-    def test_port_587_require_tls(self) -> None:
-        """Port 587 with require_tls=True forces STARTTLS."""
-        assert get_tls_settings(587, True) == (False, True)
-
-    def test_port_25_auto_upgrade(self) -> None:
-        """Port 25 with require_tls=False uses auto-upgrade."""
-        assert get_tls_settings(25, False) == (False, None)
-
-    def test_port_25_require_tls(self) -> None:
-        """Port 25 with require_tls=True forces STARTTLS."""
-        assert get_tls_settings(25, True) == (False, True)
+    @pytest.mark.parametrize(
+        ("port", "require_tls", "expected"),
+        [
+            # Port 465 uses implicit TLS regardless of require_tls
+            (465, False, (True, None)),
+            (465, True, (True, None)),
+            # Port 587 with require_tls=False uses auto-upgrade
+            (587, False, (False, None)),
+            # Port 587 with require_tls=True forces STARTTLS
+            (587, True, (False, True)),
+            # Port 25 with require_tls=False uses auto-upgrade
+            (25, False, (False, None)),
+            # Port 25 with require_tls=True forces STARTTLS
+            (25, True, (False, True)),
+        ],
+    )
+    def test_get_tls_settings(self, port: int, require_tls: bool, expected: tuple[bool, bool | None]) -> None:
+        """Test get_tls_settings with various port and TLS configurations."""
+        assert get_tls_settings(port, require_tls) == expected
 
 
 class TestEmailService:

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -25,6 +25,9 @@ class TestGetTlsSettings:
             (25, False, (False, None)),
             # Port 25 with require_tls=True forces STARTTLS
             (25, True, (False, True)),
+            # Non-standard port 2525 behaves like port 25 (fallback behavior)
+            (2525, False, (False, None)),
+            (2525, True, (False, True)),
         ],
     )
     def test_get_tls_settings(self, port: int, require_tls: bool, expected: tuple[bool, bool | None]) -> None:

--- a/backend/tests/test_tfl_api.py
+++ b/backend/tests/test_tfl_api.py
@@ -13,6 +13,7 @@ from app.core.database import get_db
 from app.main import app
 from app.models.tfl import Line, Station
 from app.models.user import User
+from app.schemas.tfl import DisruptionResponse
 from fastapi import HTTPException, status
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -87,6 +88,33 @@ async def async_client_with_admin(
         app.dependency_overrides.clear()
 
 
+# ==================== Authentication Tests ====================
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "method"),
+    [
+        ("/tfl/lines", "GET"),
+        ("/admin/tfl/build-graph", "POST"),
+        ("/tfl/lines/victoria/routes", "GET"),
+        ("/tfl/stations/940GZZLUVIC/routes", "GET"),
+    ],
+)
+async def test_endpoints_require_authentication(endpoint: str, method: str) -> None:
+    """Test that various endpoints reject unauthenticated requests."""
+    # Create client without auth headers
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        if method == "GET":
+            response = await client.get(build_api_url(endpoint))
+        else:  # POST
+            response = await client.post(build_api_url(endpoint))
+
+    assert_401_unauthorized(response, expected_detail="Not authenticated")
+
+
 # ==================== GET /tfl/lines Tests ====================
 
 
@@ -126,18 +154,6 @@ async def test_get_lines_success(
     assert data[0]["tfl_id"] == "victoria"
     assert data[0]["name"] == "Victoria"
     assert data[1]["tfl_id"] == "northern"
-
-
-async def test_get_lines_unauthenticated(async_client_with_auth: AsyncClient) -> None:
-    """Test that unauthenticated requests are rejected."""
-    # Create client without auth headers
-    async with AsyncClient(
-        transport=ASGITransport(app=app),
-        base_url="http://test",
-    ) as client:
-        response = await client.get(build_api_url("/tfl/lines"))
-
-    assert_401_unauthorized(response, expected_detail="Not authenticated")
 
 
 # ==================== GET /tfl/stations Tests ====================
@@ -452,18 +468,6 @@ async def test_build_graph_success(
     assert "success" in data["message"].lower()
 
 
-async def test_build_graph_unauthenticated(async_client_with_admin: AsyncClient) -> None:
-    """Test that unauthenticated requests to admin endpoint are rejected."""
-    # Create client without auth headers
-    async with AsyncClient(
-        transport=ASGITransport(app=app),
-        base_url="http://test",
-    ) as client:
-        response = await client.post(build_api_url("/admin/tfl/build-graph"))
-
-    assert_401_unauthorized(response, expected_detail="Not authenticated")
-
-
 async def test_build_graph_non_admin(async_client_with_auth: AsyncClient) -> None:
     """Test that non-admin authenticated users are rejected."""
     response = await async_client_with_auth.post(build_api_url("/admin/tfl/build-graph"))
@@ -673,20 +677,6 @@ async def test_get_line_routes_empty_routes(
     assert data["routes"] == []
 
 
-async def test_get_line_routes_unauthenticated(
-    async_client_with_auth: AsyncClient,
-) -> None:
-    """Test that unauthenticated requests to get_line_routes are rejected."""
-    # Create client without auth headers
-    async with AsyncClient(
-        transport=ASGITransport(app=app),
-        base_url="http://test",
-    ) as client:
-        response = await client.get(build_api_url("/tfl/lines/victoria/routes"))
-
-    assert_401_unauthorized(response, expected_detail="Not authenticated")
-
-
 @patch("app.services.tfl_service.TfLService.get_line_routes")
 async def test_get_line_routes_server_error(
     mock_get_line_routes: AsyncMock,
@@ -827,20 +817,6 @@ async def test_get_station_routes_no_lines(
     assert data["routes"] == []
 
 
-async def test_get_station_routes_unauthenticated(
-    async_client_with_auth: AsyncClient,
-) -> None:
-    """Test that unauthenticated requests to get_station_routes are rejected."""
-    # Create client without auth headers
-    async with AsyncClient(
-        transport=ASGITransport(app=app),
-        base_url="http://test",
-    ) as client:
-        response = await client.get(build_api_url("/tfl/stations/940GZZLUVIC/routes"))
-
-    assert_401_unauthorized(response, expected_detail="Not authenticated")
-
-
 @patch("app.services.tfl_service.TfLService.get_station_routes")
 async def test_get_station_routes_server_error(
     mock_get_station_routes: AsyncMock,
@@ -914,3 +890,179 @@ async def test_get_station_routes_multiple_routes_same_line(
     assert "Edgware → Morden via Bank" in route_names
     assert "High Barnet → Morden via Bank" in route_names
     assert "Morden → Edgware via Bank" in route_names
+
+
+# ==================== GET /tfl/metadata/* Tests ====================
+
+
+@patch("app.services.tfl_service.TfLService.fetch_severity_codes")
+async def test_get_severity_codes_success(
+    mock_fetch_severity_codes: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test successful retrieval of severity codes."""
+    # Setup mock data
+    mock_fetch_severity_codes.return_value = [
+        {
+            "mode_id": "tube",
+            "severity_level": 10,
+            "description": "Good Service",
+            "last_updated": datetime(2025, 1, 1, tzinfo=UTC),
+        },
+        {
+            "mode_id": "tube",
+            "severity_level": 6,
+            "description": "Severe Delays",
+            "last_updated": datetime(2025, 1, 1, tzinfo=UTC),
+        },
+    ]
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/metadata/severity-codes"))
+
+    # Verify
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["severity_level"] == 10
+    assert data[0]["description"] == "Good Service"
+    assert data[1]["severity_level"] == 6
+    assert data[1]["description"] == "Severe Delays"
+
+
+@patch("app.services.tfl_service.TfLService.fetch_disruption_categories")
+async def test_get_disruption_categories_success(
+    mock_fetch_disruption_categories: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test successful retrieval of disruption categories."""
+    # Setup mock data
+    mock_fetch_disruption_categories.return_value = [
+        {
+            "category_name": "RealTime",
+            "description": "Real-time disruption",
+            "last_updated": datetime(2025, 1, 1, tzinfo=UTC),
+        },
+        {
+            "category_name": "PlannedWork",
+            "description": "Planned engineering work",
+            "last_updated": datetime(2025, 1, 1, tzinfo=UTC),
+        },
+    ]
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/metadata/disruption-categories"))
+
+    # Verify
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["category_name"] == "RealTime"
+    assert data[1]["category_name"] == "PlannedWork"
+
+
+@patch("app.services.tfl_service.TfLService.fetch_stop_types")
+async def test_get_stop_types_success(
+    mock_fetch_stop_types: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test successful retrieval of stop types."""
+    # Setup mock data
+    mock_fetch_stop_types.return_value = [
+        {
+            "type_name": "NaptanMetroStation",
+            "description": "Underground Station",
+            "last_updated": datetime(2025, 1, 1, tzinfo=UTC),
+        },
+        {
+            "type_name": "NaptanRailStation",
+            "description": "Rail Station",
+            "last_updated": datetime(2025, 1, 1, tzinfo=UTC),
+        },
+    ]
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/metadata/stop-types"))
+
+    # Verify
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["type_name"] == "NaptanMetroStation"
+    assert data[1]["type_name"] == "NaptanRailStation"
+
+
+@patch("app.services.tfl_service.TfLService.fetch_line_disruptions")
+async def test_get_line_states_success(
+    mock_fetch_line_disruptions: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test successful retrieval of line states."""
+    # Setup mock data - using DisruptionResponse schema
+    disruptions = [
+        DisruptionResponse(
+            line_id="victoria",
+            line_name="Victoria",
+            mode="tube",
+            status_severity=10,
+            status_severity_description="Good Service",
+            reason=None,
+        ),
+        DisruptionResponse(
+            line_id="northern",
+            line_name="Northern",
+            mode="tube",
+            status_severity=6,
+            status_severity_description="Severe Delays",
+            reason="Signal failure at Camden Town",
+        ),
+    ]
+    mock_fetch_line_disruptions.return_value = disruptions
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/line-states"))
+
+    # Verify
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["line_id"] == "victoria"
+    assert data[0]["status_severity"] == 10
+    assert data[1]["line_id"] == "northern"
+    assert data[1]["status_severity"] == 6
+    assert data[1]["reason"] == "Signal failure at Camden Town"
+
+
+@patch("app.services.tfl_service.TfLService.get_alert_config")
+async def test_get_alert_config_success(
+    mock_get_alert_config: AsyncMock,
+    async_client_with_auth: AsyncClient,
+) -> None:
+    """Test successful retrieval of alert configuration."""
+    # Setup mock data
+    mock_get_alert_config.return_value = [
+        {
+            "mode_id": "tube",
+            "severity_level": 10,
+            "description": "Good Service",
+            "alerts_enabled": False,
+        },
+        {
+            "mode_id": "tube",
+            "severity_level": 6,
+            "description": "Severe Delays",
+            "alerts_enabled": True,
+        },
+    ]
+
+    # Execute
+    response = await async_client_with_auth.get(build_api_url("/tfl/alert-config"))
+
+    # Verify
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["severity_level"] == 10
+    assert data[0]["alerts_enabled"] is False
+    assert data[1]["severity_level"] == 6
+    assert data[1]["alerts_enabled"] is True


### PR DESCRIPTION
## Summary

Improved backend test coverage from 95.69% to 95.92% while reducing test redundancy and following KISS, DRY, YAGNI principles for a maintainable test suite.

### Coverage Improvement
- **Before:** 95.69% coverage, 1,591 tests
- **After:** 95.92% coverage, 1,592 tests
- **Key improvement:** `app/api/tfl.py` coverage 78.21% → 97.44%

### Changes

#### 1. Fixture Cleanup
- Removed 3 duplicate `async_client_with_db` fixture definitions from test files
- Added guidance to `AGENTS.md` about using `conftest.py` for shared fixtures

#### 2. Test Consolidation (DRY)
- Removed 5 trivial "task exists" tests that only checked `is not None`
- Parameterized 5 TLS settings tests → 1 test with 6 scenarios
- Parameterized 4 unauthenticated endpoint tests → 1 test with 4 scenarios
- **Net result:** Removed 12 tests, added 5 new tests = 1,592 total

#### 3. Coverage Addition
Added 5 new tests for TfL API metadata endpoints:
- `test_get_severity_codes_success`
- `test_get_disruption_categories_success`
- `test_get_stop_types_success`
- `test_get_line_states_success`
- `test_get_alert_config_success`

### Files Changed
- `AGENTS.md` - Added fixture usage guidance
- `backend/tests/test_admin_alerts.py` - Removed duplicate fixture
- `backend/tests/test_admin_dashboard.py` - Removed duplicate fixture
- `backend/tests/test_admin_route_index.py` - Removed duplicate fixture
- `backend/tests/test_celery_metadata_and_graph_tasks.py` - Removed trivial tests
- `backend/tests/test_celery_tasks.py` - Removed trivial tests
- `backend/tests/test_email_service.py` - Parameterized TLS tests
- `backend/tests/test_tfl_api.py` - Consolidated auth tests + added metadata tests

### Validation
- ✅ All 1,592 tests passing (165.28s runtime)
- ✅ All pre-commit hooks passing (ruff, mypy, prettier, eslint)
- ✅ No linting errors or type checking issues

### Remaining Coverage Gaps (Acceptable)
Per project guidelines, these files remain below 95% and are acceptable:
- `app/cli.py`: 65.14% - CLI tool (low ROI for testing)
- `app/celery/app.py`: 84.09% - Worker startup signals (hard to test)
- `app/celery/database.py`: 89.36% - Worker cleanup paths
- `app/celery/tasks.py`: 88.41% - Retry logic (complex to test)

All other files (46) have 100% coverage or are at target levels (95%+).

## Test Plan
- [x] Run full test suite with coverage: `dotenvx run -- uv run pytest --cov=app`
- [x] Verify all pre-commit hooks pass: `pre-commit run --all-files`
- [x] Confirm test count and coverage improvements

## Summary by Sourcery

Increase backend test coverage for TfL metadata and email TLS handling while consolidating redundant tests and fixtures for improved maintainability.

Enhancements:
- Deduplicate async_client_with_db fixtures across admin-related test modules in favor of shared test configuration.

Documentation:
- Document backend test fixture usage guidelines in AGENTS.md, encouraging reuse via backend/tests/conftest.py.

Tests:
- Add comprehensive tests for TfL metadata and line state endpoints, including severity codes, disruption categories, stop types, line states, and alert config responses.
- Consolidate multiple unauthenticated access tests into a single parameterized authentication test covering several TfL and admin endpoints.
- Parameterize email TLS setting tests across ports and TLS requirements to reduce duplication while preserving behavior coverage.
- Remove trivial Celery task existence tests that only asserted function presence to streamline the test suite.