### PR TITLE
fix: add db_session.expire_all() to test_fetch_lines_logs_changes (#373)

### DIFF
--- a/backend/tests/test_tfl_service.py
+++ b/backend/tests/test_tfl_service.py
@@ -1190,6 +1190,11 @@ async def test_fetch_lines_logs_changes(
         assert logs[0].old_values is None
         assert logs[0].new_values == {"name": "Victoria", "mode": "tube"}
 
+        # Clear SQLAlchemy's identity map to ensure fresh database read.
+        # The first fetch uses raw SQL upsert which bypasses the ORM identity map.
+        # Without this, the second fetch may see stale results due to SAVEPOINT timing.
+        db_session.expire_all()
+
         # Second fetch with name change
         mock_lines_v2 = [create_mock_line(id="victoria", name="Victoria Line")]
         mock_response_v2 = MockResponse(


### PR DESCRIPTION
## Problem

The test `test_fetch_lines_logs_changes` failed intermittently in CI (issue #373) with:
```
assert logs[1].change_type == "updated"
AssertionError: assert 'created' == 'updated'
```

This is the same issue as #331, but PR #335's fix was incomplete.

## Root Cause

PR #335 (commit dccbea5) **claimed** to add `db_session.expire_all()` to the test, but the actual commit only added `execution_options(populate_existing=True)` to the service code.

The `populate_existing=True` option doesn't solve the issue because:
1. The `fetch_lines()` method uses raw SQL `INSERT ... ON CONFLICT DO UPDATE` (line 856-870)
2. Raw SQL inserts **bypass** SQLAlchemy's ORM identity map
3. `populate_existing=True` only refreshes objects **already in** the identity map
4. Since the Line object was never in the identity map, there's nothing to refresh
5. The second `fetch_lines()` call may not find the line due to SAVEPOINT timing

## Solution

Add `db_session.expire_all()` between the two `fetch_lines()` calls in the test. This is what PR #335 claimed to do but didn't. This clears SQLAlchemy's identity map and forces fresh database reads.

**Changes**:
- `backend/tests/test_tfl_service.py`: Added 4 lines (3 comment + 1 code) after line 1191

```python
# Clear SQLAlchemy's identity map to ensure fresh database read.
# The first fetch uses raw SQL upsert which bypasses the ORM identity map.
# Without this, the second fetch may see stale results due to SAVEPOINT timing.
db_session.expire_all()
```

## Testing

- ✅ Ran `test_fetch_lines_logs_changes` 20 times with no failures
- ✅ All 231 tests in `test_tfl_service.py` pass
- ✅ All pre-commit hooks pass
- ✅ No production code changes (test-only fix)

## Impact

- **Risk**: Very low (test-only change)
- **Lines changed**: 4 (3 comment + 1 code)
- **Files modified**: 1
- **No ADR updates needed** (follows existing SQLAlchemy patterns)

Fixes #373

## Summary by Sourcery

Tests:
- Ensure test_fetch_lines_logs_changes clears the SQLAlchemy identity map between fetches to avoid intermittent stale-data assertions.