### PR TITLE
feat: simplify notification emails for better scannability (#362)

### DIFF
--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -32,12 +32,10 @@ def _build_disruption_subject(route_name: str, disruptions: list[DisruptionRespo
         Formatted subject line
     """
     if not disruptions:
-        return f"⚠️ {route_name}: All clear"
+        msg = "No disruptions provided; this indicates a programming error upstream."
+        raise ValueError(msg)
 
     line_names = ", ".join([d.line_name for d in disruptions])
-
-    if len(disruptions) == 1:
-        return f"⚠️ {route_name}: {line_names} disrupted"
     return f"⚠️ {route_name}: {line_names} disrupted"
 
 
@@ -62,14 +60,25 @@ def _build_status_update_subject(
     Returns:
         Formatted subject line
     """
-    cleared_names = ", ".join([c.line_name for c in cleared_lines])
+    # Both empty - programming error
+    if not cleared_lines and not still_disrupted:
+        msg = "No lines provided; this indicates a programming error upstream."
+        raise ValueError(msg)
 
-    if not still_disrupted:
-        # All clear
+    # Nothing cleared but some still disrupted
+    if not cleared_lines and still_disrupted:
+        disrupted_names = ", ".join([d.line_name for d in still_disrupted])
+        return f"⚠️ {route_name}: {disrupted_names} still disrupted"
+
+    # Some cleared, nothing disrupted
+    if cleared_lines and not still_disrupted:
+        cleared_names = ", ".join([c.line_name for c in cleared_lines])
         if len(cleared_lines) == 1:
             return f"✅ {route_name}: {cleared_names} restored"
         return f"✅ {route_name}: All clear"
-    # Some still disrupted
+
+    # Some cleared, some still disrupted (mixed case)
+    cleared_names = ", ".join([c.line_name for c in cleared_lines])
     disrupted_names = ", ".join([d.line_name for d in still_disrupted])
     return f"✅ {route_name}: {cleared_names} restored | {disrupted_names} still disrupted"
 

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -18,6 +18,62 @@ logger = structlog.get_logger(__name__)
 SMS_MAX_LENGTH = 160
 
 
+def _build_disruption_subject(route_name: str, disruptions: list[DisruptionResponse]) -> str:
+    """
+    Build concise subject line for disruption alerts.
+
+    Format: ⚠️ {route_name}: {line1}, {line2}, ... disrupted
+
+    Args:
+        route_name: Name of the route affected
+        disruptions: List of disruptions affecting the route
+
+    Returns:
+        Formatted subject line
+    """
+    if not disruptions:
+        return f"⚠️ {route_name}: All clear"
+
+    line_names = ", ".join([d.line_name for d in disruptions])
+
+    if len(disruptions) == 1:
+        return f"⚠️ {route_name}: {line_names} disrupted"
+    return f"⚠️ {route_name}: {line_names} disrupted"
+
+
+def _build_status_update_subject(
+    route_name: str,
+    cleared_lines: list[ClearedLineInfo],
+    still_disrupted: list[DisruptionResponse],
+) -> str:
+    """
+    Build concise subject line for status update emails.
+
+    Formats:
+    - All clear: ✅ {route_name}: All clear
+    - Restored only: ✅ {route_name}: {line1}, {line2} restored
+    - Mixed: ✅ {route_name}: {cleared} restored | {disrupted} still disrupted
+
+    Args:
+        route_name: Name of the route
+        cleared_lines: Lines that have returned to normal service
+        still_disrupted: Lines that remain disrupted
+
+    Returns:
+        Formatted subject line
+    """
+    cleared_names = ", ".join([c.line_name for c in cleared_lines])
+
+    if not still_disrupted:
+        # All clear
+        if len(cleared_lines) == 1:
+            return f"✅ {route_name}: {cleared_names} restored"
+        return f"✅ {route_name}: All clear"
+    # Some still disrupted
+    disrupted_names = ", ".join([d.line_name for d in still_disrupted])
+    return f"✅ {route_name}: {cleared_names} restored | {disrupted_names} still disrupted"
+
+
 # Initialize Jinja2 environment for email templates
 TEMPLATE_DIR = Path(__file__).parent.parent / "templates"
 # nosemgrep: python.flask.security.xss.audit.direct-use-of-jinja2
@@ -72,7 +128,7 @@ class NotificationService:
 
             try:
                 # Build email subject
-                subject = f"⚠️ Disruption Alert: {route_name}"
+                subject = _build_disruption_subject(route_name, disruptions)
 
                 # Render the HTML template
                 html_content = self._render_email_template(
@@ -97,12 +153,7 @@ The following disruptions are affecting your route:
                     if disruption.reason:
                         text_content += f"  Reason: {disruption.reason}\n"
 
-                text_content += """
-For the latest updates, visit: https://tfl.gov.uk/tube-dlr-overground/status/
-
-This is an automated alert from IsTheTubeRunning.
-© 2025 IsTheTubeRunning. All rights reserved.
-            """.strip()
+                text_content += "\nTfL Status: https://tfl.gov.uk/tube-dlr-overground/status/"
 
                 # Send email via EmailService
                 await self.email_service.send_email(email, subject, html_content, text_content)
@@ -238,7 +289,7 @@ This is an automated alert from IsTheTubeRunning.
 
             try:
                 # Build email subject
-                subject = f"✅ Service Restored: {route_name}"
+                subject = _build_status_update_subject(route_name, cleared_lines, still_disrupted)
 
                 # Render the HTML template
                 html_content = self._render_email_template(
@@ -269,12 +320,7 @@ Service has been restored on the following lines:
                     for disruption in still_disrupted:
                         text_content += f"- {disruption.line_name}: {disruption.status_severity_description}\n"
 
-                text_content += """
-For the latest updates, visit: https://tfl.gov.uk/tube-dlr-overground/status/
-
-This is an automated alert from IsTheTubeRunning.
-© 2025 IsTheTubeRunning. All rights reserved.
-            """.strip()
+                text_content += "\nTfL Status: https://tfl.gov.uk/tube-dlr-overground/status/"
 
                 # Send email via EmailService
                 await self.email_service.send_email(email, subject, html_content, text_content)

--- a/backend/app/templates/email/disruption_alert.html
+++ b/backend/app/templates/email/disruption_alert.html
@@ -137,10 +137,6 @@
             <div class="route-name">{{ route_name }}</div>
         </div>
         <div class="content">
-            <p class="greeting">Hello {{ user_name or "there" }},</p>
-
-            <p>We're writing to inform you that there are currently disruptions affecting your route <strong>{{ route_name }}</strong>.</p>
-
             {% for disruption in disruptions %}
             <div class="disruption">
                 <div class="line-name">{{ disruption.line_name }}</div>
@@ -151,20 +147,8 @@
             </div>
             {% endfor %}
 
-            <p>Please plan your journey accordingly and allow extra time for your commute.</p>
-
-            <div style="text-align: center;">
-                <a href="{{ tfl_status_url }}" class="cta-button">View TfL Status Updates</a>
-            </div>
-
             <p style="font-size: 14px; color: #666666; margin-top: 20px;">
-                This alert was sent based on your notification preferences. You can update your preferences at any time in your account settings.
-            </p>
-        </div>
-        <div class="footer">
-            <p>
-                This is an automated alert from IsTheTubeRunning.<br>
-                © 2025 IsTheTubeRunning. All rights reserved.
+                <a href="{{ tfl_status_url }}" style="color: #003366; text-decoration: none;">TfL Status →</a>
             </p>
         </div>
     </div>

--- a/backend/app/templates/email/status_update.html
+++ b/backend/app/templates/email/status_update.html
@@ -168,11 +168,7 @@
             <div class="route-name">{{ route_name }}</div>
         </div>
         <div class="content">
-            <p class="greeting">Hello {{ user_name|default("there") }},</p>
-
-            <p>Good news! Service has been restored on your route <strong>{{ route_name }}</strong>.</p>
-
-            <div class="section-title">✅ Service Restored:</div>
+            <div class="section-title">Restored:</div>
             {% for cleared in cleared_lines %}
             <div class="cleared-line">
                 <div class="line-name">{{ cleared.line_name }}</div>
@@ -182,10 +178,7 @@
             {% endfor %}
 
             {% if still_disrupted %}
-            <div class="section-title">⚠️ Still Disrupted:</div>
-            <p style="font-size: 14px; color: #666666; margin-top: 10px;">
-                The following lines remain disrupted:
-            </p>
+            <div class="section-title">Still disrupted:</div>
             {% for disruption in still_disrupted %}
             <div class="disruption">
                 <div class="line-name">{{ disruption.line_name }}</div>
@@ -197,18 +190,8 @@
             {% endfor %}
             {% endif %}
 
-            <div style="text-align: center;">
-                <a href="{{ tfl_status_url }}" class="cta-button">View TfL Status Updates</a>
-            </div>
-
             <p style="font-size: 14px; color: #666666; margin-top: 20px;">
-                This update was sent based on your notification preferences. You can update your preferences at any time in your account settings.
-            </p>
-        </div>
-        <div class="footer">
-            <p>
-                This is an automated alert from IsTheTubeRunning.<br>
-                © 2025 IsTheTubeRunning. All rights reserved.
+                <a href="{{ tfl_status_url }}" style="color: #003366; text-decoration: none;">TfL Status →</a>
             </p>
         </div>
     </div>


### PR DESCRIPTION
## Summary
Simplified notification emails by removing fluff and putting key info in subject lines for easier scanning.

## Changes

### Subject Lines
- **Disruption alerts**: `⚠️ {route_name}: {line1}, {line2}, ... disrupted`
- **Status updates**: `✅ {route_name}: {line1}, {line2} restored`
- **Mixed**: `✅ {route_name}: Victoria restored | Northern still disrupted`

Examples:
- `⚠️ To Work: Elizabeth, Victoria, DLR, Northern, Piccadilly disrupted`
- `✅ Morning Commute: Victoria restored`

### Template Simplifications
**Removed:**
- Greeting ("Hello John,")
- Intro paragraphs ("We're writing to inform you...", "Good news!...")
- Advice ("Please plan your journey accordingly...")
- Preferences text ("This alert was sent based on...")
- Footer copyright block

**Kept:**
- Route name header
- Line status boxes (the actual useful content)
- TfL link (simplified to text link)

### Files Modified
1. `backend/app/services/notification_service.py` - Subject line helpers, simplified plain text
2. `backend/app/templates/email/disruption_alert.html` - Removed verbose content
3. `backend/app/templates/email/status_update.html` - Removed verbose content
4. `backend/tests/test_notification_service.py` - Added 6 new tests, updated assertions

## Test Coverage
- ✅ All 33 tests passing
- ✅ 98.92% coverage on notification_service.py (exceeds 95% requirement)
- ✅ Added tests for subject line generation (single/multiple lines, mixed states)
- ✅ Updated existing test assertions for new subject format

## Test Plan
- [x] All notification service tests pass
- [x] Pre-commit hooks pass
- [x] Coverage exceeds 95% for modified code

Closes #362

## Summary by Sourcery

Simplify notification emails by focusing on concise, informative subject lines and minimal in-body content while keeping key status details.

New Features:
- Introduce helper functions to generate concise disruption and status update email subject lines based on affected and restored lines.

Enhancements:
- Simplify disruption and status update email templates by removing greetings, explanatory copy, preference/footer text, and CTA buttons, leaving just route details, line status boxes, and a compact TfL status link.
- Streamline plain-text email bodies to remove boilerplate and keep only per-line statuses plus a short TfL status URL line.

Tests:
- Add and update tests to cover the new subject line formats and helper functions, including empty, single-line, multi-line, and mixed-status scenarios, and adjust template expectations for the removed greeting.