### PR TITLE
Release User Routes, Notifications, and Test Coverage Improvements

### DIFF
--- a/.claude/agents/release-pr-creator.md
+++ b/.claude/agents/release-pr-creator.md
@@ -9,22 +9,28 @@ You are an expert Release Engineering Specialist with deep expertise in version 
 
 Your Operational Guidelines:
 
-1. **Reference Analysis**:
+1. **Ensure Latest Remote State**:
+   - **CRITICAL**: Always fetch the latest state from origin first: `git fetch origin`
+   - **CRITICAL**: Compare `origin/release` (NOT local `release`) to `main`
+   - Local branches may be outdated - the remote is the source of truth for releases
+   - Use `git log origin/release..main` and `git diff origin/release...main` for comparisons
+
+2. **Reference Analysis**:
    - First, examine PR #336 to understand the expected format, structure, and level of detail
    - Use this as your template for consistency in release documentation
    - Maintain the same categorization scheme and formatting conventions
 
-2. **Change Discovery Process**:
-   - Analyze all commits and merged PRs between the current release branch and main branch
+3. **Change Discovery Process**:
+   - Analyze all commits and merged PRs between `origin/release` and `main` branch
    - Systematically categorize each change into: Features, Fixes, Refactors, or other relevant categories
    - Identify the PRs associated with each change for proper attribution
 
-3. **Title Generation**:
+4. **Title Generation**:
    - Create a title following the pattern: "Release <summary>"
    - The summary should be concise but descriptive (e.g., "Release Q4 Feature Updates and Critical Fixes")
    - Make the title informative enough that stakeholders immediately understand the release scope
 
-4. **Body Structure**:
+5. **Body Structure**:
    - Organize the PR body as a clean, scannable list
    - Use clear section headers: "## Features", "## Fixes", "## Refactors"
    - For each item, provide:
@@ -32,30 +38,33 @@ Your Operational Guidelines:
      * The associated PR number in parentheses (e.g., "(#342)")
    - List items in order of significance or impact when possible
 
-5. **Quality Standards**:
+6. **Quality Standards**:
    - Ensure every significant change is captured - omissions can lead to deployment surprises
    - Use consistent, professional language throughout
    - Verify all PR numbers are accurate and link correctly
    - Group related changes together for better readability
    - Avoid technical jargon in descriptions unless necessary; make it accessible to non-technical stakeholders
 
-6. **Verification Steps**:
+7. **Verification Steps**:
    - Before creating the PR, confirm:
+     * You fetched from origin and compared against `origin/release`
      * You're merging FROM main TO release (not the reverse)
+     * The base branch is `release` and compare branch is `main`
      * All categories are properly populated
      * No duplicate entries exist
      * PR numbers are correctly referenced
      * The summary accurately reflects the scope of changes
 
-7. **Edge Case Handling**:
+8. **Edge Case Handling**:
    - If there are no changes in a category, omit that section entirely
    - If a change doesn't fit standard categories, create an appropriate new section (e.g., "## Documentation", "## Dependencies")
    - If uncertain about categorizing a change, default to providing the raw information and ask for clarification
    - If you cannot access PR #336, request it explicitly before proceeding
 
-8. **Communication Protocol**:
+9. **Communication Protocol**:
    - Before creating the PR, present a preview to the user for approval
    - Clearly state the source branch (main) and target branch (release)
+   - Report how many commits are being released (from `git log origin/release..main`)
    - Highlight any notable or breaking changes that require special attention
    - If there are an unusually high or low number of changes, mention this
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
   - **ALWAYS** run tests at least once with `./safe-test-runner.sh` to catch memory leaks.
   - **ALWAYS** trust that safe-test-runner timeouts are valid - they are there to catch leaks.
 - ⚠️ Don't pipe scripts to `python` command (triggers sandbox protection)
-  - Instead: create temporary script file, execute it, then delete it
+  - Instead: create temporary script file (directly, not by piping text), execute it, then delete it
   - try to avoid using `/tmp` - use project directory if possible - create a temp folder if needed but ensure cleanup
 - ⚠️ **NEVER** start processes detached
   - No `nohup`, no `&`, no daemon mode
@@ -25,7 +25,7 @@
   - Use foreground processes in background shells for proper log access
 
 ### Code Quality
-- ⚠️ **NEVER** use `# noqa` to suppress linting errors
+- ⚠️ **NEVER** use `# noqa` to suppress linting errors or warnings
   - Refactor the code instead, especially for complexity warnings (PLR0912, PLR0915)
   - Use pure functions to reduce complexity
   - Only exception: PLC0415 for necessary circular import prevention (document rationale)
@@ -34,6 +34,8 @@
   - `Any` only allowed for 3rd party library wrappers where precise types are impossible
 - ⚠️ Use `ast-grep` for code modifications
   - **NEVER** use `sed` or `awk` - they corrupt complex files
+- ⚠️ **NEVER** skip or override pre-commit hooks
+  - The hooks are there for a reason - fix the issues instead
 
 ### Credentials & Testing
 - ⚠️ Credentials **ARE** available - check `.env` files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@
   - **ALWAYS** use `dotenvx run --` to ensure proper environment loading e.g. when running `psql` commands
 - ⚠️ Use `./test-runner.sh` for frontend tests
   - **NEVER** run `npm test` directly (triggers consent prompts)
+  - **ALWAYS** run tests at least once with `./safe-test-runner.sh` to catch memory leaks.
+  - **ALWAYS** trust that safe-test-runner timeouts are valid - they are there to catch leaks.
 - ⚠️ Don't pipe scripts to `python` command (triggers sandbox protection)
   - Instead: create temporary script file, execute it, then delete it
   - try to avoid using `/tmp` - use project directory if possible - create a temp folder if needed but ensure cleanup
@@ -79,7 +81,7 @@
 
 ### Running Tests
 - **Backend:** `dotenvx run -- uv run pytest` (from `/backend` directory)
-- **Frontend:** `./test-runner.sh` (avoids consent prompts) or `./safe-test-runner.sh` (catches memory leaks but slightly slower)
+- **Frontend:** `./test-runner.sh` (avoids consent prompts)
 - Verify all pre-commit hooks pass: `pre-commit run --all-files`
 
 ### Test Validation

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,9 @@
   - Backend: Use `app.cli` to create users for API calls or assign/remove admin roles
   - Frontend: `frontend/.env` (includes Playwright test credentials)
   - **Don't give up on testing** - credentials exist for API testing and UI testing
+- ⚠️ **ALWAYS** read `backend/tests/conftest.py` to understand existing test fixtures
+  - Use existing fixtures where possible
+  - Add new fixtures to `conftest.py` as needed for new functionality
 
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,9 @@
   - **NEVER** use naked `python` or `python3` commands
   - **NEVER** manually set `PYTHONPATH` environment variable
 - ⚠️ Database name comes from config files
-  - **NEVER** assume database is called `testdb` or `testrun`
+  - **NEVER** assume database is called `testdb` or `testrun` etc.
   - Use actual connection details from `backend/.env` (encrypted with dotenvx)
+  - **ALWAYS** use `dotenvx run --` to ensure proper environment loading e.g. when running `psql` commands
 - ⚠️ Use `./test-runner.sh` for frontend tests
   - **NEVER** run `npm test` directly (triggers consent prompts)
 - ⚠️ Don't pipe scripts to `python` command (triggers sandbox protection)

--- a/backend/alembic/versions/1025d77921da_add_is_cleared_state_to_alert_disabled_.py
+++ b/backend/alembic/versions/1025d77921da_add_is_cleared_state_to_alert_disabled_.py
@@ -1,0 +1,86 @@
+"""add_is_cleared_state_to_alert_disabled_severities
+
+Adds is_cleared_state column to alert_disabled_severities table to distinguish
+between cleared states (Good Service, No Issues) and suppressed states (Service Closed).
+
+This enables issue #361: Alert if disruption clears during notification window.
+
+Revision ID: 1025d77921da
+Revises: 1f4d6532d88a
+Create Date: 2025-12-08 08:40:18.392507
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "1025d77921da"
+down_revision: str | Sequence[str] | None = "1f4d6532d88a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Step 1: Add is_cleared_state column with default False
+    op.add_column(
+        "alert_disabled_severities",
+        sa.Column("is_cleared_state", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+    # Step 2: Update existing "Good Service" (severity 10) rows to is_cleared_state=True
+    op.execute(
+        sa.text(
+            """
+            UPDATE alert_disabled_severities
+            SET is_cleared_state = true
+            WHERE severity_level = 10
+            """
+        )
+    )
+
+    # Step 3: Add "No Issues" (severity 18) for each mode with is_cleared_state=True
+    # List of TfL modes that support severity level 18 (No Issues)
+    tfl_modes = [
+        "tube",
+        "dlr",
+        "overground",
+        "elizabeth-line",
+        "tram",
+        "cable-car",
+        "river-bus",
+        "bus",
+        "cycle-hire",
+        "river-tour",
+    ]
+
+    for mode in tfl_modes:
+        op.execute(
+            sa.text(
+                """
+                INSERT INTO alert_disabled_severities (id, mode_id, severity_level, is_cleared_state, created_at, updated_at)
+                VALUES (gen_random_uuid(), :mode_id, 18, true, now(), now())
+                ON CONFLICT (mode_id, severity_level)
+                DO UPDATE SET is_cleared_state = true, updated_at = now()
+                """
+            ).bindparams(mode_id=mode)
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Remove "No Issues" (severity 18) entries that were added in upgrade
+    op.execute(
+        sa.text(
+            """
+            DELETE FROM alert_disabled_severities
+            WHERE severity_level = 18 AND is_cleared_state = true
+            """
+        )
+    )
+
+    # Drop the is_cleared_state column
+    op.drop_column("alert_disabled_severities", "is_cleared_state")

--- a/backend/app/core/redis.py
+++ b/backend/app/core/redis.py
@@ -33,6 +33,10 @@ class RedisClientProtocol(Protocol):
         """Set the value at key name with expiration time."""
         ...
 
+    async def delete(self, *names: str) -> int:
+        """Delete one or more keys."""
+        ...
+
     async def ping(self) -> bool:
         """Ping the Redis server to check connectivity."""
         ...

--- a/backend/app/helpers/soft_delete_filters.py
+++ b/backend/app/helpers/soft_delete_filters.py
@@ -24,15 +24,19 @@ Usage examples:
 """
 
 from typing import TypeVar
+from uuid import UUID
 
-from sqlalchemy import ColumnElement, func, update
+from sqlalchemy import ColumnElement, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import InstrumentedAttribute
 from sqlalchemy.sql import Select
 
 from app.models.base import BaseModel
 
 # TypeVar for maintaining type safety across query transformations
 T = TypeVar("T")
+# TypeVar for child model type in parent-child queries
+ChildModelT = TypeVar("ChildModelT", bound=BaseModel)
 
 
 def add_active_filter(  # noqa: UP047
@@ -161,3 +165,53 @@ def is_soft_deleted(entity: BaseModel) -> bool:
             raise HTTPException(status_code=404, detail="Route not found")
     """
     return entity.deleted_at is not None
+
+
+async def get_active_children_for_parents(  # noqa: UP047
+    db: AsyncSession,
+    child_model: type[ChildModelT],
+    parent_id_column: InstrumentedAttribute[UUID],
+    parent_ids: list[UUID],
+) -> dict[UUID, list[ChildModelT]]:
+    """
+    Load active (non-deleted) children grouped by parent ID.
+
+    Efficient batch query that loads all children for multiple parents
+    in a single database round-trip, filtering out soft-deleted records.
+
+    Args:
+        db: Database session
+        child_model: Child model class (must inherit from BaseModel)
+        parent_id_column: Column to group by (e.g., UserRouteSchedule.route_id)
+        parent_ids: List of parent UUIDs to load children for
+
+    Returns:
+        Dictionary mapping parent_id -> list of child entities.
+        Parents with no children return empty list.
+
+    Example:
+        schedules_by_route = await get_active_children_for_parents(
+            db,
+            UserRouteSchedule,
+            UserRouteSchedule.route_id,
+            [route1.id, route2.id],
+        )
+        # Returns: {route1.id: [schedule1, schedule2], route2.id: []}
+    """
+    if not parent_ids:
+        return {}
+
+    # Query all active children for these parents
+    query = select(child_model).where(parent_id_column.in_(parent_ids))
+    query = add_active_filter(query, child_model)
+
+    result = await db.execute(query)
+    children = result.scalars().all()
+
+    # Group by parent_id
+    grouped: dict[UUID, list[ChildModelT]] = {parent_id: [] for parent_id in parent_ids}
+    for child in children:
+        parent_id = getattr(child, parent_id_column.key)
+        grouped[parent_id].append(child)
+
+    return grouped

--- a/backend/app/models/tfl.py
+++ b/backend/app/models/tfl.py
@@ -236,7 +236,14 @@ class AlertDisabledSeverity(BaseModel):
     excluded from alert processing. The default behavior is to alert for all
     severities unless they appear in this table.
 
-    Example: Good Service (severity_level=10) should not trigger alerts.
+    The is_cleared_state flag distinguishes between:
+    - Cleared states (is_cleared_state=True): e.g., Good Service, No Issues
+      These indicate a disruption has cleared and users should be notified.
+    - Suppressed states (is_cleared_state=False): e.g., Service Closed
+      These are still problematic but we don't alert on them.
+
+    Example: Good Service (severity_level=10, is_cleared_state=True) should not
+    trigger disruption alerts, but should trigger "cleared" notifications.
     """
 
     __tablename__ = "alert_disabled_severities"
@@ -251,6 +258,11 @@ class AlertDisabledSeverity(BaseModel):
         nullable=False,
         index=True,
     )
+    is_cleared_state: Mapped[bool] = mapped_column(
+        nullable=False,
+        server_default="false",
+        comment="True if this state represents a cleared disruption (Good Service, No Issues)",
+    )
 
     __table_args__ = (
         UniqueConstraint(
@@ -262,7 +274,10 @@ class AlertDisabledSeverity(BaseModel):
 
     def __repr__(self) -> str:
         """String representation of the alert disabled severity."""
-        return f"<AlertDisabledSeverity(id={self.id}, mode={self.mode_id}, level={self.severity_level})>"
+        return (
+            f"<AlertDisabledSeverity(id={self.id}, mode={self.mode_id}, "
+            f"level={self.severity_level}, cleared={self.is_cleared_state})>"
+        )
 
 
 class DisruptionCategory(BaseModel):

--- a/backend/app/schemas/routes.py
+++ b/backend/app/schemas/routes.py
@@ -89,6 +89,27 @@ def _validate_timezone(tz: str | None) -> str | None:
     return tz
 
 
+def _validate_quarter_hour(t: time) -> time:
+    """
+    Validate that time is on a quarter-hour boundary - reusable helper.
+
+    Ensures time falls on 00, 15, 30, or 45 minutes with zero seconds/microseconds.
+
+    Args:
+        t: Time to validate
+
+    Returns:
+        Validated time
+
+    Raises:
+        ValueError: If time is not on a quarter-hour boundary
+    """
+    if t.minute % 15 != 0 or t.second != 0 or t.microsecond != 0:
+        msg = f"Time must be on quarter-hour boundary (00, 15, 30, 45 minutes). Got {t.strftime('%H:%M:%S')}"
+        raise ValueError(msg)
+    return t
+
+
 # ==================== Request Schemas ====================
 
 
@@ -188,6 +209,15 @@ class UpdateUserRouteSegmentRequest(BaseModel):
     line_tfl_id: str | None = None
 
 
+class UpsertUserRouteSchedulesRequest(BaseModel):
+    """Request to replace all schedules for a route."""
+
+    schedules: list["CreateUserRouteScheduleRequest"] = Field(
+        default=[],
+        description="List of schedules to set. Empty array deletes all schedules.",
+    )
+
+
 class CreateUserRouteScheduleRequest(BaseModel):
     """Request to create a schedule for a route."""
 
@@ -210,6 +240,12 @@ class CreateUserRouteScheduleRequest(BaseModel):
     def validate_days(cls, days: list[str]) -> list[str]:
         """Validate day codes using shared helper."""
         return _validate_day_codes(days)
+
+    @field_validator("start_time", "end_time")
+    @classmethod
+    def validate_quarter_hour(cls, t: time) -> time:
+        """Validate that time is on a quarter-hour boundary using shared helper."""
+        return _validate_quarter_hour(t)
 
     @model_validator(mode="after")
     def validate_time_range(self) -> "CreateUserRouteScheduleRequest":
@@ -240,6 +276,12 @@ class UpdateUserRouteScheduleRequest(BaseModel):
         if days is None:
             return None
         return _validate_day_codes(days)
+
+    @field_validator("start_time", "end_time")
+    @classmethod
+    def validate_quarter_hour(cls, t: time | None) -> time | None:
+        """Validate that time is on a quarter-hour boundary if provided using shared helper."""
+        return None if t is None else _validate_quarter_hour(t)
 
     @model_validator(mode="after")
     def validate_time_range(self) -> "UpdateUserRouteScheduleRequest":

--- a/backend/app/schemas/tfl.py
+++ b/backend/app/schemas/tfl.py
@@ -84,6 +84,21 @@ class DisruptionResponse(BaseModel):
     affected_routes: list[AffectedRouteInfo] | None = None  # Affected route segments with station sequences
 
 
+class ClearedLineInfo(BaseModel):
+    """Information about a line that has returned to normal service.
+
+    Used to track which lines have cleared from disrupted state during a notification window.
+    """
+
+    line_id: str  # TfL line ID
+    line_name: str
+    mode: str  # Transport mode
+    previous_severity: int  # What severity it was (e.g., 6 = Severe Delays)
+    previous_status: str  # What status it was (e.g., "Severe Delays")
+    current_severity: int  # What severity it is now (e.g., 10 = Good Service)
+    current_status: str  # What status it is now (e.g., "Good Service")
+
+
 class LineStatusInfo(BaseModel):
     """Individual status for a line (used in grouped API response).
 

--- a/backend/app/services/alert_service.py
+++ b/backend/app/services/alert_service.py
@@ -33,7 +33,7 @@ from app.models.tfl import AlertDisabledSeverity, Line, LineDisruptionStateLog
 from app.models.user import EmailAddress, PhoneNumber, User
 from app.models.user_route import UserRoute, UserRouteSchedule
 from app.models.user_route_index import UserRouteStationIndex
-from app.schemas.tfl import DisruptionResponse
+from app.schemas.tfl import ClearedLineInfo, DisruptionResponse
 from app.services.notification_service import NotificationService
 from app.services.tfl_service import TfLService
 from app.utils.pii import hash_pii
@@ -168,6 +168,108 @@ def filter_alertable_disruptions(
         for disruption in disruptions
         if (disruption.mode, disruption.status_severity) not in disabled_severity_pairs
     ]
+
+
+def detect_cleared_lines(
+    stored_lines: dict[str, dict[str, object]],
+    current_alertable_line_ids: set[str],
+    all_route_disruptions: list[DisruptionResponse],
+    cleared_states: set[tuple[str, int]],
+) -> list[ClearedLineInfo]:
+    """
+    Detect lines that have cleared from disrupted state.
+
+    Identifies lines that were previously alerted on but are now in a "cleared" state
+    (e.g., Good Service, No Issues) rather than just a "suppressed" state (e.g., Service Closed).
+
+    Pure function for easy testing without database or Redis dependencies.
+
+    Args:
+        stored_lines: Previously alerted lines from Redis state (line_id -> state dict)
+        current_alertable_line_ids: Set of line_ids with current alertable disruptions
+        all_route_disruptions: Unfiltered route disruptions (includes Good Service, etc.)
+        cleared_states: Set of (mode_id, severity_level) pairs that represent "cleared"
+
+    Returns:
+        List of ClearedLineInfo objects for lines that have cleared
+
+    Example:
+        >>> from app.schemas.tfl import DisruptionResponse, ClearedLineInfo
+        >>> from datetime import UTC, datetime
+        >>> # Victoria was disrupted, now Good Service
+        >>> stored = {
+        ...     "victoria": {
+        ...         "severity": 6,
+        ...         "status": "Severe Delays",
+        ...         "full_hash": "abc123",
+        ...         "last_sent_at": "2024-01-01T10:00:00Z",
+        ...     }
+        ... }
+        >>> current_alertable = set()  # No current disruptions
+        >>> all_disruptions = [
+        ...     DisruptionResponse(
+        ...         line_id="victoria",
+        ...         line_name="Victoria",
+        ...         mode="tube",
+        ...         status_severity=10,
+        ...         status_severity_description="Good Service",
+        ...     )
+        ... ]
+        >>> cleared = {("tube", 10)}  # Good Service is a cleared state
+        >>> result = detect_cleared_lines(stored, current_alertable, all_disruptions, cleared)
+        >>> len(result)
+        1
+        >>> result[0].line_id
+        'victoria'
+        >>> result[0].current_status
+        'Good Service'
+    """
+    cleared_lines: list[ClearedLineInfo] = []
+
+    # Build lookup maps for efficiency
+    current_status_by_line: dict[str, DisruptionResponse] = {
+        disruption.line_id: disruption for disruption in all_route_disruptions
+    }
+
+    # Check each previously-alerted line
+    for line_id, stored_line in stored_lines.items():
+        # Skip if still in alertable disruptions
+        if line_id in current_alertable_line_ids:
+            continue
+
+        # Get current status for this line
+        current_disruption = current_status_by_line.get(line_id)
+        if not current_disruption:
+            # Line not in current data - don't treat as cleared (could be API issue)
+            continue
+
+        # Check if current state is a "cleared" state
+        state_pair = (current_disruption.mode, current_disruption.status_severity)
+        if state_pair not in cleared_states:
+            # Not in a cleared state - it's suppressed (e.g., Service Closed)
+            continue
+
+        # Line has cleared! Create info object
+        previous_severity = stored_line.get("severity")
+        previous_status = stored_line.get("status")
+
+        # Validate stored data
+        if not isinstance(previous_severity, int) or not isinstance(previous_status, str):
+            # Corrupted stored data - skip
+            continue
+
+        cleared_line = ClearedLineInfo(
+            line_id=current_disruption.line_id,
+            line_name=current_disruption.line_name,
+            mode=current_disruption.mode,
+            previous_severity=previous_severity,
+            previous_status=previous_status,
+            current_severity=current_disruption.status_severity,
+            current_status=current_disruption.status_severity_description,
+        )
+        cleared_lines.append(cleared_line)
+
+    return cleared_lines
 
 
 def init_alert_processing_stats() -> dict[str, int]:
@@ -530,7 +632,7 @@ class AlertService:
 
                 # Fetch global disruption data once for all routes
                 # Errors are non-fatal - returns empty data on failure
-                disabled_severity_pairs = await self._fetch_global_disruption_data()
+                disabled_severity_pairs, cleared_states = await self._fetch_global_disruption_data()
 
                 # Process each route individually
                 for route in routes:
@@ -544,6 +646,7 @@ class AlertService:
                         route=route,
                         schedules=route_schedules,
                         disabled_severity_pairs=disabled_severity_pairs,
+                        cleared_states=cleared_states,
                     )
 
                     stats["alerts_sent"] += alerts_sent
@@ -590,29 +693,34 @@ class AlertService:
             logger.error("fetch_active_routes_failed", error=str(e), exc_info=e)
             return []
 
-    async def _fetch_global_disruption_data(self) -> set[tuple[str, int]]:
+    async def _fetch_global_disruption_data(self) -> tuple[set[tuple[str, int]], set[tuple[str, int]]]:
         """
         Fetch all disruptions and disabled severities once for all routes.
 
         This method fetches global disruption data that can be reused across all routes:
         - All line disruptions (cached by TfL service)
         - Disabled severity pairs for filtering
+        - Cleared state pairs (for detecting when lines return to normal)
 
-        Internally uses disruptions for state change logging, but only returns
-        the disabled severity pairs needed by callers.
+        Internally uses disruptions for state change logging.
 
         Errors are non-fatal - returns empty data on failure so per-route processing can continue.
 
         Returns:
-            Set of (mode_id, severity_level) pairs that should not trigger alerts
+            Tuple of (disabled_severity_pairs, cleared_states)
+            - disabled_severity_pairs: Set of (mode_id, severity_level) pairs that should not trigger alerts
+            - cleared_states: Set of (mode_id, severity_level) pairs that represent cleared/normal states
         """
         disabled_severity_pairs: set[tuple[str, int]] = set()
+        cleared_states: set[tuple[str, int]] = set()
 
-        # Step 1: ALWAYS fetch disabled severity pairs first (critical for filtering)
+        # Step 1: ALWAYS fetch disabled severity pairs and cleared states first (critical for filtering)
         # This query must succeed regardless of TfL API status
         try:
             disabled_result = await self.db.execute(select(AlertDisabledSeverity))
-            disabled_severity_pairs = {(d.mode_id, d.severity_level) for d in disabled_result.scalars().all()}
+            all_disabled_severities = disabled_result.scalars().all()
+            disabled_severity_pairs = {(d.mode_id, d.severity_level) for d in all_disabled_severities}
+            cleared_states = {(d.mode_id, d.severity_level) for d in all_disabled_severities if d.is_cleared_state}
         except SQLAlchemyError as e:
             logger.error(
                 "fetch_disabled_severities_failed",
@@ -620,9 +728,9 @@ class AlertService:
                 exc_info=e,
                 critical=True,
             )
-            # Return empty set on DB failure - this is a critical error
+            # Return empty sets on DB failure - this is a critical error
             # Per-route processing will still work but won't filter properly
-            return disabled_severity_pairs
+            return disabled_severity_pairs, cleared_states
 
         # Step 2: Try to fetch disruptions for state logging (optional, for analytics)
         # Failure here should not prevent alert processing
@@ -643,7 +751,7 @@ class AlertService:
             # Don't track as error - per-route processing will handle its own disruptions
             # This is just for centralized logging
 
-        return disabled_severity_pairs
+        return disabled_severity_pairs, cleared_states
 
     async def _get_active_schedule(
         self,
@@ -856,7 +964,7 @@ class AlertService:
         self,
         route: UserRoute,
         disabled_severity_pairs: set[tuple[str, int]],
-    ) -> tuple[list[DisruptionResponse], bool]:
+    ) -> tuple[list[DisruptionResponse], list[DisruptionResponse], bool]:
         """
         Get current disruptions affecting this route using inverted index.
 
@@ -868,8 +976,9 @@ class AlertService:
             disabled_severity_pairs: Set of (mode_id, severity_level) pairs to filter out
 
         Returns:
-            Tuple of (disruptions, error_occurred)
-            - disruptions: List of disruptions affecting this specific route
+            Tuple of (filtered_disruptions, unfiltered_disruptions, error_occurred)
+            - filtered_disruptions: Alertable disruptions (non-disabled severities)
+            - unfiltered_disruptions: All route disruptions (for cleared line detection)
             - error_occurred: True if an error occurred during processing
         """
         try:
@@ -908,6 +1017,9 @@ class AlertService:
                 elif disruption.line_id in route_line_ids:
                     route_disruptions.append(disruption)
 
+            # Keep unfiltered disruptions for cleared line detection
+            unfiltered_route_disruptions = route_disruptions.copy()
+
             # Filter disruptions by severity (remove non-alertable severities like "Good Service")
             before_filter_count = len(route_disruptions)
             route_disruptions = filter_alertable_disruptions(route_disruptions, disabled_severity_pairs)
@@ -921,7 +1033,7 @@ class AlertService:
                 filtered_count=filtered_count,
             )
 
-            return route_disruptions, False
+            return route_disruptions, unfiltered_route_disruptions, False
 
         except Exception as e:
             logger.error(
@@ -930,7 +1042,33 @@ class AlertService:
                 error=str(e),
                 exc_info=e,
             )
-            return [], True
+            return [], [], True
+
+    async def _get_cleared_states(self) -> set[tuple[str, int]]:
+        """
+        Get (mode_id, severity_level) pairs that represent cleared states.
+
+        Cleared states are severities marked with is_cleared_state=True
+        in the alert_disabled_severities table (e.g., Good Service, No Issues).
+
+        Returns:
+            Set of (mode_id, severity_level) tuples for cleared states
+        """
+        try:
+            result = await self.db.execute(
+                select(AlertDisabledSeverity).where(AlertDisabledSeverity.is_cleared_state == True)  # noqa: E712
+            )
+            cleared_states = {(d.mode_id, d.severity_level) for d in result.scalars().all()}
+            logger.debug("cleared_states_fetched", count=len(cleared_states))
+            return cleared_states
+        except Exception as e:
+            logger.error(
+                "fetch_cleared_states_failed",
+                error=str(e),
+                exc_info=e,
+            )
+            # Return empty set on error - cleared detection will be skipped
+            return set()
 
     async def _should_send_alert(
         self,
@@ -938,7 +1076,7 @@ class AlertService:
         user_id: UUID,
         schedule: UserRouteSchedule,
         disruptions: list[DisruptionResponse],
-    ) -> tuple[bool, list[DisruptionResponse]]:
+    ) -> tuple[bool, list[DisruptionResponse], dict[str, dict[str, object]]]:
         """
         Check if we should send an alert, with per-line cooldown logic.
 
@@ -953,9 +1091,10 @@ class AlertService:
             disruptions: Current disruptions
 
         Returns:
-            Tuple of (should_send, filtered_disruptions):
+            Tuple of (should_send, filtered_disruptions, stored_lines):
             - should_send: True if alert should be sent, False if all lines are within cooldown
             - filtered_disruptions: Only disruptions for lines that passed cooldown check
+            - stored_lines: Previously alerted lines from Redis state (for cleared detection)
         """
         with service_span("alert.should_send_check", "alert-service") as span:
             span.set_attribute("alert.route_id", str(route.id))
@@ -1015,7 +1154,7 @@ class AlertService:
                     span.set_attribute("alert.result", False)
                     span.set_attribute("alert.lines_checked", len(disruptions_by_line))
                     span.set_attribute("alert.lines_to_alert", 0)
-                    return False, []
+                    return False, [], stored_lines
 
                 # Filter disruptions to only include lines that passed the check
                 filtered_disruptions = [d for d in disruptions if d.line_id in lines_to_alert]
@@ -1032,7 +1171,7 @@ class AlertService:
                 span.set_attribute("alert.lines_checked", len(disruptions_by_line))
                 span.set_attribute("alert.lines_to_alert", len(lines_to_alert))
 
-                return True, filtered_disruptions
+                return True, filtered_disruptions, stored_lines
 
             except Exception as e:
                 logger.error(
@@ -1048,7 +1187,7 @@ class AlertService:
                 span.set_attribute("alert.error", True)
                 span.set_attribute("alert.error_type", type(e).__name__)
                 # On error, default to sending alert (better to over-notify than under-notify)
-                return True, disruptions
+                return True, disruptions, {}
 
     async def _get_verified_contact(  # noqa: PLR0911
         self,
@@ -1230,11 +1369,328 @@ class AlertService:
             )
             return False, str(send_error)
 
+    async def _send_single_status_update(
+        self,
+        pref: NotificationPreference,
+        contact_info: str,
+        route: UserRoute,
+        cleared_lines: list[ClearedLineInfo],
+        still_disrupted: list[DisruptionResponse],
+    ) -> tuple[bool, str | None]:
+        """
+        Send a single status update notification via the appropriate method.
+
+        Args:
+            pref: Notification preference
+            contact_info: Contact string (email or phone)
+            route: UserRoute being updated
+            cleared_lines: Lines that have returned to normal service
+            still_disrupted: Lines that remain disrupted
+
+        Returns:
+            Tuple of (success, error_message)
+            - success: True if sent successfully, False otherwise
+            - error_message: Error message if failed, None if successful
+        """
+        try:
+            notification_service = NotificationService()
+
+            if pref.method == NotificationMethod.EMAIL:
+                user_name = self._get_user_display_name(route)
+                await notification_service.send_status_update_email(
+                    email=contact_info,
+                    route_name=route.name,
+                    cleared_lines=cleared_lines,
+                    still_disrupted=still_disrupted,
+                    user_name=user_name,
+                )
+            elif pref.method == NotificationMethod.SMS:
+                await notification_service.send_status_update_sms(
+                    phone=contact_info,
+                    route_name=route.name,
+                    cleared_lines=cleared_lines,
+                    still_disrupted=still_disrupted,
+                )
+
+            logger.info(
+                "status_update_sent_successfully",
+                method=pref.method.value,
+                target_hash=hash_pii(contact_info),
+                route_id=str(route.id),
+                route_name=route.name,
+                cleared_count=len(cleared_lines),
+                still_disrupted_count=len(still_disrupted),
+            )
+            return True, None
+
+        except Exception as send_error:
+            logger.error(
+                "status_update_send_failed",
+                pref_id=str(pref.id),
+                route_id=str(route.id),
+                method=pref.method.value,
+                error=str(send_error),
+                exc_info=send_error,
+            )
+            return False, str(send_error)
+
+    async def _send_status_update_notifications(
+        self,
+        route: UserRoute,
+        schedule: UserRouteSchedule,
+        cleared_lines: list[ClearedLineInfo],
+        still_disrupted: list[DisruptionResponse],
+    ) -> int:
+        """
+        Send status update notifications for a route to all configured notification preferences.
+
+        Args:
+            route: UserRoute to send status updates for
+            schedule: Active schedule
+            cleared_lines: Lines that have returned to normal service
+            still_disrupted: Lines that remain disrupted
+
+        Returns:
+            Number of status updates successfully sent
+        """
+        with service_span(
+            "alert.send_status_update",
+            "alert-service",
+        ) as span:
+            # Set span attributes
+            span.set_attribute("alert.route_id", str(route.id))
+            span.set_attribute("alert.route_name", route.name)
+            span.set_attribute("alert.cleared_count", len(cleared_lines))
+            span.set_attribute("alert.still_disrupted_count", len(still_disrupted))
+
+            updates_sent = 0
+            # Initialize prefs outside try block so it's accessible in except block
+            prefs: list[NotificationPreference] = []
+
+            try:
+                # Get notification preferences safely (may not be loaded in async context)
+                try:
+                    insp = inspect(route)
+                    prefs = [] if "notification_preferences" in insp.unloaded else route.notification_preferences or []
+                except Exception:
+                    # Can't inspect (e.g., Mock object in tests) - try direct access
+                    prefs = route.notification_preferences or []
+
+                # Check if route has notification preferences
+                if not prefs:
+                    logger.warning(
+                        "no_notification_preferences_for_status_update",
+                        route_id=str(route.id),
+                        route_name=route.name,
+                    )
+                    span.set_attribute("alert.preference_count", 0)
+                    span.set_attribute("alert.updates_sent", 0)
+                    return 0
+
+                # Process each notification preference
+                for pref in prefs:
+                    try:
+                        # Get verified contact information
+                        contact_info = await self._get_verified_contact(pref, route.id)
+                        if not contact_info:
+                            continue
+
+                        # Send status update notification
+                        success, error_message = await self._send_single_status_update(
+                            pref=pref,
+                            contact_info=contact_info,
+                            route=route,
+                            cleared_lines=cleared_lines,
+                            still_disrupted=still_disrupted,
+                        )
+
+                        # Create notification log
+                        if success:
+                            self._create_notification_log(
+                                user_id=route.user_id,
+                                route_id=route.id,
+                                method=pref.method,
+                                status=NotificationStatus.SENT,
+                            )
+                            updates_sent += 1
+                        else:
+                            self._create_notification_log(
+                                user_id=route.user_id,
+                                route_id=route.id,
+                                method=pref.method,
+                                status=NotificationStatus.FAILED,
+                                error_message=error_message,
+                            )
+
+                    except Exception as e:
+                        # Catch any other unexpected errors in preference processing
+                        logger.error(
+                            "preference_processing_failed_for_status_update",
+                            pref_id=str(pref.id),
+                            route_id=str(route.id),
+                            error=str(e),
+                            exc_info=e,
+                        )
+
+                # Commit all notification logs
+                await self.db.commit()
+
+                # If any status updates were sent successfully, remove cleared lines from Redis state
+                if updates_sent > 0:
+                    await self._update_alert_state_remove_cleared(
+                        route=route,
+                        user_id=route.user_id,
+                        schedule=schedule,
+                        cleared_line_ids=[cl.line_id for cl in cleared_lines],
+                    )
+
+                # Set span attributes at the end
+                span.set_attribute("alert.preference_count", len(prefs))
+                span.set_attribute("alert.updates_sent", updates_sent)
+
+                logger.info(
+                    "status_updates_sent_for_route",
+                    route_id=str(route.id),
+                    route_name=route.name,
+                    updates_sent=updates_sent,
+                )
+
+                return updates_sent
+
+            except Exception as e:
+                logger.error(
+                    "send_status_updates_for_route_failed",
+                    route_id=str(route.id),
+                    error=str(e),
+                    exc_info=e,
+                )
+                await self.db.rollback()
+                # Set span attributes even on error (preserve prefs count if we got it)
+                try:
+                    pref_count = len(prefs) if isinstance(prefs, list) else 0
+                except (TypeError, AttributeError):
+                    pref_count = 0
+                span.set_attribute("alert.preference_count", pref_count)
+                span.set_attribute("alert.updates_sent", updates_sent)
+                return 0
+
+    async def _update_alert_state_remove_cleared(
+        self,
+        route: UserRoute,
+        user_id: UUID,
+        schedule: UserRouteSchedule,
+        cleared_line_ids: list[str],
+    ) -> None:
+        """
+        Remove cleared lines from the alert state in Redis.
+
+        After sending status update notifications for cleared lines,
+        we remove them from the stored state so we don't continue tracking them.
+
+        Args:
+            route: UserRoute the status update was sent for
+            user_id: User ID for deduplication key
+            schedule: Active schedule
+            cleared_line_ids: List of line IDs that have cleared
+        """
+        with service_span("alert.remove_cleared_from_state", "alert-service") as span:
+            span.set_attribute("alert.route_id", str(route.id))
+            span.set_attribute("alert.user_id", str(user_id))
+            span.set_attribute("alert.schedule_id", str(schedule.id))
+            span.set_attribute("alert.cleared_count", len(cleared_line_ids))
+
+            try:
+                # Build Redis key
+                redis_key = f"alert:{route.id}:{user_id}:{schedule.id}"
+
+                # Get existing state
+                existing_state = await self.redis_client.get(redis_key)
+                if not existing_state:
+                    logger.debug(
+                        "no_existing_state_to_update",
+                        route_id=str(route.id),
+                        redis_key=redis_key,
+                    )
+                    return
+
+                # Parse existing state
+                try:
+                    state_data = json.loads(existing_state)
+                    if state_data.get("version") != ALERT_STATE_VERSION:
+                        logger.warning(
+                            "incompatible_state_version_on_update",
+                            route_id=str(route.id),
+                            redis_key=redis_key,
+                            version=state_data.get("version"),
+                        )
+                        return
+
+                    lines_state = state_data.get("lines", {})
+
+                    # Remove cleared lines from state
+                    for line_id in cleared_line_ids:
+                        if line_id in lines_state:
+                            del lines_state[line_id]
+
+                    # Update state data
+                    state_data["lines"] = lines_state
+
+                    # Calculate TTL for updated state (same logic as _store_alert_state)
+                    route_tz = ZoneInfo(route.timezone)
+                    now_utc = datetime.now(UTC)
+                    now_local = now_utc.astimezone(route_tz)
+                    end_datetime = datetime.combine(now_local.date(), schedule.end_time, tzinfo=route_tz)
+
+                    ttl_seconds = 0 if end_datetime <= now_local else int((end_datetime - now_local).total_seconds())
+
+                    # Store updated state back to Redis
+                    if ttl_seconds > 0 and lines_state:
+                        # Only store if we have TTL and remaining lines
+                        await self.redis_client.setex(
+                            redis_key,
+                            ttl_seconds,
+                            json.dumps(state_data),
+                        )
+                        logger.info(
+                            "cleared_lines_removed_from_state",
+                            route_id=str(route.id),
+                            redis_key=redis_key,
+                            cleared_line_ids=cleared_line_ids,
+                            remaining_lines=list(lines_state.keys()),
+                        )
+                    else:
+                        # No lines left or TTL expired - delete the key
+                        await self.redis_client.delete(redis_key)
+                        logger.info(
+                            "alert_state_deleted_no_remaining_lines",
+                            route_id=str(route.id),
+                            redis_key=redis_key,
+                            cleared_line_ids=cleared_line_ids,
+                        )
+
+                except (json.JSONDecodeError, AttributeError) as e:
+                    logger.warning(
+                        "failed_to_parse_existing_state_on_update",
+                        route_id=str(route.id),
+                        redis_key=redis_key,
+                        error=str(e),
+                    )
+
+            except Exception as e:
+                logger.error(
+                    "failed_to_update_alert_state",
+                    route_id=str(route.id),
+                    error=str(e),
+                    exc_info=e,
+                )
+                # Don't raise - state cleanup failure shouldn't break the flow
+
     async def _process_single_route(
         self,
         route: UserRoute,
         schedules: list[UserRouteSchedule],
         disabled_severity_pairs: set[tuple[str, int]],
+        cleared_states: set[tuple[str, int]],
     ) -> tuple[int, bool]:
         """
         Process a single route: check schedule, get disruptions, send alerts.
@@ -1249,6 +1705,7 @@ class AlertService:
             route: UserRoute to process (with segments, preferences loaded)
             schedules: Active (non-deleted) schedules for this route
             disabled_severity_pairs: Set of (mode_id, severity_level) pairs to filter out
+            cleared_states: Set of (mode_id, severity_level) pairs that represent cleared/normal states
 
         Returns:
             Tuple of (alerts_sent, error_occurred)
@@ -1271,11 +1728,13 @@ class AlertService:
                 schedule_id=str(active_schedule.id),
             )
 
-            # Get disruptions for this route
-            disruptions, error_occurred = await self._get_route_disruptions(route, disabled_severity_pairs)
+            # Get disruptions for this route (both filtered and unfiltered)
+            disruptions, all_route_disruptions, error_occurred = await self._get_route_disruptions(
+                route, disabled_severity_pairs
+            )
 
-            # Skip if no disruptions
-            if not disruptions:
+            # Skip if no disruptions at all (need to check cleared lines even if no alertable disruptions)
+            if not disruptions and not all_route_disruptions:
                 logger.debug(
                     "no_disruptions_for_route",
                     route_id=str(route.id),
@@ -1283,35 +1742,70 @@ class AlertService:
                 )
                 return 0, error_occurred
 
-            logger.info(
-                "disruptions_found_for_route",
-                route_id=str(route.id),
-                route_name=route.name,
-                disruption_count=len(disruptions),
-            )
+            if disruptions:
+                logger.info(
+                    "disruptions_found_for_route",
+                    route_id=str(route.id),
+                    route_name=route.name,
+                    disruption_count=len(disruptions),
+                )
 
             # Check if we should send alert (per-line cooldown deduplication)
-            should_send, filtered_disruptions = await self._should_send_alert(
+            should_send, filtered_disruptions, stored_lines = await self._should_send_alert(
                 route=route,
                 user_id=route.user_id,
                 schedule=active_schedule,
                 disruptions=disruptions,
             )
 
-            if not should_send:
+            # Detect cleared lines (lines that were previously alerted but now in cleared state)
+            cleared_lines: list[ClearedLineInfo] = []
+            if stored_lines and all_route_disruptions and cleared_states:
+                # Get current alertable line IDs
+                current_alertable_line_ids = {d.line_id for d in disruptions}
+
+                # Detect cleared lines using pure function
+                cleared_lines = detect_cleared_lines(
+                    stored_lines=stored_lines,
+                    current_alertable_line_ids=current_alertable_line_ids,
+                    all_route_disruptions=all_route_disruptions,
+                    cleared_states=cleared_states,
+                )
+
+                if cleared_lines:
+                    logger.info(
+                        "cleared_lines_detected",
+                        route_id=str(route.id),
+                        route_name=route.name,
+                        cleared_count=len(cleared_lines),
+                        cleared_line_ids=[cl.line_id for cl in cleared_lines],
+                    )
+                    # Send status update notifications
+                    await self._send_status_update_notifications(
+                        route=route,
+                        schedule=active_schedule,
+                        cleared_lines=cleared_lines,
+                        still_disrupted=disruptions,  # Current alertable disruptions
+                    )
+
+            # If no new disruptions AND no cleared lines, skip
+            if not should_send and not cleared_lines:
                 logger.debug(
-                    "alert_skipped_all_lines_within_cooldown",
+                    "alert_skipped_no_changes",
                     route_id=str(route.id),
                     route_name=route.name,
                 )
                 return 0, error_occurred
 
-            # Send alerts (only for lines that passed cooldown check)
-            alerts_sent = await self._send_alerts_for_route(
-                route=route,
-                schedule=active_schedule,
-                disruptions=filtered_disruptions,
-            )
+            # Send alerts if we have new disruptions
+            alerts_sent = 0
+            if should_send:
+                # Send alerts (only for lines that passed cooldown check)
+                alerts_sent = await self._send_alerts_for_route(
+                    route=route,
+                    schedule=active_schedule,
+                    disruptions=filtered_disruptions,
+                )
 
             return alerts_sent, error_occurred
 

--- a/backend/app/templates/email/disruption_alert.html
+++ b/backend/app/templates/email/disruption_alert.html
@@ -137,10 +137,6 @@
             <div class="route-name">{{ route_name }}</div>
         </div>
         <div class="content">
-            <p class="greeting">Hello {{ user_name or "there" }},</p>
-
-            <p>We're writing to inform you that there are currently disruptions affecting your route <strong>{{ route_name }}</strong>.</p>
-
             {% for disruption in disruptions %}
             <div class="disruption">
                 <div class="line-name">{{ disruption.line_name }}</div>
@@ -151,20 +147,8 @@
             </div>
             {% endfor %}
 
-            <p>Please plan your journey accordingly and allow extra time for your commute.</p>
-
-            <div style="text-align: center;">
-                <a href="{{ tfl_status_url }}" class="cta-button">View TfL Status Updates</a>
-            </div>
-
             <p style="font-size: 14px; color: #666666; margin-top: 20px;">
-                This alert was sent based on your notification preferences. You can update your preferences at any time in your account settings.
-            </p>
-        </div>
-        <div class="footer">
-            <p>
-                This is an automated alert from IsTheTubeRunning.<br>
-                © 2025 IsTheTubeRunning. All rights reserved.
+                <a href="{{ tfl_status_url }}" style="color: #003366; text-decoration: none;">TfL Status →</a>
             </p>
         </div>
     </div>

--- a/backend/app/templates/email/status_update.html
+++ b/backend/app/templates/email/status_update.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Service Restored - IsTheTubeRunning</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background-color: #f5f5f5;
+        }
+        .container {
+            max-width: 600px;
+            margin: 40px auto;
+            background-color: #ffffff;
+            border-radius: 8px;
+            overflow: hidden;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+        }
+        .header {
+            background: #27ae60;
+            padding: 30px 20px;
+            text-align: center;
+            color: #ffffff;
+        }
+        .header h1 {
+            margin: 0 0 10px 0;
+            font-size: 24px;
+            font-weight: 600;
+        }
+        .header .alert-icon {
+            font-size: 36px;
+            margin-bottom: 10px;
+        }
+        .header .route-name {
+            font-size: 18px;
+            font-weight: 400;
+            opacity: 0.95;
+        }
+        .content {
+            padding: 30px 30px 20px;
+        }
+        .content p {
+            color: #333333;
+            line-height: 1.6;
+            margin: 0 0 20px;
+        }
+        .greeting {
+            font-size: 16px;
+            color: #333333;
+            margin-bottom: 20px;
+        }
+        .section-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: #2c3e50;
+            margin: 25px 0 15px;
+        }
+        .cleared-line {
+            border-left: 4px solid #27ae60;
+            padding: 15px;
+            margin: 15px 0;
+            background: #e8f8f5;
+            border-radius: 4px;
+        }
+        .cleared-line .line-name {
+            font-size: 18px;
+            font-weight: 600;
+            color: #2c3e50;
+            margin-bottom: 8px;
+        }
+        .cleared-line .status {
+            font-size: 16px;
+            color: #27ae60;
+            font-weight: 500;
+            margin-bottom: 4px;
+        }
+        .cleared-line .previous-status {
+            font-size: 14px;
+            color: #666666;
+        }
+        .disruption {
+            border-left: 4px solid #e74c3c;
+            padding: 15px;
+            margin: 15px 0;
+            background: #f8f9fa;
+            border-radius: 4px;
+        }
+        .disruption .line-name {
+            font-size: 18px;
+            font-weight: 600;
+            color: #2c3e50;
+            margin-bottom: 8px;
+        }
+        .disruption .status {
+            font-size: 16px;
+            color: #e74c3c;
+            font-weight: 500;
+            margin-bottom: 8px;
+        }
+        .disruption .reason {
+            font-size: 14px;
+            color: #555555;
+            line-height: 1.5;
+            margin-top: 8px;
+        }
+        .cta-button {
+            display: inline-block;
+            background-color: #003366;
+            color: #ffffff;
+            text-decoration: none;
+            padding: 12px 30px;
+            border-radius: 6px;
+            font-weight: 600;
+            margin: 20px 0;
+            text-align: center;
+        }
+        .cta-button:hover {
+            background-color: #00254d;
+        }
+        .footer {
+            background-color: #f8f9fa;
+            padding: 20px 30px;
+            text-align: center;
+            color: #666666;
+            font-size: 12px;
+            line-height: 1.5;
+        }
+        .footer a {
+            color: #003366;
+            text-decoration: none;
+        }
+        @media only screen and (max-width: 600px) {
+            .container {
+                margin: 20px;
+                border-radius: 0;
+            }
+            .header {
+                padding: 20px 15px;
+            }
+            .header h1 {
+                font-size: 20px;
+            }
+            .header .route-name {
+                font-size: 16px;
+            }
+            .content {
+                padding: 20px 15px;
+            }
+            .cleared-line .line-name,
+            .disruption .line-name {
+                font-size: 16px;
+            }
+            .cleared-line .status,
+            .disruption .status {
+                font-size: 14px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="header">
+            <div class="alert-icon">✅</div>
+            <h1>Service Restored</h1>
+            <div class="route-name">{{ route_name }}</div>
+        </div>
+        <div class="content">
+            <p class="greeting">Hello {{ user_name|default("there") }},</p>
+
+            <p>Good news! Service has been restored on your route <strong>{{ route_name }}</strong>.</p>
+
+            <div class="section-title">✅ Service Restored:</div>
+            {% for cleared in cleared_lines %}
+            <div class="cleared-line">
+                <div class="line-name">{{ cleared.line_name }}</div>
+                <div class="status">{{ cleared.current_status }}</div>
+                <div class="previous-status">Previously: {{ cleared.previous_status }}</div>
+            </div>
+            {% endfor %}
+
+            {% if still_disrupted %}
+            <div class="section-title">⚠️ Still Disrupted:</div>
+            <p style="font-size: 14px; color: #666666; margin-top: 10px;">
+                The following lines remain disrupted:
+            </p>
+            {% for disruption in still_disrupted %}
+            <div class="disruption">
+                <div class="line-name">{{ disruption.line_name }}</div>
+                <div class="status">{{ disruption.status_severity_description }}</div>
+                {% if disruption.reason %}
+                <div class="reason">{{ disruption.reason }}</div>
+                {% endif %}
+            </div>
+            {% endfor %}
+            {% endif %}
+
+            <div style="text-align: center;">
+                <a href="{{ tfl_status_url }}" class="cta-button">View TfL Status Updates</a>
+            </div>
+
+            <p style="font-size: 14px; color: #666666; margin-top: 20px;">
+                This update was sent based on your notification preferences. You can update your preferences at any time in your account settings.
+            </p>
+        </div>
+        <div class="footer">
+            <p>
+                This is an automated alert from IsTheTubeRunning.<br>
+                © 2025 IsTheTubeRunning. All rights reserved.
+            </p>
+        </div>
+    </div>
+</body>
+</html>

--- a/backend/app/templates/email/status_update.html
+++ b/backend/app/templates/email/status_update.html
@@ -168,11 +168,7 @@
             <div class="route-name">{{ route_name }}</div>
         </div>
         <div class="content">
-            <p class="greeting">Hello {{ user_name|default("there") }},</p>
-
-            <p>Good news! Service has been restored on your route <strong>{{ route_name }}</strong>.</p>
-
-            <div class="section-title">✅ Service Restored:</div>
+            <div class="section-title">Restored:</div>
             {% for cleared in cleared_lines %}
             <div class="cleared-line">
                 <div class="line-name">{{ cleared.line_name }}</div>
@@ -182,10 +178,7 @@
             {% endfor %}
 
             {% if still_disrupted %}
-            <div class="section-title">⚠️ Still Disrupted:</div>
-            <p style="font-size: 14px; color: #666666; margin-top: 10px;">
-                The following lines remain disrupted:
-            </p>
+            <div class="section-title">Still disrupted:</div>
             {% for disruption in still_disrupted %}
             <div class="disruption">
                 <div class="line-name">{{ disruption.line_name }}</div>
@@ -197,18 +190,8 @@
             {% endfor %}
             {% endif %}
 
-            <div style="text-align: center;">
-                <a href="{{ tfl_status_url }}" class="cta-button">View TfL Status Updates</a>
-            </div>
-
             <p style="font-size: 14px; color: #666666; margin-top: 20px;">
-                This update was sent based on your notification preferences. You can update your preferences at any time in your account settings.
-            </p>
-        </div>
-        <div class="footer">
-            <p>
-                This is an automated alert from IsTheTubeRunning.<br>
-                © 2025 IsTheTubeRunning. All rights reserved.
+                <a href="{{ tfl_status_url }}" style="color: #003366; text-decoration: none;">TfL Status →</a>
             </p>
         </div>
     </div>

--- a/backend/tests/services/test_alert_otel.py
+++ b/backend/tests/services/test_alert_otel.py
@@ -119,14 +119,15 @@ class TestAlertServiceProcessAllRoutesOtelSpans:
         alert_svc._get_active_routes = AsyncMock(return_value=[successful_route, failing_route])
 
         # Mock _fetch_global_disruption_data (refactored method)
-        alert_svc._fetch_global_disruption_data = AsyncMock(return_value=set())
+        alert_svc._fetch_global_disruption_data = AsyncMock(return_value=(set(), set()))
 
         # Mock _process_single_route: succeed for first route, fail for second
-        # Updated signature includes schedules parameter
+        # Updated signature includes schedules and cleared_states parameters
         async def mock_process_route(
             route: UserRoute,
             schedules: list,
             disabled_severity_pairs: set,
+            cleared_states: set,
         ) -> tuple[int, bool]:
             if route is successful_route:
                 return 3, False  # 3 alerts sent, no error
@@ -643,7 +644,7 @@ class TestAlertServiceShouldSendAlertOtelSpans:
         mock_schedule.id = schedule_id
 
         # Call the method
-        should_send, _filtered = await alert_svc._should_send_alert(
+        should_send, _filtered, _stored_lines = await alert_svc._should_send_alert(
             route=mock_route,
             user_id=user_id,
             schedule=mock_schedule,
@@ -700,7 +701,7 @@ class TestAlertServiceShouldSendAlertOtelSpans:
         mock_schedule.id = schedule_id
 
         # Method handles exception gracefully
-        should_send, _filtered = await alert_svc._should_send_alert(
+        should_send, _filtered, _stored_lines = await alert_svc._should_send_alert(
             route=mock_route,
             user_id=user_id,
             schedule=mock_schedule,

--- a/backend/tests/services/test_alert_otel.py
+++ b/backend/tests/services/test_alert_otel.py
@@ -98,6 +98,11 @@ class TestAlertServiceProcessAllRoutesOtelSpans:
         mock_db = AsyncMock()
         mock_redis = AsyncMock()
 
+        # Mock database execute for get_active_children_for_parents query
+        mock_result = MagicMock()
+        mock_result.scalars.return_value.all.return_value = []  # No schedules
+        mock_db.execute.return_value = mock_result
+
         # Create alert service
         alert_svc = AlertService(db=mock_db, redis_client=mock_redis)
 
@@ -117,7 +122,12 @@ class TestAlertServiceProcessAllRoutesOtelSpans:
         alert_svc._fetch_global_disruption_data = AsyncMock(return_value=set())
 
         # Mock _process_single_route: succeed for first route, fail for second
-        async def mock_process_route(route: UserRoute, disabled_severity_pairs: set) -> tuple[int, bool]:
+        # Updated signature includes schedules parameter
+        async def mock_process_route(
+            route: UserRoute,
+            schedules: list,
+            disabled_severity_pairs: set,
+        ) -> tuple[int, bool]:
             if route is successful_route:
                 return 3, False  # 3 alerts sent, no error
             if route is failing_route:

--- a/backend/tests/test_admin_alerts.py
+++ b/backend/tests/test_admin_alerts.py
@@ -1,6 +1,5 @@
 """Tests for admin alert management endpoints."""
 
-from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -8,12 +7,10 @@ from uuid import UUID
 
 import pytest
 from app.core.config import settings
-from app.core.database import get_db
-from app.main import app
 from app.models.notification import NotificationLog, NotificationMethod, NotificationStatus
 from app.models.user import User
 from app.models.user_route import UserRoute
-from httpx import ASGITransport, AsyncClient
+from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from tests.helpers.http_assertions import assert_401_unauthorized
@@ -33,22 +30,6 @@ def build_api_url(endpoint: str) -> str:
     prefix = settings.API_V1_PREFIX.rstrip("/")
     path = endpoint if endpoint.startswith("/") else f"/{endpoint}"
     return f"{prefix}{path}"
-
-
-@pytest.fixture
-async def async_client_with_db(db_session: AsyncSession) -> AsyncGenerator[AsyncClient]:
-    """Async HTTP client with database dependency override."""
-
-    async def override_get_db() -> AsyncGenerator[AsyncSession]:
-        yield db_session
-
-    app.dependency_overrides[get_db] = override_get_db
-
-    try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            yield client
-    finally:
-        app.dependency_overrides.clear()
 
 
 # ==================== Authorization Tests ====================

--- a/backend/tests/test_admin_dashboard.py
+++ b/backend/tests/test_admin_dashboard.py
@@ -1,14 +1,11 @@
 """Tests for admin dashboard user management and analytics endpoints."""
 
-from collections.abc import AsyncGenerator
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import uuid4
 
 import pytest
 from app.core.config import settings
-from app.core.database import get_db
-from app.main import app
 from app.models.notification import (
     NotificationLog,
     NotificationMethod,
@@ -23,7 +20,7 @@ from app.models.user import (
 )
 from app.models.user_route import UserRoute
 from app.services.admin_service import calculate_avg_routes, calculate_success_rate
-from httpx import ASGITransport, AsyncClient
+from httpx import AsyncClient
 from sqlalchemy import select as sql_select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -43,24 +40,6 @@ def build_api_url(endpoint: str) -> str:
     prefix = settings.API_V1_PREFIX.rstrip("/")
     path = endpoint if endpoint.startswith("/") else f"/{endpoint}"
     return f"{prefix}{path}"
-
-
-@pytest.fixture
-async def async_client_with_db(
-    db_session: AsyncSession,
-) -> AsyncGenerator[AsyncClient]:
-    """Async HTTP client with database dependency override."""
-
-    async def override_get_db() -> AsyncGenerator[AsyncSession]:
-        yield db_session
-
-    app.dependency_overrides[get_db] = override_get_db
-
-    try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            yield client
-    finally:
-        app.dependency_overrides.clear()
 
 
 # ==================== Authorization Tests ====================

--- a/backend/tests/test_admin_route_index.py
+++ b/backend/tests/test_admin_route_index.py
@@ -1,20 +1,17 @@
 """Tests for admin route index management endpoint."""
 
 import uuid
-from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 from app.core.config import settings
-from app.core.database import get_db
-from app.main import app
 from app.models.tfl import Line, Station
 from app.models.user import User
 from app.models.user_route import UserRoute, UserRouteSegment
 from app.models.user_route_index import UserRouteStationIndex
-from httpx import ASGITransport, AsyncClient
+from httpx import AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -32,22 +29,6 @@ def build_api_url(endpoint: str) -> str:
     prefix = settings.API_V1_PREFIX.rstrip("/")
     path = endpoint if endpoint.startswith("/") else f"/{endpoint}"
     return f"{prefix}{path}"
-
-
-@pytest.fixture
-async def async_client_with_db(db_session: AsyncSession) -> AsyncGenerator[AsyncClient]:
-    """Async HTTP client with database dependency override."""
-
-    async def override_get_db() -> AsyncGenerator[AsyncSession]:
-        yield db_session
-
-    app.dependency_overrides[get_db] = override_get_db
-
-    try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            yield client
-    finally:
-        app.dependency_overrides.clear()
 
 
 class TestAdminRebuildIndexesEndpoint:

--- a/backend/tests/test_alert_service.py
+++ b/backend/tests/test_alert_service.py
@@ -24,11 +24,12 @@ from app.models.tfl import AlertDisabledSeverity, Line, LineDisruptionStateLog, 
 from app.models.user import EmailAddress, PhoneNumber, User
 from app.models.user_route import UserRoute, UserRouteSchedule, UserRouteSegment
 from app.models.user_route_index import UserRouteStationIndex
-from app.schemas.tfl import AffectedRouteInfo, DisruptionResponse
+from app.schemas.tfl import AffectedRouteInfo, ClearedLineInfo, DisruptionResponse
 from app.services.alert_service import (
     ALERT_STATE_VERSION,
     AlertService,
     create_line_aggregate_hash,
+    detect_cleared_lines,
     filter_alertable_disruptions,
     get_day_code,
     init_alert_processing_stats,
@@ -42,22 +43,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 # ==================== Fixtures ====================
-
-
-@pytest.fixture
-def mock_redis() -> AsyncMock:
-    """Mock Redis client for testing."""
-    client = AsyncMock(spec=redis.Redis)
-    client.get = AsyncMock(return_value=None)
-    client.set = AsyncMock(return_value=True)
-    client.setex = AsyncMock()
-    return client
-
-
-@pytest.fixture
-def alert_service(db_session: AsyncSession, mock_redis: AsyncMock) -> AlertService:
-    """Create AlertService instance with mocked Redis."""
-    return AlertService(db=db_session, redis_client=mock_redis)
+# Note: mock_redis and alert_service fixtures are defined in conftest.py
 
 
 @pytest.fixture
@@ -381,6 +367,326 @@ def test_init_alert_processing_stats() -> None:
     assert stats2["routes_checked"] == 0
 
 
+# ==================== Tests for detect_cleared_lines() ====================
+
+
+@pytest.mark.parametrize(
+    (
+        "scenario",
+        "stored_lines",
+        "current_alertable",
+        "all_disruptions",
+        "cleared_states",
+        "expected_count",
+        "expected_line_ids",
+        "expected_fields",
+    ),
+    [
+        pytest.param(
+            "no_stored_lines",
+            {},
+            set(),
+            [],
+            {("tube", 10)},
+            0,
+            None,
+            None,
+            id="no_stored_lines",
+        ),
+        pytest.param(
+            "line_still_disrupted",
+            {
+                "victoria": {
+                    "severity": 6,
+                    "status": "Severe Delays",
+                    "full_hash": "abc123",
+                    "last_sent_at": "2024-01-01T10:00:00Z",
+                }
+            },
+            {"victoria"},
+            [
+                DisruptionResponse(
+                    line_id="victoria",
+                    line_name="Victoria",
+                    mode="tube",
+                    status_severity=6,
+                    status_severity_description="Severe Delays",
+                )
+            ],
+            {("tube", 10)},
+            0,
+            None,
+            None,
+            id="line_still_disrupted",
+        ),
+        pytest.param(
+            "line_cleared_to_good_service",
+            {
+                "victoria": {
+                    "severity": 6,
+                    "status": "Severe Delays",
+                    "full_hash": "abc123",
+                    "last_sent_at": "2024-01-01T10:00:00Z",
+                }
+            },
+            set(),
+            [
+                DisruptionResponse(
+                    line_id="victoria",
+                    line_name="Victoria",
+                    mode="tube",
+                    status_severity=10,
+                    status_severity_description="Good Service",
+                )
+            ],
+            {("tube", 10)},
+            1,
+            {"victoria"},
+            {
+                "line_name": "Victoria",
+                "mode": "tube",
+                "previous_severity": 6,
+                "previous_status": "Severe Delays",
+                "current_severity": 10,
+                "current_status": "Good Service",
+            },
+            id="line_cleared_to_good_service",
+        ),
+        pytest.param(
+            "line_in_suppressed_state",
+            {
+                "victoria": {
+                    "severity": 6,
+                    "status": "Severe Delays",
+                    "full_hash": "abc123",
+                    "last_sent_at": "2024-01-01T10:00:00Z",
+                }
+            },
+            set(),
+            [
+                DisruptionResponse(
+                    line_id="victoria",
+                    line_name="Victoria",
+                    mode="tube",
+                    status_severity=20,
+                    status_severity_description="Service Closed",
+                )
+            ],
+            {("tube", 10)},
+            0,
+            None,
+            None,
+            id="line_in_suppressed_state",
+        ),
+        pytest.param(
+            "line_not_in_current_data",
+            {
+                "victoria": {
+                    "severity": 6,
+                    "status": "Severe Delays",
+                    "full_hash": "abc123",
+                    "last_sent_at": "2024-01-01T10:00:00Z",
+                }
+            },
+            set(),
+            [],
+            {("tube", 10)},
+            0,
+            None,
+            None,
+            id="line_not_in_current_data",
+        ),
+        pytest.param(
+            "multiple_lines_cleared",
+            {
+                "victoria": {
+                    "severity": 6,
+                    "status": "Severe Delays",
+                    "full_hash": "abc123",
+                    "last_sent_at": "2024-01-01T10:00:00Z",
+                },
+                "northern": {
+                    "severity": 9,
+                    "status": "Minor Delays",
+                    "full_hash": "def456",
+                    "last_sent_at": "2024-01-01T10:05:00Z",
+                },
+            },
+            set(),
+            [
+                DisruptionResponse(
+                    line_id="victoria",
+                    line_name="Victoria",
+                    mode="tube",
+                    status_severity=10,
+                    status_severity_description="Good Service",
+                ),
+                DisruptionResponse(
+                    line_id="northern",
+                    line_name="Northern",
+                    mode="tube",
+                    status_severity=18,
+                    status_severity_description="No Issues",
+                ),
+            ],
+            {("tube", 10), ("tube", 18)},
+            2,
+            {"victoria", "northern"},
+            None,
+            id="multiple_lines_cleared",
+        ),
+        pytest.param(
+            "partial_clearing",
+            {
+                "victoria": {
+                    "severity": 6,
+                    "status": "Severe Delays",
+                    "full_hash": "abc123",
+                    "last_sent_at": "2024-01-01T10:00:00Z",
+                },
+                "northern": {
+                    "severity": 9,
+                    "status": "Minor Delays",
+                    "full_hash": "def456",
+                    "last_sent_at": "2024-01-01T10:05:00Z",
+                },
+            },
+            {"northern"},
+            [
+                DisruptionResponse(
+                    line_id="victoria",
+                    line_name="Victoria",
+                    mode="tube",
+                    status_severity=10,
+                    status_severity_description="Good Service",
+                ),
+                DisruptionResponse(
+                    line_id="northern",
+                    line_name="Northern",
+                    mode="tube",
+                    status_severity=9,
+                    status_severity_description="Minor Delays",
+                ),
+            ],
+            {("tube", 10)},
+            1,
+            {"victoria"},
+            None,
+            id="partial_clearing",
+        ),
+        pytest.param(
+            "corrupted_stored_data",
+            {
+                "victoria": {
+                    "severity": "not_an_int",
+                    "status": "Severe Delays",
+                    "full_hash": "abc123",
+                    "last_sent_at": "2024-01-01T10:00:00Z",
+                },
+                "northern": {
+                    "severity": 6,
+                    "status": 123,
+                    "full_hash": "def456",
+                    "last_sent_at": "2024-01-01T10:05:00Z",
+                },
+            },
+            set(),
+            [
+                DisruptionResponse(
+                    line_id="victoria",
+                    line_name="Victoria",
+                    mode="tube",
+                    status_severity=10,
+                    status_severity_description="Good Service",
+                ),
+                DisruptionResponse(
+                    line_id="northern",
+                    line_name="Northern",
+                    mode="tube",
+                    status_severity=10,
+                    status_severity_description="Good Service",
+                ),
+            ],
+            {("tube", 10)},
+            0,
+            None,
+            None,
+            id="corrupted_stored_data",
+        ),
+    ],
+)
+def test_detect_cleared_lines(
+    scenario: str,
+    stored_lines: dict[str, dict[str, Any]],
+    current_alertable: set[str],
+    all_disruptions: list[DisruptionResponse],
+    cleared_states: set[tuple[str, int]],
+    expected_count: int,
+    expected_line_ids: set[str] | None,
+    expected_fields: dict[str, Any] | None,
+) -> None:
+    """Parameterized test for detect_cleared_lines covering various scenarios."""
+    result = detect_cleared_lines(stored_lines, current_alertable, all_disruptions, cleared_states)
+
+    # Check count
+    assert len(result) == expected_count
+
+    # Check line IDs if provided
+    if expected_line_ids is not None:
+        actual_line_ids = {r.line_id for r in result}
+        assert actual_line_ids == expected_line_ids
+
+    # Check specific fields if provided (for single result tests)
+    if expected_fields is not None and len(result) == 1:
+        cleared = result[0]
+        for field, value in expected_fields.items():
+            assert getattr(cleared, field) == value
+
+
+# ==================== Database Method Tests ====================
+
+
+@pytest.mark.asyncio
+async def test_get_cleared_states_returns_cleared_severities(
+    alert_service: AlertService, db_session: AsyncSession
+) -> None:
+    """Test _get_cleared_states returns set of (mode, severity) tuples for cleared states."""
+    # Create test data that won't conflict with migration-created records
+    # Use a test mode that doesn't exist in migrations
+    cleared1 = AlertDisabledSeverity(mode_id="test-mode-1", severity_level=15, is_cleared_state=True)
+    cleared2 = AlertDisabledSeverity(mode_id="test-mode-2", severity_level=16, is_cleared_state=True)
+    non_cleared = AlertDisabledSeverity(mode_id="test-mode-3", severity_level=20, is_cleared_state=False)
+
+    db_session.add_all([cleared1, cleared2, non_cleared])
+    await db_session.commit()
+
+    # Call method
+    result = await alert_service._get_cleared_states()
+
+    # Should return our cleared states
+    assert ("test-mode-1", 15) in result
+    assert ("test-mode-2", 16) in result
+    # Non-cleared should not be in result
+    assert ("test-mode-3", 20) not in result
+    # Should also include migration-created cleared states (tube, 10) and (tube, 18)
+    assert ("tube", 10) in result
+    assert ("tube", 18) in result
+
+
+@pytest.mark.asyncio
+async def test_get_cleared_states_returns_empty_set_on_db_error(
+    alert_service: AlertService, db_session: AsyncSession
+) -> None:
+    """Test _get_cleared_states returns empty set when database query fails."""
+    # Mock database execute to raise an error
+    with patch.object(db_session, "execute", side_effect=SQLAlchemyError("Database error")):
+        # Call method
+        result = await alert_service._get_cleared_states()
+
+        # Should return empty set on error
+        assert result == set()
+
+
 # ==================== Helper Method Unit Tests ====================
 
 
@@ -439,7 +745,7 @@ class TestFetchGlobalDisruptionData:
         await db_session.commit()
 
         # Execute
-        disabled_pairs = await alert_service._fetch_global_disruption_data()
+        disabled_pairs, _cleared_states = await alert_service._fetch_global_disruption_data()
 
         # Verify
         assert ("test-mode", 99) in disabled_pairs
@@ -470,7 +776,7 @@ class TestFetchGlobalDisruptionData:
         mock_tfl_class.return_value = mock_tfl
 
         # Execute
-        disabled_pairs = await alert_service._fetch_global_disruption_data()
+        disabled_pairs, _cleared_states = await alert_service._fetch_global_disruption_data()
 
         # Verify returns disabled pairs from DB, even though TfL failed
         assert ("test-mode-tfl-error", 98) in disabled_pairs
@@ -494,11 +800,12 @@ class TestFetchGlobalDisruptionData:
         alert_service.db.execute = AsyncMock(side_effect=SQLAlchemyError("DB connection error"))
 
         # Execute
-        disabled_pairs = await alert_service._fetch_global_disruption_data()
+        disabled_pairs, cleared_states = await alert_service._fetch_global_disruption_data()
 
-        # Verify returns empty disabled pairs (DB failed)
+        # Verify returns empty disabled pairs and cleared states (DB failed)
         # TfL service should not be called since DB query happens first
         assert disabled_pairs == set()
+        assert cleared_states == set()
         mock_tfl_class.assert_not_called()
 
 
@@ -518,6 +825,7 @@ class TestProcessSingleRoute:
                 route=test_route_with_schedule,
                 schedules=[],
                 disabled_severity_pairs=set(),
+                cleared_states=set(),
             )
 
         assert alerts_sent == 0
@@ -536,12 +844,13 @@ class TestProcessSingleRoute:
         # Mock dependencies
         with (
             patch.object(alert_service, "_get_active_schedule", new_callable=AsyncMock, return_value=mock_schedule),
-            patch.object(alert_service, "_get_route_disruptions", new_callable=AsyncMock, return_value=([], False)),
+            patch.object(alert_service, "_get_route_disruptions", new_callable=AsyncMock, return_value=([], [], False)),
         ):
             alerts_sent, error_occurred = await alert_service._process_single_route(
                 route=test_route_with_schedule,
                 schedules=[],
                 disabled_severity_pairs=set(),
+                cleared_states=set(),
             )
 
         assert alerts_sent == 0
@@ -565,10 +874,10 @@ class TestProcessSingleRoute:
                 alert_service,
                 "_get_route_disruptions",
                 new_callable=AsyncMock,
-                return_value=(sample_disruptions, False),
+                return_value=(sample_disruptions, sample_disruptions, False),
             ),
             patch.object(
-                alert_service, "_should_send_alert", new_callable=AsyncMock, return_value=(True, sample_disruptions)
+                alert_service, "_should_send_alert", new_callable=AsyncMock, return_value=(True, sample_disruptions, {})
             ),
             patch.object(alert_service, "_send_alerts_for_route", new_callable=AsyncMock, return_value=2),
         ):
@@ -576,6 +885,7 @@ class TestProcessSingleRoute:
                 route=test_route_with_schedule,
                 schedules=[],
                 disabled_severity_pairs=set(),
+                cleared_states=set(),
             )
 
         assert alerts_sent == 2
@@ -596,10 +906,13 @@ class TestProcessSingleRoute:
         with (
             patch.object(alert_service, "_get_active_schedule", new_callable=AsyncMock, return_value=mock_schedule),
             patch.object(
-                alert_service, "_get_route_disruptions", new_callable=AsyncMock, return_value=(sample_disruptions, True)
+                alert_service,
+                "_get_route_disruptions",
+                new_callable=AsyncMock,
+                return_value=(sample_disruptions, sample_disruptions, True),
             ),
             patch.object(
-                alert_service, "_should_send_alert", new_callable=AsyncMock, return_value=(True, sample_disruptions)
+                alert_service, "_should_send_alert", new_callable=AsyncMock, return_value=(True, sample_disruptions, {})
             ),
             patch.object(alert_service, "_send_alerts_for_route", new_callable=AsyncMock, return_value=1),
         ):
@@ -607,6 +920,7 @@ class TestProcessSingleRoute:
                 route=test_route_with_schedule,
                 schedules=[],
                 disabled_severity_pairs=set(),
+                cleared_states=set(),
             )
 
         assert alerts_sent == 1
@@ -630,14 +944,15 @@ class TestProcessSingleRoute:
                 alert_service,
                 "_get_route_disruptions",
                 new_callable=AsyncMock,
-                return_value=(sample_disruptions, False),
+                return_value=(sample_disruptions, sample_disruptions, False),
             ),
-            patch.object(alert_service, "_should_send_alert", new_callable=AsyncMock, return_value=(False, [])),
+            patch.object(alert_service, "_should_send_alert", new_callable=AsyncMock, return_value=(False, [], {})),
         ):
             alerts_sent, error_occurred = await alert_service._process_single_route(
                 route=test_route_with_schedule,
                 schedules=[],
                 disabled_severity_pairs=set(),
+                cleared_states=set(),
             )
 
         assert alerts_sent == 0
@@ -656,10 +971,82 @@ class TestProcessSingleRoute:
                 route=test_route_with_schedule,
                 schedules=[],
                 disabled_severity_pairs=set(),
+                cleared_states=set(),
             )
 
         assert alerts_sent == 0
         assert error_occurred is True
+
+    @pytest.mark.asyncio
+    async def test_cleared_lines_detection_integration(
+        self,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+        sample_disruptions: list[DisruptionResponse],
+        db_session: AsyncSession,
+    ) -> None:
+        """Test integration of cleared lines detection and status update notifications.
+
+        Note: Cleared states (severity 10, 18) are created by migration 1025d77921da,
+        so no need to create them in this test.
+        """
+        mock_schedule = MagicMock(spec=UserRouteSchedule)
+        mock_schedule.id = uuid4()
+
+        # Create disruption that cleared from severe to good service
+        cleared_disruption = DisruptionResponse(
+            line_id="victoria",
+            line_name="Victoria",
+            mode="tube",
+            status_severity=10,
+            status_severity_description="Good Service",
+        )
+
+        # Mock Redis state showing previous severe disruption
+        stored_lines = {
+            "victoria": {
+                "severity": 6,
+                "status": "Severe Delays",
+                "full_hash": "old_hash",
+                "last_sent_at": "2024-01-01T10:00:00Z",
+            }
+        }
+
+        with (
+            patch.object(alert_service, "_get_active_schedule", new_callable=AsyncMock, return_value=mock_schedule),
+            patch.object(
+                alert_service,
+                "_get_route_disruptions",
+                new_callable=AsyncMock,
+                return_value=([], [cleared_disruption], False),  # No alertable, but has cleared
+            ),
+            patch.object(
+                alert_service,
+                "_should_send_alert",
+                new_callable=AsyncMock,
+                return_value=(False, [], stored_lines),  # Returns stored lines
+            ),
+            patch.object(
+                alert_service, "_send_status_update_notifications", new_callable=AsyncMock, return_value=1
+            ) as mock_send_status,
+        ):
+            alerts_sent, error_occurred = await alert_service._process_single_route(
+                route=test_route_with_schedule,
+                schedules=[],
+                disabled_severity_pairs=set(),
+                cleared_states={("tube", 10)},  # Severity 10 (Good Service) is a cleared state
+            )
+
+        # Verify status update notifications were called
+        assert mock_send_status.called
+        call_args = mock_send_status.call_args
+        assert len(call_args.kwargs["cleared_lines"]) == 1
+        assert call_args.kwargs["cleared_lines"][0].line_id == "victoria"
+        assert call_args.kwargs["cleared_lines"][0].current_severity == 10
+        assert call_args.kwargs["cleared_lines"][0].previous_severity == 6
+
+        assert alerts_sent == 0  # No new disruption alerts
+        assert error_occurred is False
 
 
 # ==================== process_all_routes Tests ====================
@@ -995,7 +1382,7 @@ async def test_get_route_disruptions_returns_relevant(
 
     disabled_severity_pairs: set[tuple[str, int]] = set()
 
-    disruptions, error_occurred = await alert_service._get_route_disruptions(
+    disruptions, unfiltered, error_occurred = await alert_service._get_route_disruptions(
         test_route_with_schedule, disabled_severity_pairs
     )
 
@@ -1004,6 +1391,9 @@ async def test_get_route_disruptions_returns_relevant(
     # Should only return victoria line disruptions (route only has victoria)
     assert len(disruptions) == 1
     assert disruptions[0].line_id == "victoria"
+    # Unfiltered should also have only victoria (since no severity filtering)
+    assert len(unfiltered) == 1
+    assert unfiltered[0].line_id == "victoria"
 
 
 @pytest.mark.asyncio
@@ -1024,12 +1414,13 @@ async def test_get_route_disruptions_empty(
     mock_tfl_class.return_value = mock_tfl_instance
 
     disabled_severity_pairs: set[tuple[str, int]] = set()
-    disruptions, error_occurred = await alert_service._get_route_disruptions(
+    disruptions, unfiltered, error_occurred = await alert_service._get_route_disruptions(
         test_route_with_schedule, disabled_severity_pairs
     )
 
     assert not error_occurred
     assert len(disruptions) == 0
+    assert len(unfiltered) == 0
 
 
 @pytest.mark.asyncio
@@ -1063,7 +1454,7 @@ async def test_get_route_disruptions_filters_correctly(
     mock_tfl_class.return_value = mock_tfl_instance
 
     disabled_severity_pairs: set[tuple[str, int]] = set()
-    disruptions, error_occurred = await alert_service._get_route_disruptions(
+    disruptions, unfiltered, error_occurred = await alert_service._get_route_disruptions(
         test_route_with_schedule, disabled_severity_pairs
     )
 
@@ -1071,6 +1462,7 @@ async def test_get_route_disruptions_filters_correctly(
     assert not error_occurred
     # Should return empty since central line is not in route
     assert len(disruptions) == 0
+    assert len(unfiltered) == 0
 
 
 @pytest.mark.asyncio
@@ -1115,12 +1507,14 @@ async def test_get_route_disruptions_filters_disabled_severities(
     # Set up disabled severity pairs - (tube, 10) should be filtered
     disabled_severity_pairs: set[tuple[str, int]] = {("tube", 10)}
 
-    disruptions, error_occurred = await alert_service._get_route_disruptions(
+    disruptions, unfiltered, error_occurred = await alert_service._get_route_disruptions(
         test_route_with_schedule, disabled_severity_pairs
     )
 
     # Should return no error
     assert not error_occurred
+    # Unfiltered should have both disruptions
+    assert len(unfiltered) == 2
     # Should only return the disruption with severity 5 (Severe Delays)
     # The Good Service (severity 10) should be filtered out
     assert len(disruptions) == 1
@@ -1148,7 +1542,7 @@ async def test_should_send_alert_no_previous_alert(
     schedule = test_route_with_schedule.schedules[0]
 
     # Redis returns None (no previous alert)
-    should_send, filtered = await alert_service._should_send_alert(
+    should_send, filtered, _stored_lines = await alert_service._should_send_alert(
         route=test_route_with_schedule,
         user_id=test_route_with_schedule.user_id,
         schedule=schedule,
@@ -1190,7 +1584,7 @@ async def test_should_send_alert_same_disruption(
     )
     alert_service.redis_client.get = AsyncMock(return_value=stored_state)  # type: ignore[method-assign]
 
-    should_send, filtered = await alert_service._should_send_alert(
+    should_send, filtered, _stored_lines = await alert_service._should_send_alert(
         route=test_route_with_schedule,
         user_id=test_route_with_schedule.user_id,
         schedule=schedule,
@@ -1244,7 +1638,7 @@ async def test_should_send_alert_changed_disruption(
     )
     alert_service.redis_client.get = AsyncMock(return_value=stored_state)  # type: ignore[method-assign]
 
-    should_send, filtered = await alert_service._should_send_alert(
+    should_send, filtered, _stored_lines = await alert_service._should_send_alert(
         route=test_route_with_schedule,
         user_id=test_route_with_schedule.user_id,
         schedule=schedule,
@@ -1267,7 +1661,7 @@ async def test_should_send_alert_redis_error(
     # Mock Redis to raise error
     alert_service.redis_client.get = AsyncMock(side_effect=Exception("Redis error"))  # type: ignore[method-assign]
 
-    should_send, filtered = await alert_service._should_send_alert(
+    should_send, filtered, _stored_lines = await alert_service._should_send_alert(
         route=test_route_with_schedule,
         user_id=test_route_with_schedule.user_id,
         schedule=schedule,
@@ -1291,7 +1685,7 @@ async def test_should_send_alert_invalid_stored_data(
     # Mock Redis to return invalid JSON
     alert_service.redis_client.get = AsyncMock(return_value="invalid json")  # type: ignore[method-assign]
 
-    should_send, filtered = await alert_service._should_send_alert(
+    should_send, filtered, _stored_lines = await alert_service._should_send_alert(
         route=test_route_with_schedule,
         user_id=test_route_with_schedule.user_id,
         schedule=schedule,
@@ -2091,41 +2485,6 @@ async def test_get_redis_client() -> None:
 
 
 @pytest.mark.asyncio
-async def test_alert_service_skips_duplicate_alerts(
-    alert_service: AlertService,
-) -> None:
-    """Test that duplicate alerts are skipped (lines 137-142)."""
-    # Test the logic by mocking should_send_alert to return False
-    mock_route = Mock(spec=UserRoute)
-    mock_route.id = "test-route"
-    mock_route.name = "Test Route"
-
-    mock_disruptions = [
-        DisruptionResponse(
-            line_id="victoria",
-            line_name="Victoria",
-            mode="tube",
-            status_severity=5,
-            status_severity_description="Severe Delays",
-            reason="Signal failure",
-            created_at=datetime.now(UTC),
-        ),
-    ]
-
-    with (
-        patch.object(alert_service, "_should_send_alert", return_value=(False, [])),
-        patch.object(alert_service, "_get_verified_contact", return_value=None),
-    ):
-        alerts_sent = await alert_service._send_alerts_for_route(
-            route=mock_route,
-            schedule=Mock(),
-            disruptions=mock_disruptions,
-        )
-        # When all alerts are skipped, no alerts sent
-        assert alerts_sent == 0
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("scenario", "mock_config", "expected_result"),
     [
@@ -2341,41 +2700,6 @@ async def test_get_active_schedule_exception_handling(
 
 
 @pytest.mark.asyncio
-@patch("app.services.alert_service.NotificationService")
-async def test_send_alerts_for_route_no_preferences(
-    mock_notif_class: MagicMock,
-    alert_service: AlertService,
-) -> None:
-    """Test _send_alerts_for_route with no notification preferences (lines 594-599)."""
-    mock_route = Mock(spec=UserRoute)
-    mock_route.id = uuid4()
-    mock_route.name = "Test Route"
-    mock_route.notification_preferences = []  # No preferences
-
-    mock_schedule = Mock()
-    disruptions = [
-        DisruptionResponse(
-            line_id="victoria",
-            line_name="Victoria",
-            mode="tube",
-            status_severity=5,
-            status_severity_description="Severe Delays",
-            reason="Signal failure",
-            created_at=datetime.now(UTC),
-        )
-    ]
-
-    alerts_sent = await alert_service._send_alerts_for_route(
-        route=mock_route,
-        schedule=mock_schedule,
-        disruptions=disruptions,
-    )
-
-    # Should return 0 when no preferences
-    assert alerts_sent == 0
-
-
-@pytest.mark.asyncio
 @freeze_time("2025-01-13 09:00:00", tz_offset=0)
 @patch("app.services.alert_service.NotificationService")
 async def test_send_alerts_for_route_sms_notification(
@@ -2565,6 +2889,32 @@ async def test_send_alerts_for_route_handles_get_verified_contact_exception(
 
     # Notification service was not called
     mock_notif_instance.send_disruption_email.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_alerts_for_route_catastrophic_error_handling(
+    alert_service: AlertService,
+    test_route_with_schedule: UserRoute,
+    sample_disruptions: list[DisruptionResponse],
+    db_session: AsyncSession,
+) -> None:
+    """Test catastrophic error handling in _send_alerts_for_route (lines 1934-1949)."""
+    # Patch db.execute to raise exception when getting notification preferences
+    # This will trigger the outer exception handler
+    with patch.object(
+        db_session,
+        "execute",
+        side_effect=SQLAlchemyError("Catastrophic database error"),
+    ):
+        # Call the method - should catch exception and return 0
+        alerts_sent = await alert_service._send_alerts_for_route(
+            route=test_route_with_schedule,
+            schedule=test_route_with_schedule.schedules[0],
+            disruptions=sample_disruptions,
+        )
+
+    # Should return 0 on catastrophic error
+    assert alerts_sent == 0
 
 
 # ==================== Phase 3: Inverted Index Matching Tests ====================
@@ -3592,6 +3942,25 @@ class TestLineDisruptionStateLogging:
         # Should raise ValueError
         with pytest.raises(ValueError, match="All disruptions must have the same line_id"):
             create_line_aggregate_hash(disruptions_mixed)
+
+    async def test_log_line_disruption_state_changes_empty_list(
+        self,
+        db_session: AsyncSession,
+        mock_redis: AsyncMock,
+    ):
+        """Test that _log_line_disruption_state_changes returns 0 for empty disruptions list."""
+        alert_service = AlertService(db=db_session, redis_client=mock_redis)
+
+        # Call with empty list
+        logged_count = await alert_service._log_line_disruption_state_changes([])
+
+        # Should return 0 immediately without logging anything
+        assert logged_count == 0
+
+        # Verify no database entries created
+        result = await db_session.execute(select(LineDisruptionStateLog))
+        logs = result.scalars().all()
+        assert len(logs) == 0
 
     async def test_log_line_disruption_state_changes_first_state(
         self,
@@ -4725,6 +5094,43 @@ class TestPerLineCooldown:
 
         assert result is True  # Should alert immediately due to invalid format
 
+    def test_check_line_alert_needed_invalid_last_sent_at_type(
+        self, db_session: AsyncSession, stateful_mock_redis: AsyncMock
+    ):
+        """Test that invalid last_sent_at type (not string) triggers immediate alert (lines 2148-2154)."""
+        service = AlertService(db=db_session, redis_client=stateful_mock_redis)
+
+        disruptions = [
+            DisruptionResponse(
+                line_id="victoria",
+                line_name="Victoria",
+                mode="tube",
+                status_severity=4,
+                status_severity_description="Severe Delays",
+                reason="Signal failure",
+            ),
+        ]
+
+        # Stored state with wrong type for last_sent_at (int instead of string)
+        stored_line = {
+            "full_hash": "some_hash",
+            "status_hash": "some_status_hash",
+            "severity": 4,
+            "status": "Severe Delays",
+            "last_sent_at": 123456789,  # Wrong type - should be string
+        }
+
+        result = service._check_line_alert_needed(
+            line_id="victoria",
+            line_disruptions=disruptions,
+            stored_line=stored_line,
+            now_utc=datetime.now(UTC),
+            cooldown=timedelta(minutes=5),
+            route_id="test-route",
+        )
+
+        assert result is True  # Should alert immediately due to invalid type
+
     def test_check_line_alert_needed_missing_required_fields(
         self, db_session: AsyncSession, stateful_mock_redis: AsyncMock
     ):
@@ -4820,7 +5226,7 @@ class TestPerLineCooldown:
         ]
 
         with patch("app.services.alert_service.settings.ALERT_COOLDOWN_MINUTES", 5):
-            should_send, filtered = await service._should_send_alert(
+            should_send, filtered, _stored_lines = await service._should_send_alert(
                 route=test_route_with_schedule,
                 user_id=test_route_with_schedule.user_id,
                 schedule=test_route_with_schedule.schedules[0],
@@ -4860,7 +5266,7 @@ class TestPerLineCooldown:
             ),
         ]
 
-        should_send, filtered = await service._should_send_alert(
+        should_send, filtered, _stored_lines = await service._should_send_alert(
             route=test_route_with_schedule,
             user_id=test_route_with_schedule.user_id,
             schedule=test_route_with_schedule.schedules[0],
@@ -5018,3 +5424,708 @@ class TestPerLineCooldown:
         # Piccadilly should be unchanged (preserved from existing state)
         assert stored_data["lines"]["piccadilly"]["full_hash"] == "piccadilly_hash"
         assert stored_data["lines"]["piccadilly"]["severity"] == 6
+
+
+# ==================== Cleared Line Notification Tests ====================
+
+
+@pytest.fixture
+def sample_cleared_lines() -> list[ClearedLineInfo]:
+    """Sample cleared lines for testing status updates."""
+    return [
+        ClearedLineInfo(
+            line_id="victoria",
+            line_name="Victoria",
+            mode="tube",
+            previous_severity=5,
+            previous_status="Severe Delays",
+            current_severity=10,
+            current_status="Good Service",
+        ),
+    ]
+
+
+class TestSendSingleStatusUpdate:
+    """Tests for _send_single_status_update method."""
+
+    @pytest.mark.asyncio
+    @patch("app.services.alert_service.NotificationService")
+    async def test_send_email_status_update_success(
+        self,
+        mock_notif_class: MagicMock,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+        sample_cleared_lines: list[ClearedLineInfo],
+        sample_disruptions: list[DisruptionResponse],
+        db_session: AsyncSession,
+    ) -> None:
+        """Test successful email status update notification."""
+        # Mock notification service
+        mock_notif_instance = AsyncMock()
+        mock_notif_instance.send_status_update_email = AsyncMock()
+        mock_notif_class.return_value = mock_notif_instance
+
+        # Get email preference
+        email_result = await db_session.execute(
+            select(EmailAddress).where(EmailAddress.user_id == test_route_with_schedule.user_id)
+        )
+        email = email_result.scalar_one()
+
+        notification_pref = NotificationPreference(
+            route_id=test_route_with_schedule.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=email.id,
+        )
+
+        success, error = await alert_service._send_single_status_update(
+            pref=notification_pref,
+            contact_info=email.email,
+            route=test_route_with_schedule,
+            cleared_lines=sample_cleared_lines,
+            still_disrupted=sample_disruptions,
+        )
+
+        assert success is True
+        assert error is None
+        mock_notif_instance.send_status_update_email.assert_called_once_with(
+            email=email.email,
+            route_name=test_route_with_schedule.name,
+            cleared_lines=sample_cleared_lines,
+            still_disrupted=sample_disruptions,
+            user_name="test@example.com",  # Email from test_user_with_contacts fixture
+        )
+
+    @pytest.mark.asyncio
+    @patch("app.services.alert_service.NotificationService")
+    async def test_send_sms_status_update_success(
+        self,
+        mock_notif_class: MagicMock,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+        sample_cleared_lines: list[ClearedLineInfo],
+        sample_disruptions: list[DisruptionResponse],
+        db_session: AsyncSession,
+    ) -> None:
+        """Test successful SMS status update notification."""
+        # Mock notification service
+        mock_notif_instance = AsyncMock()
+        mock_notif_instance.send_status_update_sms = AsyncMock()
+        mock_notif_class.return_value = mock_notif_instance
+
+        # Get phone preference
+        phone_result = await db_session.execute(
+            select(PhoneNumber).where(PhoneNumber.user_id == test_route_with_schedule.user_id)
+        )
+        phone = phone_result.scalar_one()
+
+        notification_pref = NotificationPreference(
+            route_id=test_route_with_schedule.id,
+            method=NotificationMethod.SMS,
+            target_phone_id=phone.id,
+        )
+
+        success, error = await alert_service._send_single_status_update(
+            pref=notification_pref,
+            contact_info=phone.phone,
+            route=test_route_with_schedule,
+            cleared_lines=sample_cleared_lines,
+            still_disrupted=sample_disruptions,
+        )
+
+        assert success is True
+        assert error is None
+        mock_notif_instance.send_status_update_sms.assert_called_once_with(
+            phone=phone.phone,
+            route_name=test_route_with_schedule.name,
+            cleared_lines=sample_cleared_lines,
+            still_disrupted=sample_disruptions,
+        )
+
+    @pytest.mark.asyncio
+    @patch("app.services.alert_service.NotificationService")
+    async def test_send_status_update_email_error(
+        self,
+        mock_notif_class: MagicMock,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+        sample_cleared_lines: list[ClearedLineInfo],
+        sample_disruptions: list[DisruptionResponse],
+        db_session: AsyncSession,
+    ) -> None:
+        """Test email status update error handling."""
+        # Mock notification service to raise error
+        mock_notif_instance = AsyncMock()
+        mock_notif_instance.send_status_update_email = AsyncMock(side_effect=Exception("SMTP error"))
+        mock_notif_class.return_value = mock_notif_instance
+
+        # Get email preference
+        email_result = await db_session.execute(
+            select(EmailAddress).where(EmailAddress.user_id == test_route_with_schedule.user_id)
+        )
+        email = email_result.scalar_one()
+
+        notification_pref = NotificationPreference(
+            route_id=test_route_with_schedule.id,
+            method=NotificationMethod.EMAIL,
+            target_email_id=email.id,
+        )
+
+        success, error = await alert_service._send_single_status_update(
+            pref=notification_pref,
+            contact_info=email.email,
+            route=test_route_with_schedule,
+            cleared_lines=sample_cleared_lines,
+            still_disrupted=sample_disruptions,
+        )
+
+        assert success is False
+        assert error == "SMTP error"
+
+    @pytest.mark.asyncio
+    @patch("app.services.alert_service.NotificationService")
+    async def test_send_status_update_sms_error(
+        self,
+        mock_notif_class: MagicMock,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+        sample_cleared_lines: list[ClearedLineInfo],
+        sample_disruptions: list[DisruptionResponse],
+        db_session: AsyncSession,
+    ) -> None:
+        """Test SMS status update error handling."""
+        # Mock notification service to raise error
+        mock_notif_instance = AsyncMock()
+        mock_notif_instance.send_status_update_sms = AsyncMock(side_effect=Exception("Twilio error"))
+        mock_notif_class.return_value = mock_notif_instance
+
+        # Get phone preference
+        phone_result = await db_session.execute(
+            select(PhoneNumber).where(PhoneNumber.user_id == test_route_with_schedule.user_id)
+        )
+        phone = phone_result.scalar_one()
+
+        notification_pref = NotificationPreference(
+            route_id=test_route_with_schedule.id,
+            method=NotificationMethod.SMS,
+            target_phone_id=phone.id,
+        )
+
+        success, error = await alert_service._send_single_status_update(
+            pref=notification_pref,
+            contact_info=phone.phone,
+            route=test_route_with_schedule,
+            cleared_lines=sample_cleared_lines,
+            still_disrupted=sample_disruptions,
+        )
+
+        assert success is False
+        assert error == "Twilio error"
+
+
+class TestSendStatusUpdateNotifications:
+    """Tests for _send_status_update_notifications method."""
+
+    @pytest.mark.asyncio
+    @patch("app.services.alert_service.NotificationService")
+    async def test_send_status_update_notifications_success(
+        self,
+        mock_notif_class: MagicMock,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+        sample_cleared_lines: list[ClearedLineInfo],
+        sample_disruptions: list[DisruptionResponse],
+        db_session: AsyncSession,
+    ) -> None:
+        """Test successful status update notifications."""
+        # Mock notification service
+        mock_notif_instance = AsyncMock()
+        mock_notif_instance.send_status_update_email = AsyncMock()
+        mock_notif_class.return_value = mock_notif_instance
+
+        schedule = test_route_with_schedule.schedules[0]
+
+        # Call method
+        await alert_service._send_status_update_notifications(
+            route=test_route_with_schedule,
+            schedule=schedule,
+            cleared_lines=sample_cleared_lines,
+            still_disrupted=sample_disruptions,
+        )
+
+        # Verify notification was sent
+        mock_notif_instance.send_status_update_email.assert_called_once()
+
+        # Verify notification log was created
+        result = await db_session.execute(
+            select(NotificationLog).where(NotificationLog.route_id == test_route_with_schedule.id)
+        )
+        logs = result.scalars().all()
+        assert len(logs) == 1
+        assert logs[0].status == NotificationStatus.SENT
+
+    @pytest.mark.asyncio
+    @patch("app.services.alert_service.NotificationService")
+    async def test_send_status_update_updates_redis_state(
+        self,
+        mock_notif_class: MagicMock,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+        sample_cleared_lines: list[ClearedLineInfo],
+        sample_disruptions: list[DisruptionResponse],
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that status update notifications remove cleared lines from Redis state."""
+        # Mock notification service
+        mock_notif_instance = AsyncMock()
+        mock_notif_instance.send_status_update_email = AsyncMock()
+        mock_notif_class.return_value = mock_notif_instance
+
+        # Mock Redis to verify state updates
+        mock_redis = alert_service.redis_client
+        mock_redis.get = AsyncMock(
+            return_value=json.dumps(
+                {
+                    "version": ALERT_STATE_VERSION,
+                    "lines": {
+                        "victoria": {
+                            "full_hash": "test_hash",
+                            "severity": 5,
+                            "status": "Severe Delays",
+                        }
+                    },
+                }
+            )
+        )
+        mock_redis.setex = AsyncMock()
+        mock_redis.delete = AsyncMock()
+
+        schedule = test_route_with_schedule.schedules[0]
+
+        # Call method
+        await alert_service._send_status_update_notifications(
+            route=test_route_with_schedule,
+            schedule=schedule,
+            cleared_lines=sample_cleared_lines,
+            still_disrupted=sample_disruptions,
+        )
+
+        # Verify Redis was updated (either setex for partial update or delete for full clear)
+        assert mock_redis.setex.called or mock_redis.delete.called
+
+    @pytest.mark.asyncio
+    async def test_send_status_update_no_preferences(
+        self,
+        alert_service: AlertService,
+        db_session: AsyncSession,
+        test_user_with_contacts: User,
+        test_line: Line,
+        test_station: Station,
+        sample_cleared_lines: list[ClearedLineInfo],
+        sample_disruptions: list[DisruptionResponse],
+    ) -> None:
+        """Test that no notifications are sent when route has no preferences."""
+        # Create route without notification preferences
+        route = UserRoute(
+            user_id=test_user_with_contacts.id,
+            name="No Prefs Route",
+            active=True,
+            timezone="Europe/London",
+        )
+        db_session.add(route)
+        await db_session.flush()
+
+        segment = UserRouteSegment(
+            route_id=route.id,
+            sequence=0,
+            station_id=test_station.id,
+            line_id=test_line.id,
+        )
+        db_session.add(segment)
+
+        schedule = UserRouteSchedule(
+            route_id=route.id,
+            days_of_week=["MON", "TUE", "WED", "THU", "FRI"],
+            start_time=time_class(8, 0),
+            end_time=time_class(10, 0),
+        )
+        db_session.add(schedule)
+        await db_session.commit()
+        await db_session.refresh(route)
+
+        # Call method - should complete without errors
+        await alert_service._send_status_update_notifications(
+            route=route,
+            schedule=schedule,
+            cleared_lines=sample_cleared_lines,
+            still_disrupted=sample_disruptions,
+        )
+
+        # Verify no notification logs were created
+        result = await db_session.execute(select(NotificationLog).where(NotificationLog.route_id == route.id))
+        logs = result.scalars().all()
+        assert len(logs) == 0
+
+    @pytest.mark.asyncio
+    async def test_send_status_update_notifications_handles_exception(
+        self,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+        sample_cleared_lines: list[ClearedLineInfo],
+        sample_disruptions: list[DisruptionResponse],
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that exceptions in _send_status_update_notifications are handled gracefully."""
+        schedule = test_route_with_schedule.schedules[0]
+
+        # Mock database commit to raise an error
+        with patch.object(db_session, "commit", side_effect=SQLAlchemyError("Database error")):
+            # Call method - should handle exception and return 0
+            result = await alert_service._send_status_update_notifications(
+                route=test_route_with_schedule,
+                schedule=schedule,
+                cleared_lines=sample_cleared_lines,
+                still_disrupted=sample_disruptions,
+            )
+
+            # Should return 0 on error
+            assert result == 0
+
+    @pytest.mark.asyncio
+    @patch("app.services.alert_service.NotificationService")
+    async def test_send_status_update_creates_failed_log_on_error(
+        self,
+        mock_notif_class: MagicMock,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+        sample_cleared_lines: list[ClearedLineInfo],
+        sample_disruptions: list[DisruptionResponse],
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that FAILED notification log is created when status update sending fails."""
+        # Mock notification service to raise error
+        mock_notif_instance = AsyncMock()
+        mock_notif_instance.send_status_update_email = AsyncMock(side_effect=Exception("SMTP error"))
+        mock_notif_class.return_value = mock_notif_instance
+
+        schedule = test_route_with_schedule.schedules[0]
+
+        # Call method
+        result = await alert_service._send_status_update_notifications(
+            route=test_route_with_schedule,
+            schedule=schedule,
+            cleared_lines=sample_cleared_lines,
+            still_disrupted=sample_disruptions,
+        )
+
+        # Should return 0 (no successful updates)
+        assert result == 0
+
+        # Verify FAILED notification log was created
+        log_result = await db_session.execute(
+            select(NotificationLog).where(NotificationLog.route_id == test_route_with_schedule.id)
+        )
+        logs = log_result.scalars().all()
+        assert len(logs) == 1
+        assert logs[0].status == NotificationStatus.FAILED
+        assert logs[0].error_message is not None
+        assert "SMTP error" in logs[0].error_message
+
+    @pytest.mark.asyncio
+    @patch("app.services.alert_service.NotificationService")
+    async def test_all_lines_cleared_sends_status_update(
+        self,
+        mock_notif_class: MagicMock,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that status updates are sent when all lines return to Good Service.
+
+        Verifies the fix for comment PRRT_kwDOQNO0Es5lONzI:
+        When all lines return to normal service (disruptions list becomes empty
+        but all_route_disruptions contains Good Service entries), status update
+        notifications should still be sent.
+        """
+        # Mock notification service
+        mock_notif_instance = AsyncMock()
+        mock_notif_instance.send_status_update_email = AsyncMock()
+        mock_notif_class.return_value = mock_notif_instance
+
+        mock_schedule = MagicMock(spec=UserRouteSchedule)
+        mock_schedule.id = uuid4()
+
+        # Create Good Service disruption (severity 10)
+        good_service_disruption = DisruptionResponse(
+            line_id="victoria",
+            line_name="Victoria",
+            mode="tube",
+            status_severity=10,
+            status_severity_description="Good Service",
+        )
+
+        # Mock Redis state showing previous severe disruption
+        stored_lines = {
+            "victoria": {
+                "severity": 6,
+                "status": "Severe Delays",
+                "full_hash": "old_hash",
+                "last_sent_at": "2024-01-01T10:00:00Z",
+            }
+        }
+
+        with (
+            patch.object(alert_service, "_get_active_schedule", new_callable=AsyncMock, return_value=mock_schedule),
+            patch.object(
+                alert_service,
+                "_get_route_disruptions",
+                new_callable=AsyncMock,
+                # disruptions is empty (Good Service is filtered), but all_route_disruptions contains it
+                return_value=([], [good_service_disruption], False),
+            ),
+            patch.object(
+                alert_service,
+                "_should_send_alert",
+                new_callable=AsyncMock,
+                return_value=(False, [], stored_lines),  # Returns stored lines
+            ),
+            patch.object(
+                alert_service, "_send_status_update_notifications", new_callable=AsyncMock, return_value=1
+            ) as mock_send_status,
+            patch.object(alert_service, "_send_alerts_for_route", new_callable=AsyncMock, return_value=0),
+        ):
+            alerts_sent, error_occurred = await alert_service._process_single_route(
+                route=test_route_with_schedule,
+                schedules=[],
+                disabled_severity_pairs=set(),
+                cleared_states={("tube", 10)},  # Severity 10 (Good Service) is a cleared state
+            )
+
+        # Verify status update notifications were called with cleared lines
+        assert mock_send_status.called
+        call_args = mock_send_status.call_args
+        assert len(call_args.kwargs["cleared_lines"]) == 1
+        assert call_args.kwargs["cleared_lines"][0].line_id == "victoria"
+        assert call_args.kwargs["cleared_lines"][0].current_severity == 10
+        assert call_args.kwargs["cleared_lines"][0].previous_severity == 6
+
+        # Verify no new disruption alerts were sent (since disruptions list is empty)
+        assert alerts_sent == 0
+        assert error_occurred is False
+
+
+class TestUpdateAlertStateRemoveCleared:
+    """Tests for _update_alert_state_remove_cleared method."""
+
+    @pytest.mark.asyncio
+    @freeze_time("2025-01-15 09:00:00", tz_offset=0)
+    async def test_remove_cleared_lines_from_state(
+        self,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+    ) -> None:
+        """Test removing cleared lines from Redis state."""
+        schedule = test_route_with_schedule.schedules[0]
+        mock_redis = alert_service.redis_client
+
+        # Setup existing state with multiple lines
+        existing_state = {
+            "version": ALERT_STATE_VERSION,
+            "lines": {
+                "victoria": {
+                    "full_hash": "victoria_hash",
+                    "severity": 5,
+                    "status": "Severe Delays",
+                },
+                "piccadilly": {
+                    "full_hash": "piccadilly_hash",
+                    "severity": 6,
+                    "status": "Minor Delays",
+                },
+            },
+        }
+        mock_redis.get = AsyncMock(return_value=json.dumps(existing_state))
+        mock_redis.setex = AsyncMock()
+
+        # Remove victoria from state
+        await alert_service._update_alert_state_remove_cleared(
+            route=test_route_with_schedule,
+            user_id=test_route_with_schedule.user_id,
+            schedule=schedule,
+            cleared_line_ids=["victoria"],
+        )
+
+        # Verify setex was called
+        assert mock_redis.setex.called
+        call_args = mock_redis.setex.call_args[0]
+        _key, _ttl, value = call_args
+        updated_state = json.loads(value)
+
+        # Verify victoria was removed
+        assert "victoria" not in updated_state["lines"]
+        # Verify piccadilly was preserved
+        assert "piccadilly" in updated_state["lines"]
+        assert updated_state["lines"]["piccadilly"]["full_hash"] == "piccadilly_hash"
+
+    @pytest.mark.asyncio
+    @freeze_time("2025-01-15 09:00:00", tz_offset=0)
+    async def test_delete_state_when_all_lines_cleared(
+        self,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+    ) -> None:
+        """Test deleting Redis key when all lines are cleared."""
+        schedule = test_route_with_schedule.schedules[0]
+        mock_redis = alert_service.redis_client
+
+        # Setup existing state with one line
+        existing_state = {
+            "version": ALERT_STATE_VERSION,
+            "lines": {
+                "victoria": {
+                    "full_hash": "victoria_hash",
+                    "severity": 5,
+                    "status": "Severe Delays",
+                }
+            },
+        }
+        mock_redis.get = AsyncMock(return_value=json.dumps(existing_state))
+        mock_redis.delete = AsyncMock()
+
+        # Remove the only line from state
+        await alert_service._update_alert_state_remove_cleared(
+            route=test_route_with_schedule,
+            user_id=test_route_with_schedule.user_id,
+            schedule=schedule,
+            cleared_line_ids=["victoria"],
+        )
+
+        # Verify delete was called instead of setex
+        assert mock_redis.delete.called
+
+    @pytest.mark.asyncio
+    async def test_handle_missing_redis_state(
+        self,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+    ) -> None:
+        """Test handling when Redis state doesn't exist."""
+        schedule = test_route_with_schedule.schedules[0]
+        mock_redis = alert_service.redis_client
+
+        # No existing state
+        mock_redis.get = AsyncMock(return_value=None)
+        mock_redis.setex = AsyncMock()
+
+        # Call method - should complete without errors
+        await alert_service._update_alert_state_remove_cleared(
+            route=test_route_with_schedule,
+            user_id=test_route_with_schedule.user_id,
+            schedule=schedule,
+            cleared_line_ids=["victoria"],
+        )
+
+        # Verify no setex was called (nothing to update)
+        assert not mock_redis.setex.called
+
+    @pytest.mark.asyncio
+    @freeze_time("2025-01-15 09:00:00", tz_offset=0)
+    async def test_handle_cleared_line_not_in_state(
+        self,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+    ) -> None:
+        """Test handling when cleared line is not in Redis state."""
+        schedule = test_route_with_schedule.schedules[0]
+        mock_redis = alert_service.redis_client
+
+        # Setup existing state without the cleared line
+        existing_state = {
+            "version": ALERT_STATE_VERSION,
+            "lines": {
+                "piccadilly": {
+                    "full_hash": "piccadilly_hash",
+                    "severity": 6,
+                    "status": "Minor Delays",
+                }
+            },
+        }
+        mock_redis.get = AsyncMock(return_value=json.dumps(existing_state))
+        mock_redis.setex = AsyncMock()
+        mock_redis.delete = AsyncMock()
+
+        # Try to remove victoria (not in state)
+        await alert_service._update_alert_state_remove_cleared(
+            route=test_route_with_schedule,
+            user_id=test_route_with_schedule.user_id,
+            schedule=schedule,
+            cleared_line_ids=["victoria"],
+        )
+
+        # Verify setex was still called (to update TTL)
+        assert mock_redis.setex.called
+        call_args = mock_redis.setex.call_args[0]
+        _key, _ttl, value = call_args
+        updated_state = json.loads(value)
+
+        # Verify piccadilly is still present
+        assert "piccadilly" in updated_state["lines"]
+
+    @pytest.mark.asyncio
+    async def test_handle_incompatible_state_version(
+        self,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+    ) -> None:
+        """Test handling when Redis state has incompatible version."""
+        schedule = test_route_with_schedule.schedules[0]
+        mock_redis = alert_service.redis_client
+
+        # Setup existing state with wrong version
+        existing_state = {
+            "version": "1.0.0",  # Incompatible version
+            "lines": {
+                "victoria": {
+                    "full_hash": "victoria_hash",
+                    "severity": 5,
+                    "status": "Severe Delays",
+                }
+            },
+        }
+        mock_redis.get = AsyncMock(return_value=json.dumps(existing_state))
+        mock_redis.setex = AsyncMock()
+
+        # Try to remove cleared line - should complete without errors
+        await alert_service._update_alert_state_remove_cleared(
+            route=test_route_with_schedule,
+            user_id=test_route_with_schedule.user_id,
+            schedule=schedule,
+            cleared_line_ids=["victoria"],
+        )
+
+        # Verify setex was NOT called (incompatible version, early return)
+        assert not mock_redis.setex.called
+
+    @pytest.mark.asyncio
+    async def test_handle_json_decode_error(
+        self,
+        alert_service: AlertService,
+        test_route_with_schedule: UserRoute,
+    ) -> None:
+        """Test handling when Redis state contains invalid JSON."""
+        schedule = test_route_with_schedule.schedules[0]
+        mock_redis = alert_service.redis_client
+
+        # Setup existing state with invalid JSON
+        mock_redis.get = AsyncMock(return_value="{ invalid json")
+        mock_redis.setex = AsyncMock()
+
+        # Try to remove cleared line - should complete without errors
+        await alert_service._update_alert_state_remove_cleared(
+            route=test_route_with_schedule,
+            user_id=test_route_with_schedule.user_id,
+            schedule=schedule,
+            cleared_line_ids=["victoria"],
+        )
+
+        # Verify setex was NOT called (JSON decode error, early return)
+        assert not mock_redis.setex.called

--- a/backend/tests/test_celery_metadata_and_graph_tasks.py
+++ b/backend/tests/test_celery_metadata_and_graph_tasks.py
@@ -7,17 +7,10 @@ import pytest
 from app.celery.tasks import (
     _rebuild_graph_async,
     _refresh_metadata_async,
-    rebuild_network_graph_task,
-    refresh_tfl_metadata_task,
 )
 from app.services.tfl_service import MetadataChangeDetectedError
 
 # ==================== refresh_tfl_metadata_task Tests ====================
-
-
-def test_refresh_metadata_task_registered() -> None:
-    """Test that task function exists."""
-    assert refresh_tfl_metadata_task is not None
 
 
 @pytest.mark.asyncio
@@ -135,11 +128,6 @@ async def test_refresh_metadata_async_ensures_session_cleanup(
 
 
 # ==================== rebuild_network_graph_task Tests ====================
-
-
-def test_rebuild_graph_task_registered() -> None:
-    """Test that task function exists."""
-    assert rebuild_network_graph_task is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_celery_tasks.py
+++ b/backend/tests/test_celery_tasks.py
@@ -17,12 +17,6 @@ from app.celery.tasks import (
 # ==================== check_disruptions_and_alert Tests ====================
 
 
-def test_check_disruptions_task_registered() -> None:
-    """Test that task function exists."""
-    # This is a simple test to ensure the task exists
-    assert check_disruptions_and_alert is not None
-
-
 @pytest.mark.asyncio
 @patch("app.celery.tasks.AlertService")
 @patch("app.celery.tasks.get_worker_redis_client")
@@ -388,12 +382,6 @@ def test_check_disruptions_task_logs_on_error(mock_run_async_task: MagicMock) ->
 # ==================== rebuild_route_indexes_task Tests ====================
 
 
-def test_rebuild_indexes_task_registered() -> None:
-    """Test that rebuild_route_indexes_task function exists."""
-    # This is a simple test to ensure the task exists
-    assert rebuild_route_indexes_task is not None
-
-
 @pytest.mark.asyncio
 @patch("app.celery.tasks.UserRouteIndexService")
 @patch("app.celery.tasks.get_worker_session")
@@ -677,11 +665,6 @@ def test_rebuild_indexes_task_logs_on_error(mock_run_async_task: MagicMock) -> N
 
 
 # ==================== detect_and_rebuild_stale_routes Tests ====================
-
-
-def test_detect_stale_routes_task_registered() -> None:
-    """Test that detect_and_rebuild_stale_routes task function exists."""
-    assert detect_and_rebuild_stale_routes is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -11,26 +11,28 @@ from app.services.email_service import EmailService, get_tls_settings
 class TestGetTlsSettings:
     """Test cases for get_tls_settings pure function."""
 
-    def test_port_465_implicit_tls(self) -> None:
-        """Port 465 uses implicit TLS regardless of require_tls."""
-        assert get_tls_settings(465, False) == (True, None)
-        assert get_tls_settings(465, True) == (True, None)
-
-    def test_port_587_auto_upgrade(self) -> None:
-        """Port 587 with require_tls=False uses auto-upgrade."""
-        assert get_tls_settings(587, False) == (False, None)
-
-    def test_port_587_require_tls(self) -> None:
-        """Port 587 with require_tls=True forces STARTTLS."""
-        assert get_tls_settings(587, True) == (False, True)
-
-    def test_port_25_auto_upgrade(self) -> None:
-        """Port 25 with require_tls=False uses auto-upgrade."""
-        assert get_tls_settings(25, False) == (False, None)
-
-    def test_port_25_require_tls(self) -> None:
-        """Port 25 with require_tls=True forces STARTTLS."""
-        assert get_tls_settings(25, True) == (False, True)
+    @pytest.mark.parametrize(
+        ("port", "require_tls", "expected"),
+        [
+            # Port 465 uses implicit TLS regardless of require_tls
+            (465, False, (True, None)),
+            (465, True, (True, None)),
+            # Port 587 with require_tls=False uses auto-upgrade
+            (587, False, (False, None)),
+            # Port 587 with require_tls=True forces STARTTLS
+            (587, True, (False, True)),
+            # Port 25 with require_tls=False uses auto-upgrade
+            (25, False, (False, None)),
+            # Port 25 with require_tls=True forces STARTTLS
+            (25, True, (False, True)),
+            # Non-standard port 2525 behaves like port 25 (fallback behavior)
+            (2525, False, (False, None)),
+            (2525, True, (False, True)),
+        ],
+    )
+    def test_get_tls_settings(self, port: int, require_tls: bool, expected: tuple[bool, bool | None]) -> None:
+        """Test get_tls_settings with various port and TLS configurations."""
+        assert get_tls_settings(port, require_tls) == expected
 
 
 class TestEmailService:

--- a/backend/tests/test_notification_service.py
+++ b/backend/tests/test_notification_service.py
@@ -8,7 +8,11 @@ from urllib.parse import urlparse
 
 import pytest
 from app.schemas.tfl import ClearedLineInfo, DisruptionResponse
-from app.services.notification_service import NotificationService
+from app.services.notification_service import (
+    NotificationService,
+    _build_disruption_subject,
+    _build_status_update_subject,
+)
 
 
 class TestNotificationService:
@@ -38,7 +42,7 @@ class TestNotificationService:
         mock_send_email.assert_called_once()
         call_args = mock_send_email.call_args
         assert call_args[0][0] == email
-        assert "Disruption Alert" in call_args[0][1]
+        assert call_args[0][1] == f"⚠️ {route_name}: Victoria disrupted"
 
     @pytest.mark.asyncio
     @patch("app.services.email_service.EmailService.send_email", new_callable=AsyncMock)
@@ -64,7 +68,7 @@ class TestNotificationService:
         mock_send_email.assert_called_once()
         call_args = mock_send_email.call_args
         assert call_args[0][0] == email
-        assert call_args[0][1] == f"⚠️ Disruption Alert: {route_name}"
+        assert call_args[0][1] == f"⚠️ {route_name}: Victoria disrupted"
 
     @pytest.mark.asyncio
     @patch("app.services.email_service.EmailService.send_email", new_callable=AsyncMock)
@@ -241,7 +245,7 @@ class TestNotificationService:
 
     @pytest.mark.asyncio
     async def test_render_email_template_without_user_name(self) -> None:
-        """Test template rendering defaults to 'there' when no user name."""
+        """Test template rendering works without user name (greeting removed)."""
         service = NotificationService()
         disruptions = [
             DisruptionResponse(
@@ -263,8 +267,15 @@ class TestNotificationService:
             },
         )
 
-        # Verify "there" appears as default greeting
-        assert "Hello there" in html or "there" in html.lower()
+        # Verify template renders correctly without greeting
+        assert "Test Route" in html
+        assert "Victoria" in html
+
+        # Verify old greeting text is no longer rendered
+        assert "Hello there" not in html
+        assert "Hello" not in html
+        assert "hello there" not in html.lower()
+        assert "hello" not in html.lower()
 
     @pytest.mark.asyncio
     async def test_send_disruption_sms_long_message(self) -> None:
@@ -492,7 +503,7 @@ class TestNotificationService:
         mock_send_email.assert_called_once()
         call_args = mock_send_email.call_args
         assert call_args[0][0] == email
-        assert "Service Restored" in call_args[0][1]
+        assert call_args[0][1] == f"✅ {route_name}: Victoria restored | Northern still disrupted"
 
     @pytest.mark.asyncio
     @patch("app.services.email_service.EmailService.send_email", new_callable=AsyncMock)
@@ -520,7 +531,7 @@ class TestNotificationService:
         mock_send_email.assert_called_once()
         call_args = mock_send_email.call_args
         assert call_args[0][0] == email
-        assert call_args[0][1] == f"✅ Service Restored: {route_name}"
+        assert call_args[0][1] == f"✅ {route_name}: Victoria restored"
 
     @pytest.mark.asyncio
     @patch("app.services.email_service.EmailService.send_email", new_callable=AsyncMock)
@@ -910,3 +921,153 @@ class TestNotificationService:
                 cleared_lines=cleared_lines,
                 still_disrupted=still_disrupted,
             )
+
+    def test_build_disruption_subject_empty_list(self) -> None:
+        """Test subject line generation for empty disruption list raises error."""
+        disruptions = []
+
+        with pytest.raises(ValueError, match="No disruptions provided"):
+            _build_disruption_subject("Morning Commute", disruptions)
+
+    def test_build_disruption_subject_single_line(self) -> None:
+        """Test subject line generation for single disrupted line."""
+        disruptions = [
+            DisruptionResponse(
+                line_id="victoria",
+                line_name="Victoria",
+                mode="tube",
+                status_severity=6,
+                status_severity_description="Minor Delays",
+                reason="Signal failure",
+            )
+        ]
+
+        subject = _build_disruption_subject("Morning Commute", disruptions)
+        assert subject == "⚠️ Morning Commute: Victoria disrupted"
+
+    def test_build_disruption_subject_multiple_lines(self) -> None:
+        """Test subject line generation for multiple disrupted lines."""
+        disruptions = [
+            DisruptionResponse(
+                line_id="victoria",
+                line_name="Victoria",
+                mode="tube",
+                status_severity=6,
+                status_severity_description="Minor Delays",
+            ),
+            DisruptionResponse(
+                line_id="northern",
+                line_name="Northern",
+                mode="tube",
+                status_severity=3,
+                status_severity_description="Severe Delays",
+            ),
+            DisruptionResponse(
+                line_id="central",
+                line_name="Central",
+                mode="tube",
+                status_severity=6,
+                status_severity_description="Part Suspended",
+            ),
+        ]
+
+        subject = _build_disruption_subject("To Work", disruptions)
+        assert subject == "⚠️ To Work: Victoria, Northern, Central disrupted"
+
+    def test_build_status_update_subject_single_restored(self) -> None:
+        """Test subject line for single restored line with no remaining disruptions."""
+        cleared_lines = [
+            ClearedLineInfo(
+                line_id="victoria",
+                line_name="Victoria",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays",
+                current_severity=10,
+                current_status="Good Service",
+            )
+        ]
+        still_disrupted = []
+
+        subject = _build_status_update_subject("Morning Commute", cleared_lines, still_disrupted)
+        assert subject == "✅ Morning Commute: Victoria restored"
+
+    def test_build_status_update_subject_all_clear(self) -> None:
+        """Test subject line when multiple lines cleared and all clear."""
+        cleared_lines = [
+            ClearedLineInfo(
+                line_id="victoria",
+                line_name="Victoria",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays",
+                current_severity=10,
+                current_status="Good Service",
+            ),
+            ClearedLineInfo(
+                line_id="northern",
+                line_name="Northern",
+                mode="tube",
+                previous_severity=6,
+                previous_status="Minor Delays",
+                current_severity=10,
+                current_status="Good Service",
+            ),
+        ]
+        still_disrupted = []
+
+        subject = _build_status_update_subject("Morning Commute", cleared_lines, still_disrupted)
+        assert subject == "✅ Morning Commute: All clear"
+
+    def test_build_status_update_subject_mixed(self) -> None:
+        """Test subject line when some lines cleared but others still disrupted."""
+        cleared_lines = [
+            ClearedLineInfo(
+                line_id="victoria",
+                line_name="Victoria",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays",
+                current_severity=10,
+                current_status="Good Service",
+            )
+        ]
+        still_disrupted = [
+            DisruptionResponse(
+                line_id="northern",
+                line_name="Northern",
+                mode="tube",
+                status_severity=6,
+                status_severity_description="Minor Delays",
+                reason="Signal failure",
+            )
+        ]
+
+        subject = _build_status_update_subject("To Work", cleared_lines, still_disrupted)
+        assert subject == "✅ To Work: Victoria restored | Northern still disrupted"
+
+    def test_build_status_update_subject_no_cleared_lines(self) -> None:
+        """Test subject line when no lines cleared but some still disrupted."""
+        cleared_lines = []
+        still_disrupted = [
+            DisruptionResponse(
+                line_id="northern",
+                line_name="Northern",
+                mode="tube",
+                status_severity=6,
+                status_severity_description="Part Suspended",
+            )
+        ]
+
+        subject = _build_status_update_subject("To Work", cleared_lines, still_disrupted)
+        assert subject == "⚠️ To Work: Northern still disrupted"
+        # Should not mention restoration when nothing was cleared
+        assert "restored" not in subject.lower()
+
+    def test_build_status_update_subject_both_empty(self) -> None:
+        """Test subject line generation for both lists empty raises error."""
+        cleared_lines = []
+        still_disrupted = []
+
+        with pytest.raises(ValueError, match="No lines provided"):
+            _build_status_update_subject("To Work", cleared_lines, still_disrupted)

--- a/backend/tests/test_notification_service.py
+++ b/backend/tests/test_notification_service.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 from urllib.parse import urlparse
 
 import pytest
-from app.schemas.tfl import DisruptionResponse
+from app.schemas.tfl import ClearedLineInfo, DisruptionResponse
 from app.services.notification_service import NotificationService
 
 
@@ -456,3 +456,457 @@ class TestNotificationService:
         # We have "TfL Alert: ", "LineName: Status", and "More: url" - so 3 colons total
         disruption_count = sent_message.count(": ") - 2  # -2 for "TfL Alert: " and "More: "
         assert disruption_count == 1, f"Expected 1 disruption after truncation, got {disruption_count}"
+
+    @pytest.mark.asyncio
+    @patch("app.services.email_service.EmailService.send_email", new_callable=AsyncMock)
+    async def test_send_status_update_email_success(self, mock_send_email: AsyncMock) -> None:
+        """Test successful status update email sending."""
+        service = NotificationService()
+        email = "test@example.com"
+        route_name = "Morning Commute"
+        cleared_lines = [
+            ClearedLineInfo(
+                line_id="victoria",
+                line_name="Victoria",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays",
+                current_severity=10,
+                current_status="Good Service",
+            )
+        ]
+        still_disrupted = [
+            DisruptionResponse(
+                line_id="northern",
+                line_name="Northern",
+                mode="tube",
+                status_severity=6,
+                status_severity_description="Minor Delays",
+                reason="Signal failure",
+            )
+        ]
+
+        await service.send_status_update_email(email, route_name, cleared_lines, still_disrupted)
+
+        # Verify EmailService.send_email was called
+        mock_send_email.assert_called_once()
+        call_args = mock_send_email.call_args
+        assert call_args[0][0] == email
+        assert "Service Restored" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    @patch("app.services.email_service.EmailService.send_email", new_callable=AsyncMock)
+    async def test_send_status_update_email_with_user_name(self, mock_send_email: AsyncMock) -> None:
+        """Test status update email with user name."""
+        service = NotificationService()
+        email = "test@example.com"
+        route_name = "Morning Commute"
+        cleared_lines = [
+            ClearedLineInfo(
+                line_id="victoria",
+                line_name="Victoria",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays",
+                current_severity=10,
+                current_status="Good Service",
+            )
+        ]
+        still_disrupted = []
+
+        await service.send_status_update_email(email, route_name, cleared_lines, still_disrupted, user_name="John")
+
+        # Verify EmailService.send_email was called
+        mock_send_email.assert_called_once()
+        call_args = mock_send_email.call_args
+        assert call_args[0][0] == email
+        assert call_args[0][1] == f"✅ Service Restored: {route_name}"
+
+    @pytest.mark.asyncio
+    @patch("app.services.email_service.EmailService.send_email", new_callable=AsyncMock)
+    async def test_send_status_update_email_multiple_cleared_lines(self, mock_send_email: AsyncMock) -> None:
+        """Test status update email with multiple cleared lines."""
+        service = NotificationService()
+        email = "test@example.com"
+        route_name = "Morning Commute"
+        cleared_lines = [
+            ClearedLineInfo(
+                line_id="victoria",
+                line_name="Victoria",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays",
+                current_severity=10,
+                current_status="Good Service",
+            ),
+            ClearedLineInfo(
+                line_id="northern",
+                line_name="Northern",
+                mode="tube",
+                previous_severity=6,
+                previous_status="Minor Delays",
+                current_severity=10,
+                current_status="Good Service",
+            ),
+        ]
+        still_disrupted = []
+
+        await service.send_status_update_email(email, route_name, cleared_lines, still_disrupted)
+
+        # Verify email was sent
+        mock_send_email.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_status_update_email_error_propagates(self) -> None:
+        """Test status update email error is propagated."""
+        service = NotificationService()
+        cleared_lines = [
+            ClearedLineInfo(
+                line_id="victoria",
+                line_name="Victoria",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays",
+                current_severity=10,
+                current_status="Good Service",
+            )
+        ]
+        still_disrupted = []
+
+        with (
+            patch.object(service.email_service, "send_email", side_effect=Exception("Email error")),
+            pytest.raises(Exception, match="Email error"),
+        ):
+            await service.send_status_update_email(
+                email="test@example.com",
+                route_name="Test",
+                cleared_lines=cleared_lines,
+                still_disrupted=still_disrupted,
+            )
+
+    @pytest.mark.asyncio
+    @patch("app.services.sms_service.SmsService.send_sms", new_callable=AsyncMock)
+    async def test_send_status_update_sms_success(self, mock_send_sms: AsyncMock) -> None:
+        """Test successful status update SMS sending."""
+        service = NotificationService()
+        phone = "+447700900123"
+        route_name = "Morning Commute"
+        cleared_lines = [
+            ClearedLineInfo(
+                line_id="victoria",
+                line_name="Victoria",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays",
+                current_severity=10,
+                current_status="Good Service",
+            )
+        ]
+        still_disrupted = [
+            DisruptionResponse(
+                line_id="northern",
+                line_name="Northern",
+                mode="tube",
+                status_severity=6,
+                status_severity_description="Minor Delays",
+                reason="Signal failure",
+                created_at=datetime.now(UTC),
+            )
+        ]
+
+        await service.send_status_update_sms(phone, route_name, cleared_lines, still_disrupted)
+
+        # Verify SmsService.send_sms was called
+        mock_send_sms.assert_called_once()
+        call_args = mock_send_sms.call_args
+        assert call_args[0][0] == phone
+        assert "Service restored" in call_args[0][1]
+        assert "Victoria" in call_args[0][1]
+
+    @pytest.mark.asyncio
+    @patch("app.services.sms_service.SmsService.send_sms", new_callable=AsyncMock)
+    async def test_send_status_update_sms_multiple_cleared_lines(self, mock_send_sms: AsyncMock) -> None:
+        """Test status update SMS with multiple cleared lines."""
+        service = NotificationService()
+        phone = "+447700900123"
+        route_name = "Test Route"
+        cleared_lines = [
+            ClearedLineInfo(
+                line_id="victoria",
+                line_name="Victoria",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays",
+                current_severity=10,
+                current_status="Good Service",
+            ),
+            ClearedLineInfo(
+                line_id="northern",
+                line_name="Northern",
+                mode="tube",
+                previous_severity=6,
+                previous_status="Minor Delays",
+                current_severity=10,
+                current_status="Good Service",
+            ),
+            ClearedLineInfo(
+                line_id="piccadilly",
+                line_name="Piccadilly",
+                mode="tube",
+                previous_severity=4,
+                previous_status="Part Suspended",
+                current_severity=10,
+                current_status="Good Service",
+            ),
+            ClearedLineInfo(
+                line_id="district",
+                line_name="District",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays",
+                current_severity=10,
+                current_status="Good Service",
+            ),
+        ]
+        still_disrupted = []
+
+        await service.send_status_update_sms(phone, route_name, cleared_lines, still_disrupted)
+
+        # Verify SMS was sent
+        mock_send_sms.assert_called_once()
+        call_args = mock_send_sms.call_args
+        sent_message = call_args[0][1]
+
+        # Should limit to first 3 cleared lines
+        assert "Victoria" in sent_message
+        assert "Northern" in sent_message
+        assert "Piccadilly" in sent_message
+        # Fourth line may or may not be included depending on length
+
+    @pytest.mark.asyncio
+    @patch("app.services.sms_service.SmsService.send_sms", new_callable=AsyncMock)
+    async def test_send_status_update_sms_truncates_long_message(self, mock_send_sms: AsyncMock) -> None:
+        """Test status update SMS truncation when message is too long."""
+        service = NotificationService()
+        phone = "+447700900123"
+        route_name = "My Very Long Route Name For Testing Purposes"
+        cleared_lines = [
+            ClearedLineInfo(
+                line_id="metropolitan",
+                line_name="Metropolitan Line Experiencing Issues",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays and Signal Failures",
+                current_severity=10,
+                current_status="Good Service",
+            )
+        ]
+        still_disrupted = [
+            DisruptionResponse(
+                line_id="hammersmith-city",
+                line_name="Hammersmith & City Line Now",
+                mode="tube",
+                status_severity=10,
+                status_severity_description="Part Suspended Between Multiple Stations",
+                reason="Engineering works",
+                created_at=datetime.now(UTC),
+            ),
+            DisruptionResponse(
+                line_id="circle",
+                line_name="Circle Line With Additional Information",
+                mode="tube",
+                status_severity=6,
+                status_severity_description="Minor Delays Throughout The Line",
+                reason="Signal failure",
+                created_at=datetime.now(UTC),
+            ),
+        ]
+
+        await service.send_status_update_sms(phone, route_name, cleared_lines, still_disrupted)
+
+        # Verify SMS was sent
+        mock_send_sms.assert_called_once()
+        call_args = mock_send_sms.call_args
+        sent_message = call_args[0][1]
+
+        # Verify message was truncated (still_disrupted part removed)
+        assert "Service restored" in sent_message
+        assert "Metropolitan" in sent_message or "Metropolitan Line" in sent_message
+        # Still disrupted section should be removed if message is too long
+        assert len(sent_message) <= 160
+
+    @pytest.mark.asyncio
+    @patch("app.services.sms_service.SmsService.send_sms", new_callable=AsyncMock)
+    async def test_send_status_update_sms_multistage_truncation_3_to_2_lines(self, mock_send_sms: AsyncMock) -> None:
+        """Test SMS truncation reduces from 3 cleared lines to 2 when needed."""
+        service = NotificationService()
+        phone = "+447700900123"
+        route_name = "Very Long Route Name That Takes Up Space"
+        cleared_lines = [
+            ClearedLineInfo(
+                line_id="metropolitan",
+                line_name="Metropolitan Line",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays",
+                current_severity=10,
+                current_status="Good Service",
+            ),
+            ClearedLineInfo(
+                line_id="hammersmith-city",
+                line_name="Hammersmith & City",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Minor Delays",
+                current_severity=10,
+                current_status="Good Service",
+            ),
+            ClearedLineInfo(
+                line_id="circle",
+                line_name="Circle Line Name",
+                mode="tube",
+                previous_severity=6,
+                previous_status="Part Suspended",
+                current_severity=10,
+                current_status="Good Service",
+            ),
+        ]
+        still_disrupted = []
+
+        await service.send_status_update_sms(phone, route_name, cleared_lines, still_disrupted)
+
+        mock_send_sms.assert_called_once()
+        call_args = mock_send_sms.call_args
+        sent_message = call_args[0][1]
+
+        # Should reduce to 2 lines if 3 is too long
+        assert len(sent_message) <= 160
+
+    @pytest.mark.asyncio
+    @patch("app.services.sms_service.SmsService.send_sms", new_callable=AsyncMock)
+    async def test_send_status_update_sms_multistage_truncation_2_to_1_line(self, mock_send_sms: AsyncMock) -> None:
+        """Test SMS truncation reduces from 2 cleared lines to 1 when needed."""
+        service = NotificationService()
+        phone = "+447700900123"
+        route_name = "Extremely Long Route Name For Testing Multi-Stage Truncation"
+        cleared_lines = [
+            ClearedLineInfo(
+                line_id="metropolitan",
+                line_name="Metropolitan Line With Very Long Name",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays",
+                current_severity=10,
+                current_status="Good Service",
+            ),
+            ClearedLineInfo(
+                line_id="hammersmith-city",
+                line_name="Hammersmith & City Line",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Minor Delays",
+                current_severity=10,
+                current_status="Good Service",
+            ),
+        ]
+        still_disrupted = []
+
+        await service.send_status_update_sms(phone, route_name, cleared_lines, still_disrupted)
+
+        mock_send_sms.assert_called_once()
+        call_args = mock_send_sms.call_args
+        sent_message = call_args[0][1]
+
+        # Should reduce to 1 line if 2 is too long
+        assert len(sent_message) <= 160
+        # Should contain first line name
+        assert "Metropolitan" in sent_message
+
+    @pytest.mark.asyncio
+    @patch("app.services.sms_service.SmsService.send_sms", new_callable=AsyncMock)
+    async def test_send_status_update_sms_multistage_truncation_with_ellipsis(self, mock_send_sms: AsyncMock) -> None:
+        """Test SMS truncation uses ellipsis for very long route and line names."""
+        service = NotificationService()
+        phone = "+447700900123"
+        route_name = "Extremely Long Route Name That Definitely Needs To Be Truncated With Ellipsis For Testing"
+        cleared_lines = [
+            ClearedLineInfo(
+                line_id="metropolitan",
+                line_name="Metropolitan Line With An Extremely Long Name That Also Needs Truncation",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays",
+                current_severity=10,
+                current_status="Good Service",
+            ),
+        ]
+        still_disrupted = []
+
+        await service.send_status_update_sms(phone, route_name, cleared_lines, still_disrupted)
+
+        mock_send_sms.assert_called_once()
+        call_args = mock_send_sms.call_args
+        sent_message = call_args[0][1]
+
+        # Should truncate with ellipsis
+        assert len(sent_message) <= 160
+        # Should contain ellipsis if truncation occurred
+        # Note: ellipsis may appear in route name or line name depending on lengths
+
+    @pytest.mark.asyncio
+    @patch("app.services.sms_service.SmsService.send_sms", new_callable=AsyncMock)
+    async def test_send_status_update_sms_force_truncate_fallback(self, mock_send_sms: AsyncMock) -> None:
+        """Test SMS force truncate as final fallback."""
+        service = NotificationService()
+        phone = "+447700900123"
+        # Create an extreme case that would still exceed 160 chars even after all truncation stages
+        route_name = "A" * 50  # Very long route name
+        cleared_lines = [
+            ClearedLineInfo(
+                line_id="line",
+                line_name="B" * 50,  # Very long line name
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays",
+                current_severity=10,
+                current_status="Good Service",
+            ),
+        ]
+        still_disrupted = []
+
+        await service.send_status_update_sms(phone, route_name, cleared_lines, still_disrupted)
+
+        mock_send_sms.assert_called_once()
+        call_args = mock_send_sms.call_args
+        sent_message = call_args[0][1]
+
+        # Must be exactly 160 chars or less due to force truncate
+        assert len(sent_message) <= 160
+
+    @pytest.mark.asyncio
+    async def test_send_status_update_sms_error_propagates(self) -> None:
+        """Test status update SMS error is propagated."""
+        service = NotificationService()
+        cleared_lines = [
+            ClearedLineInfo(
+                line_id="victoria",
+                line_name="Victoria",
+                mode="tube",
+                previous_severity=3,
+                previous_status="Severe Delays",
+                current_severity=10,
+                current_status="Good Service",
+            )
+        ]
+        still_disrupted = []
+
+        with (
+            patch.object(service.sms_service, "send_sms", side_effect=Exception("SMS error")),
+            pytest.raises(Exception, match="SMS error"),
+        ):
+            await service.send_status_update_sms(
+                phone="+447700900123",
+                route_name="Test",
+                cleared_lines=cleared_lines,
+                still_disrupted=still_disrupted,
+            )

--- a/backend/tests/test_routes_api.py
+++ b/backend/tests/test_routes_api.py
@@ -294,6 +294,194 @@ class TestRoutesAPI:
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
     @pytest.mark.asyncio
+    async def test_get_route_excludes_soft_deleted_segments(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_user: User,
+        test_station1: Station,
+        test_station2: Station,
+        test_line: Line,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that get_route only returns active segments, not soft-deleted ones."""
+        # Create route with segments
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
+        db_session.add(route)
+        await db_session.commit()
+        await db_session.refresh(route)
+
+        # Create 2 active segments
+        active_seg1 = UserRouteSegment(
+            route_id=route.id,
+            sequence=0,
+            station_id=test_station1.id,
+            line_id=test_line.id,
+        )
+        active_seg2 = UserRouteSegment(
+            route_id=route.id,
+            sequence=1,
+            station_id=test_station2.id,
+            line_id=None,  # destination
+        )
+        db_session.add_all([active_seg1, active_seg2])
+
+        # Create 2 soft-deleted segments (simulating an old upsert)
+        deleted_seg1 = UserRouteSegment(
+            route_id=route.id,
+            sequence=0,
+            station_id=test_station1.id,
+            line_id=test_line.id,
+            deleted_at=datetime.now(UTC),
+        )
+        deleted_seg2 = UserRouteSegment(
+            route_id=route.id,
+            sequence=1,
+            station_id=test_station2.id,
+            line_id=None,
+            deleted_at=datetime.now(UTC),
+        )
+        db_session.add_all([deleted_seg1, deleted_seg2])
+        await db_session.commit()
+
+        # Fetch route via API
+        response = await async_client.get(
+            f"/api/v1/routes/{route.id}",
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        # Should only return 2 active segments, not 4 total
+        assert len(data["segments"]) == 2
+        # Verify both returned segments have no deleted_at
+        for segment in data["segments"]:
+            # API doesn't return deleted_at, but we verify count is correct
+            assert segment["sequence"] in [0, 1]
+
+    @pytest.mark.asyncio
+    async def test_get_route_excludes_soft_deleted_schedules(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that get_route only returns active schedules, not soft-deleted ones."""
+        # Create route
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
+        db_session.add(route)
+        await db_session.commit()
+        await db_session.refresh(route)
+
+        # Create 2 active schedules
+        active_sched1 = UserRouteSchedule(
+            route_id=route.id,
+            days_of_week=["MON"],
+            start_time=time(8, 0),
+            end_time=time(9, 0),
+        )
+        active_sched2 = UserRouteSchedule(
+            route_id=route.id,
+            days_of_week=["TUE"],
+            start_time=time(8, 0),
+            end_time=time(9, 0),
+        )
+        db_session.add_all([active_sched1, active_sched2])
+
+        # Create 2 soft-deleted schedules (simulating an old upsert)
+        deleted_sched1 = UserRouteSchedule(
+            route_id=route.id,
+            days_of_week=["MON"],
+            start_time=time(8, 0),
+            end_time=time(9, 0),
+            deleted_at=datetime.now(UTC),
+        )
+        deleted_sched2 = UserRouteSchedule(
+            route_id=route.id,
+            days_of_week=["TUE"],
+            start_time=time(8, 0),
+            end_time=time(9, 0),
+            deleted_at=datetime.now(UTC),
+        )
+        db_session.add_all([deleted_sched1, deleted_sched2])
+        await db_session.commit()
+
+        # Fetch route via API
+        response = await async_client.get(
+            f"/api/v1/routes/{route.id}",
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        # Should only return 2 active schedules, not 4 total
+        assert len(data["schedules"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_routes_excludes_soft_deleted_segments(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_user: User,
+        test_station1: Station,
+        test_station2: Station,
+        test_line: Line,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that list_routes only counts active segments, not soft-deleted ones."""
+        # Create route
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
+        db_session.add(route)
+        await db_session.commit()
+        await db_session.refresh(route)
+
+        # Create 2 active segments
+        active_seg1 = UserRouteSegment(
+            route_id=route.id,
+            sequence=0,
+            station_id=test_station1.id,
+            line_id=test_line.id,
+        )
+        active_seg2 = UserRouteSegment(
+            route_id=route.id,
+            sequence=1,
+            station_id=test_station2.id,
+            line_id=None,
+        )
+        db_session.add_all([active_seg1, active_seg2])
+
+        # Create 2 soft-deleted segments
+        deleted_seg1 = UserRouteSegment(
+            route_id=route.id,
+            sequence=0,
+            station_id=test_station1.id,
+            line_id=test_line.id,
+            deleted_at=datetime.now(UTC),
+        )
+        deleted_seg2 = UserRouteSegment(
+            route_id=route.id,
+            sequence=1,
+            station_id=test_station2.id,
+            line_id=None,
+            deleted_at=datetime.now(UTC),
+        )
+        db_session.add_all([deleted_seg1, deleted_seg2])
+        await db_session.commit()
+
+        # List routes via API
+        response = await async_client.get(
+            "/api/v1/routes",
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 1
+        # segment_count should be 2 (active only), not 4 (active + deleted)
+        assert data[0]["segment_count"] == 2
+
+    @pytest.mark.asyncio
     async def test_update_route(
         self,
         async_client: AsyncClient,
@@ -1325,6 +1513,296 @@ class TestRoutesAPI:
         )
 
         assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    # ==================== Upsert Schedules Tests ====================
+
+    @pytest.mark.asyncio
+    async def test_upsert_schedules_replaces_all(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that upsert replaces all existing schedules."""
+        # Create route with existing schedules
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
+        db_session.add(route)
+        await db_session.flush()
+
+        # Add existing schedule
+        old_schedule = UserRouteSchedule(
+            route_id=route.id,
+            days_of_week=["MON"],
+            start_time=time(8, 0),
+            end_time=time(9, 0),
+        )
+        db_session.add(old_schedule)
+        await db_session.commit()
+        old_schedule_id = old_schedule.id
+
+        # Upsert with new schedules
+        response = await async_client.put(
+            f"/api/v1/routes/{route.id}/schedules",
+            json={
+                "schedules": [
+                    {"days_of_week": ["TUE", "WED"], "start_time": "10:00:00", "end_time": "11:00:00"},
+                    {"days_of_week": ["THU"], "start_time": "14:00:00", "end_time": "15:00:00"},
+                ]
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert len(data) == 2
+
+        # Verify old schedule was soft-deleted
+        result = await db_session.execute(select(UserRouteSchedule).where(UserRouteSchedule.id == old_schedule_id))
+        deleted_schedule = result.scalar_one()
+        assert deleted_schedule.deleted_at is not None
+
+    @pytest.mark.asyncio
+    async def test_upsert_schedules_empty_array_deletes_all(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that empty array deletes all schedules."""
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
+        db_session.add(route)
+        await db_session.flush()
+
+        schedule = UserRouteSchedule(
+            route_id=route.id,
+            days_of_week=["MON"],
+            start_time=time(8, 0),
+            end_time=time(9, 0),
+        )
+        db_session.add(schedule)
+        await db_session.commit()
+
+        response = await async_client.put(
+            f"/api/v1/routes/{route.id}/schedules",
+            json={"schedules": []},
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+
+        # Verify schedule was actually soft-deleted in the database
+        result = await db_session.execute(
+            select(UserRouteSchedule).where(
+                UserRouteSchedule.route_id == route.id,
+                UserRouteSchedule.deleted_at.is_(None),
+            )
+        )
+        active_schedules = result.scalars().all()
+        assert active_schedules == []
+
+    @pytest.mark.asyncio
+    async def test_upsert_schedules_schema_validation_preserves_state(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that schema validation failure (422) preserves original state.
+
+        Note: This tests Pydantic schema validation which occurs before the service
+        layer runs, not transactional rollback within upsert_schedules().
+        """
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
+        db_session.add(route)
+        await db_session.flush()
+
+        original_schedule = UserRouteSchedule(
+            route_id=route.id,
+            days_of_week=["MON"],
+            start_time=time(8, 0),
+            end_time=time(9, 0),
+        )
+        db_session.add(original_schedule)
+        await db_session.commit()
+        await db_session.refresh(original_schedule)
+
+        # Try to upsert with one valid and one invalid schedule
+        response = await async_client.put(
+            f"/api/v1/routes/{route.id}/schedules",
+            json={
+                "schedules": [
+                    {"days_of_week": ["TUE"], "start_time": "10:00:00", "end_time": "11:00:00"},
+                    {"days_of_week": ["INVALID_DAY"], "start_time": "14:00:00", "end_time": "15:00:00"},
+                ]
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+        # Verify original schedule is still active (transaction rolled back)
+        await db_session.refresh(original_schedule)
+        assert original_schedule.deleted_at is None
+
+        # Ensure no new schedules were created and original remained unchanged
+        result = await db_session.execute(
+            select(UserRouteSchedule).where(
+                UserRouteSchedule.route_id == route.id,
+                UserRouteSchedule.deleted_at.is_(None),
+            )
+        )
+        active_schedules = result.scalars().all()
+        assert len(active_schedules) == 1
+
+        schedule = active_schedules[0]
+        assert schedule.id == original_schedule.id
+        assert schedule.start_time == original_schedule.start_time
+        assert schedule.end_time == original_schedule.end_time
+        assert schedule.days_of_week == original_schedule.days_of_week
+
+    @pytest.mark.asyncio
+    async def test_upsert_schedules_invalid_time_range(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that end_time <= start_time is rejected."""
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
+        db_session.add(route)
+        await db_session.commit()
+
+        response = await async_client.put(
+            f"/api/v1/routes/{route.id}/schedules",
+            json={
+                "schedules": [
+                    {"days_of_week": ["MON"], "start_time": "18:00:00", "end_time": "08:00:00"},
+                ]
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    @pytest.mark.asyncio
+    async def test_upsert_schedules_route_not_found(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+    ) -> None:
+        """Test 404 for non-existent route."""
+        fake_route_id = str(uuid.uuid4())
+
+        response = await async_client.put(
+            f"/api/v1/routes/{fake_route_id}/schedules",
+            json={"schedules": []},
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_upsert_schedules_ownership_validation(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        another_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that users cannot modify other users' schedules."""
+        route = UserRoute(user_id=another_user.id, name="Other User Route", active=True)
+        db_session.add(route)
+        await db_session.commit()
+
+        response = await async_client.put(
+            f"/api/v1/routes/{route.id}/schedules",
+            json={"schedules": []},
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @pytest.mark.asyncio
+    async def test_upsert_schedules_invalid_days(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that invalid day codes are rejected."""
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
+        db_session.add(route)
+        await db_session.commit()
+
+        response = await async_client.put(
+            f"/api/v1/routes/{route.id}/schedules",
+            json={
+                "schedules": [
+                    {"days_of_week": ["MONDAY"], "start_time": "08:00:00", "end_time": "18:00:00"},
+                ]
+            },
+            headers=auth_headers_for_user,
+        )
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+    @pytest.mark.asyncio
+    async def test_upsert_schedules_invalid_quarter_hour(
+        self,
+        async_client: AsyncClient,
+        auth_headers_for_user: dict[str, str],
+        test_user: User,
+        db_session: AsyncSession,
+    ) -> None:
+        """Test that times not on quarter-hour boundaries are rejected."""
+        route = UserRoute(user_id=test_user.id, name="Test Route", active=True)
+        db_session.add(route)
+        await db_session.commit()
+
+        # Test with start_time not on quarter-hour
+        response = await async_client.put(
+            f"/api/v1/routes/{route.id}/schedules",
+            json={
+                "schedules": [
+                    {"days_of_week": ["MON"], "start_time": "08:17:00", "end_time": "09:00:00"},
+                ]
+            },
+            headers=auth_headers_for_user,
+        )
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        assert "quarter-hour boundary" in response.json()["detail"][0]["msg"].lower()
+
+        # Test with end_time not on quarter-hour
+        response = await async_client.put(
+            f"/api/v1/routes/{route.id}/schedules",
+            json={
+                "schedules": [
+                    {"days_of_week": ["MON"], "start_time": "08:00:00", "end_time": "09:07:00"},
+                ]
+            },
+            headers=auth_headers_for_user,
+        )
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        assert "quarter-hour boundary" in response.json()["detail"][0]["msg"].lower()
+
+        # Test with seconds (not on quarter-hour)
+        response = await async_client.put(
+            f"/api/v1/routes/{route.id}/schedules",
+            json={
+                "schedules": [
+                    {"days_of_week": ["MON"], "start_time": "08:00:30", "end_time": "09:00:00"},
+                ]
+            },
+            headers=auth_headers_for_user,
+        )
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+        assert "quarter-hour boundary" in response.json()["detail"][0]["msg"].lower()
 
     # ==================== Additional Coverage Tests ====================
 

--- a/backend/tests/test_tfl_service.py
+++ b/backend/tests/test_tfl_service.py
@@ -1190,6 +1190,11 @@ async def test_fetch_lines_logs_changes(
         assert logs[0].old_values is None
         assert logs[0].new_values == {"name": "Victoria", "mode": "tube"}
 
+        # Clear SQLAlchemy's identity map to ensure fresh database read.
+        # The first fetch uses raw SQL upsert which bypasses the ORM identity map.
+        # Without this, the second fetch may see stale results due to SAVEPOINT timing.
+        db_session.expire_all()
+
         # Second fetch with name change
         mock_lines_v2 = [create_mock_line(id="victoria", name="Victoria Line")]
         mock_response_v2 = MockResponse(

--- a/frontend/safe-test-runner.sh
+++ b/frontend/safe-test-runner.sh
@@ -119,8 +119,8 @@ echo "Difference: +$((FINAL_COUNT - BASELINE_COUNT))" | tee -a "$LOG_FILE"
 echo "" | tee -a "$LOG_FILE"
 
 # Show test output
-echo "=== Test Output (last 50 lines) ===" | tee -a "$LOG_FILE"
-tail -50 test-output.log | tee -a "$LOG_FILE"
+echo "=== Test Output (last 100 lines) ===" | tee -a "$LOG_FILE"
+tail -100 test-output.log | tee -a "$LOG_FILE"
 
 echo "" | tee -a "$LOG_FILE"
 echo "Completed at: $(date)" | tee -a "$LOG_FILE"

--- a/frontend/src/components/routes/RouteCard.tsx
+++ b/frontend/src/components/routes/RouteCard.tsx
@@ -2,7 +2,8 @@ import { Calendar, Pencil, Trash2, Route as RouteIcon } from 'lucide-react'
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card'
 import { Button } from '../ui/button'
 import { Badge } from '../ui/badge'
-import type { RouteListItemResponse } from '@/types'
+import type { RouteListItemResponse, RouteDisruptionResponse } from '@/types'
+import { RouteDisruptionStatus } from './RouteDisruptionStatus'
 
 export interface RouteCardProps {
   route: RouteListItemResponse
@@ -10,6 +11,8 @@ export interface RouteCardProps {
   onDelete: (id: string) => void
   onClick?: (id: string) => void
   isDeleting?: boolean
+  disruption?: RouteDisruptionResponse | null
+  disruptionsLoading?: boolean
 }
 
 /**
@@ -20,6 +23,8 @@ export interface RouteCardProps {
  * @param onDelete - Callback when delete button is clicked
  * @param onClick - Optional callback when card is clicked (for navigation)
  * @param isDeleting - Loading state for deletion
+ * @param disruption - Optional disruption data for this route
+ * @param disruptionsLoading - Whether disruption data is loading
  */
 export function RouteCard({
   route,
@@ -27,6 +32,8 @@ export function RouteCard({
   onDelete,
   onClick,
   isDeleting = false,
+  disruption,
+  disruptionsLoading = false,
 }: RouteCardProps) {
   const handleCardClick = () => {
     if (onClick) {
@@ -71,6 +78,13 @@ export function RouteCard({
       </CardHeader>
 
       <CardContent className="pt-0">
+        {/* Disruption status indicator */}
+        <RouteDisruptionStatus
+          disruption={disruption ?? null}
+          loading={disruptionsLoading}
+          className="mb-4"
+        />
+
         <div className="flex items-center gap-4 text-sm text-muted-foreground mb-4">
           <div className="flex items-center gap-1" title="Number of segments">
             <RouteIcon className="h-4 w-4" aria-hidden="true" />

--- a/frontend/src/components/routes/RouteDisruptionStatus.test.tsx
+++ b/frontend/src/components/routes/RouteDisruptionStatus.test.tsx
@@ -1,0 +1,220 @@
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import { RouteDisruptionStatus } from './RouteDisruptionStatus'
+import type { RouteDisruptionResponse, DisruptionResponse } from '@/types'
+
+// Helper function to create mock disruption data
+const createDisruption = (overrides?: Partial<DisruptionResponse>): RouteDisruptionResponse => ({
+  route_id: 'route-1',
+  route_name: 'Home to Work',
+  disruption: {
+    line_id: 'victoria',
+    line_name: 'Victoria',
+    mode: 'tube',
+    status_severity: 6,
+    status_severity_description: 'Minor Delays',
+    reason: 'Victoria: Signal failure at Kings Cross',
+    created_at: '2025-01-01T10:00:00Z',
+    affected_routes: null,
+    ...overrides,
+  },
+  affected_segments: [0, 1],
+  affected_stations: ['940GZZLUOXC'],
+})
+
+describe('RouteDisruptionStatus', () => {
+  describe('loading state', () => {
+    it('should render loading skeleton when loading is true', () => {
+      render(<RouteDisruptionStatus disruption={null} loading={true} />)
+
+      const status = screen.getByRole('status')
+      expect(status).toHaveAttribute('aria-busy', 'true')
+      expect(status).toHaveAttribute('aria-label', 'Loading disruption status')
+
+      // Check for skeleton element (animated placeholder)
+      const skeleton = status.querySelector('.animate-pulse')
+      expect(skeleton).toBeInTheDocument()
+    })
+
+    it('should render loading skeleton even when disruption is provided', () => {
+      const disruption = createDisruption()
+      render(<RouteDisruptionStatus disruption={disruption} loading={true} />)
+
+      const status = screen.getByRole('status')
+      expect(status).toHaveAttribute('aria-busy', 'true')
+
+      // Should show loading, not the disruption
+      expect(screen.queryByText('Victoria')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('good service state', () => {
+    it('should render "Good Service" when disruption is null and not loading', () => {
+      render(<RouteDisruptionStatus disruption={null} loading={false} />)
+
+      const status = screen.getByRole('status')
+      expect(status).toHaveAttribute('aria-label', 'Good Service')
+
+      expect(screen.getByText('Good Service')).toBeInTheDocument()
+    })
+
+    it('should render CheckCircle icon for good service', () => {
+      render(<RouteDisruptionStatus disruption={null} />)
+
+      const icon = screen.getByRole('status').querySelector('svg')
+      expect(icon).toBeInTheDocument()
+      expect(icon).toHaveAttribute('aria-hidden', 'true')
+    })
+  })
+
+  describe('disruption state', () => {
+    it('should render disruption badge and line name', () => {
+      const disruption = createDisruption()
+      render(<RouteDisruptionStatus disruption={disruption} />)
+
+      // Should show line name
+      expect(screen.getByText('Victoria')).toBeInTheDocument()
+
+      // Should show severity badge (DisruptionBadge has role="status")
+      const badge = screen.getByRole('status', { name: 'Minor Delays' })
+      expect(badge).toBeInTheDocument()
+      expect(badge).toHaveTextContent('Minor Delays')
+    })
+
+    it('should render disruption reason without line name prefix', () => {
+      const disruption = createDisruption({
+        reason: 'Victoria: Signal failure at Kings Cross',
+      })
+      render(<RouteDisruptionStatus disruption={disruption} />)
+
+      // Should strip "Victoria: " prefix
+      expect(screen.getByText(/Signal failure at Kings Cross/i)).toBeInTheDocument()
+      expect(screen.queryByText(/Victoria: Signal failure/i)).not.toBeInTheDocument()
+    })
+
+    it('should render disruption reason as-is when no line name prefix', () => {
+      const disruption = createDisruption({
+        reason: 'Signal failure at Kings Cross',
+      })
+      render(<RouteDisruptionStatus disruption={disruption} />)
+
+      expect(screen.getByText('Signal failure at Kings Cross')).toBeInTheDocument()
+    })
+
+    it('should not render reason text when reason is null', () => {
+      const disruption = createDisruption({
+        reason: null,
+      })
+      const { container } = render(<RouteDisruptionStatus disruption={disruption} />)
+
+      // Should show line name and badge
+      expect(screen.getByText('Victoria')).toBeInTheDocument()
+
+      // Should not have a paragraph with reason
+      const reason = container.querySelector('p')
+      expect(reason).toBeNull()
+    })
+
+    it('should handle severe disruptions (low severity number)', () => {
+      const disruption = createDisruption({
+        status_severity: 1,
+        status_severity_description: 'Closed',
+        reason: 'Line closed due to emergency',
+      })
+      render(<RouteDisruptionStatus disruption={disruption} />)
+
+      const badge = screen.getByRole('status', { name: 'Closed' })
+      expect(badge).toHaveTextContent('Closed')
+      expect(screen.getByText('Victoria')).toBeInTheDocument()
+      expect(screen.getByText(/emergency/i)).toBeInTheDocument()
+    })
+
+    it('should handle good service severity (severity 10)', () => {
+      const disruption = createDisruption({
+        status_severity: 10,
+        status_severity_description: 'Good Service',
+        reason: null,
+      })
+      render(<RouteDisruptionStatus disruption={disruption} />)
+
+      const badge = screen.getByRole('status', { name: 'Good Service' })
+      expect(badge).toHaveTextContent('Good Service')
+    })
+
+    it('should clamp long reason text to 2 lines', () => {
+      const longReason = 'A'.repeat(200)
+      const disruption = createDisruption({
+        reason: longReason,
+      })
+      render(<RouteDisruptionStatus disruption={disruption} />)
+
+      const reasonElement = screen.getByTitle(longReason)
+      expect(reasonElement).toHaveClass('line-clamp-2')
+    })
+  })
+
+  describe('custom styling', () => {
+    it('should accept and apply custom className', () => {
+      render(<RouteDisruptionStatus disruption={null} className="custom-class" />)
+
+      const status = screen.getByRole('status')
+      expect(status).toHaveClass('custom-class')
+    })
+
+    it('should apply custom className to loading state', () => {
+      render(<RouteDisruptionStatus disruption={null} loading={true} className="custom-class" />)
+
+      const status = screen.getByRole('status')
+      expect(status).toHaveClass('custom-class')
+    })
+
+    it('should apply custom className to disruption state', () => {
+      const disruption = createDisruption()
+      const { container } = render(
+        <RouteDisruptionStatus disruption={disruption} className="custom-class" />
+      )
+
+      // The outer div should have the custom class
+      const outerDiv = container.firstChild as HTMLElement
+      expect(outerDiv).toHaveClass('custom-class')
+    })
+  })
+
+  describe('accessibility', () => {
+    it('should have proper ARIA labels for all states', () => {
+      const { rerender } = render(<RouteDisruptionStatus disruption={null} loading={true} />)
+      expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Loading disruption status')
+
+      rerender(<RouteDisruptionStatus disruption={null} loading={false} />)
+      expect(screen.getByRole('status')).toHaveAttribute('aria-label', 'Good Service')
+
+      const disruption = createDisruption()
+      rerender(<RouteDisruptionStatus disruption={disruption} loading={false} />)
+      // DisruptionBadge has role="status" with appropriate aria-label
+      const badge = screen.getByRole('status')
+      expect(badge).toHaveAttribute('aria-label', 'Minor Delays')
+    })
+
+    it('should mark decorative icons as aria-hidden', () => {
+      render(<RouteDisruptionStatus disruption={null} />)
+
+      const icon = screen.getByRole('status').querySelector('svg')
+      expect(icon).toHaveAttribute('aria-hidden', 'true')
+    })
+
+    it('should use role="status" for live region updates', () => {
+      // Loading state has role="status"
+      const { rerender } = render(<RouteDisruptionStatus disruption={null} loading={true} />)
+      expect(screen.getByRole('status')).toBeInTheDocument()
+
+      // Good service state has role="status"
+      rerender(<RouteDisruptionStatus disruption={null} loading={false} />)
+      expect(screen.getByRole('status')).toBeInTheDocument()
+
+      // Disruption state has role="status" on the badge
+      const disruption = createDisruption()
+      rerender(<RouteDisruptionStatus disruption={disruption} />)
+      expect(screen.getByRole('status')).toBeInTheDocument()
+    })
+  })
+})

--- a/frontend/src/components/routes/RouteDisruptionStatus.tsx
+++ b/frontend/src/components/routes/RouteDisruptionStatus.tsx
@@ -1,0 +1,84 @@
+import { CheckCircle } from 'lucide-react'
+import { DisruptionBadge } from '@/components/disruptions'
+import type { RouteDisruptionResponse } from '@/types'
+import { cn } from '@/lib/utils'
+
+export interface RouteDisruptionStatusProps {
+  /** The disruption affecting this route (null = good service) */
+  disruption: RouteDisruptionResponse | null
+  /** Whether disruption data is still loading */
+  loading?: boolean
+  /** Additional CSS classes */
+  className?: string
+}
+
+/**
+ * RouteDisruptionStatus component
+ *
+ * Displays the disruption status for a single route:
+ * - Loading state: skeleton placeholder
+ * - No disruption: "Good Service" with green checkmark
+ * - Has disruption: Badge with severity and reason summary
+ *
+ * @example
+ * <RouteDisruptionStatus disruption={routeDisruption} loading={false} />
+ * <RouteDisruptionStatus disruption={null} />
+ */
+export function RouteDisruptionStatus({
+  disruption,
+  loading = false,
+  className,
+}: RouteDisruptionStatusProps) {
+  // Loading state: show skeleton placeholder
+  if (loading) {
+    return (
+      <div
+        className={cn('flex items-center gap-2 h-6', className)}
+        role="status"
+        aria-label="Loading disruption status"
+        aria-busy="true"
+      >
+        <div className="h-5 w-24 bg-muted animate-pulse rounded" />
+      </div>
+    )
+  }
+
+  // No disruption: show "Good Service"
+  if (!disruption) {
+    return (
+      <div
+        className={cn('flex items-center gap-2 text-sm text-muted-foreground', className)}
+        role="status"
+        aria-label="Good Service"
+      >
+        <CheckCircle className="h-4 w-4 text-green-600" aria-hidden="true" />
+        <span>Good Service</span>
+      </div>
+    )
+  }
+
+  // Has disruption: show badge and reason
+  const { disruption: disruptionData } = disruption
+  // Escape regex special characters in line_name before using in RegExp
+  const escapedLineName = disruptionData.line_name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const reason = disruptionData.reason
+    ? disruptionData.reason.replace(new RegExp(`^${escapedLineName}:\\s*`, 'i'), '')
+    : null
+
+  return (
+    <div className={cn('flex flex-col gap-1', className)}>
+      <div className="flex items-center gap-2">
+        <DisruptionBadge
+          severity={disruptionData.status_severity}
+          severityDescription={disruptionData.status_severity_description}
+        />
+        <span className="text-sm font-medium">{disruptionData.line_name}</span>
+      </div>
+      {reason && (
+        <p className="text-xs text-muted-foreground line-clamp-2" title={reason}>
+          {reason}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/routes/RouteList.test.tsx
+++ b/frontend/src/components/routes/RouteList.test.tsx
@@ -1,7 +1,11 @@
 import { render, screen } from '@testing-library/react'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { RouteList } from './RouteList'
-import type { RouteListItemResponse } from '../../lib/api'
+import type {
+  RouteListItemResponse,
+  RouteDisruptionResponse,
+  DisruptionResponse,
+} from '../../lib/api'
 
 describe('RouteList', () => {
   const mockRoutes: RouteListItemResponse[] = [
@@ -87,5 +91,154 @@ describe('RouteList', () => {
     // The deleting route should have disabled buttons
     const editButtons = screen.getAllByRole('button', { name: /edit/i })
     expect(editButtons[0]).toBeDisabled() // First route's edit button
+  })
+
+  describe('disruptions', () => {
+    const createDisruption = (
+      routeId: string,
+      severity: number,
+      overrides?: Partial<DisruptionResponse>
+    ): RouteDisruptionResponse => ({
+      route_id: routeId,
+      route_name: 'Test Route',
+      disruption: {
+        line_id: 'victoria',
+        line_name: 'Victoria',
+        mode: 'tube',
+        status_severity: severity,
+        status_severity_description: severity === 10 ? 'Good Service' : 'Minor Delays',
+        reason: 'Test reason',
+        created_at: '2025-01-01T10:00:00Z',
+        affected_routes: null,
+        ...overrides,
+      },
+      affected_segments: [0, 1],
+      affected_stations: ['940GZZLUOXC'],
+    })
+
+    it('should render routes without disruptions prop (backward compatible)', () => {
+      render(<RouteList routes={mockRoutes} onEdit={mockOnEdit} onDelete={mockOnDelete} />)
+
+      // All routes should show "Good Service" by default
+      const goodServiceElements = screen.getAllByText('Good Service')
+      expect(goodServiceElements).toHaveLength(2)
+    })
+
+    it('should handle null disruptions', () => {
+      render(
+        <RouteList
+          routes={mockRoutes}
+          onEdit={mockOnEdit}
+          onDelete={mockOnDelete}
+          disruptions={null}
+        />
+      )
+
+      // All routes should show "Good Service"
+      const goodServiceElements = screen.getAllByText('Good Service')
+      expect(goodServiceElements).toHaveLength(2)
+    })
+
+    it('should handle empty disruptions array', () => {
+      render(
+        <RouteList
+          routes={mockRoutes}
+          onEdit={mockOnEdit}
+          onDelete={mockOnDelete}
+          disruptions={[]}
+        />
+      )
+
+      // All routes should show "Good Service"
+      const goodServiceElements = screen.getAllByText('Good Service')
+      expect(goodServiceElements).toHaveLength(2)
+    })
+
+    it('should pass disruption loading state to RouteCards', () => {
+      render(
+        <RouteList
+          routes={mockRoutes}
+          onEdit={mockOnEdit}
+          onDelete={mockOnDelete}
+          disruptionsLoading={true}
+        />
+      )
+
+      // All routes should show loading state
+      const loadingStatuses = screen.getAllByRole('status', { name: /loading disruption status/i })
+      expect(loadingStatuses).toHaveLength(2)
+    })
+
+    it('should map disruptions to correct routes', () => {
+      const disruptions = [
+        createDisruption('route-1', 6, {
+          status_severity_description: 'Minor Delays',
+          reason: 'Signal failure',
+        }),
+      ]
+      render(
+        <RouteList
+          routes={mockRoutes}
+          onEdit={mockOnEdit}
+          onDelete={mockOnDelete}
+          disruptions={disruptions}
+        />
+      )
+
+      // First route should show disruption
+      expect(screen.getByText('Minor Delays')).toBeInTheDocument()
+      expect(screen.getByText(/Signal failure/i)).toBeInTheDocument()
+
+      // Second route should show "Good Service"
+      expect(screen.getByText('Good Service')).toBeInTheDocument()
+    })
+
+    it('should show worst disruption when multiple disruptions for same route', () => {
+      const disruptions = [
+        createDisruption('route-1', 10, { status_severity_description: 'Good Service' }),
+        createDisruption('route-1', 6, { status_severity_description: 'Minor Delays' }),
+        createDisruption('route-1', 20, { status_severity_description: 'Severe Delays' }),
+      ]
+      render(
+        <RouteList
+          routes={mockRoutes}
+          onEdit={mockOnEdit}
+          onDelete={mockOnDelete}
+          disruptions={disruptions}
+        />
+      )
+
+      // Should show Minor Delays (severity 6, lowest/worst)
+      expect(screen.getByText('Minor Delays')).toBeInTheDocument()
+      // Should not show Good Service or Severe Delays for first route
+      expect(screen.queryByText('Severe Delays')).not.toBeInTheDocument()
+    })
+
+    it('should handle disruptions for multiple routes', () => {
+      const disruptions = [
+        createDisruption('route-1', 6, {
+          line_name: 'Victoria',
+          status_severity_description: 'Minor Delays',
+        }),
+        createDisruption('route-2', 1, {
+          line_name: 'Piccadilly',
+          status_severity_description: 'Closed',
+        }),
+      ]
+      render(
+        <RouteList
+          routes={mockRoutes}
+          onEdit={mockOnEdit}
+          onDelete={mockOnDelete}
+          disruptions={disruptions}
+        />
+      )
+
+      // Both disruptions should be shown
+      expect(screen.getByText('Victoria')).toBeInTheDocument()
+      expect(screen.getByText('Piccadilly')).toBeInTheDocument()
+      expect(screen.getByText('Minor Delays')).toBeInTheDocument()
+      expect(screen.getByText('Closed')).toBeInTheDocument()
+    })
   })
 })

--- a/frontend/src/components/routes/RouteList.tsx
+++ b/frontend/src/components/routes/RouteList.tsx
@@ -1,6 +1,7 @@
 import { MapPin } from 'lucide-react'
 import { RouteCard } from './RouteCard'
-import type { RouteListItemResponse } from '@/types'
+import type { RouteListItemResponse, RouteDisruptionResponse } from '@/types'
+import { getWorstDisruptionForRoute } from '@/lib/disruption-utils'
 
 export interface RouteListProps {
   routes: RouteListItemResponse[]
@@ -9,6 +10,8 @@ export interface RouteListProps {
   onClick?: (id: string) => void
   loading?: boolean
   deletingId?: string
+  disruptions?: RouteDisruptionResponse[] | null
+  disruptionsLoading?: boolean
 }
 
 /**
@@ -20,6 +23,8 @@ export interface RouteListProps {
  * @param onClick - Optional callback when card is clicked
  * @param loading - Loading state for the list
  * @param deletingId - ID of route currently being deleted
+ * @param disruptions - Optional array of route disruptions
+ * @param disruptionsLoading - Whether disruption data is loading
  */
 export function RouteList({
   routes,
@@ -28,6 +33,8 @@ export function RouteList({
   onClick,
   loading = false,
   deletingId,
+  disruptions,
+  disruptionsLoading = false,
 }: RouteListProps) {
   if (loading) {
     return (
@@ -57,16 +64,21 @@ export function RouteList({
 
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-      {routes.map((route) => (
-        <RouteCard
-          key={route.id}
-          route={route}
-          onEdit={onEdit}
-          onDelete={onDelete}
-          onClick={onClick}
-          isDeleting={deletingId === route.id}
-        />
-      ))}
+      {routes.map((route) => {
+        const disruption = getWorstDisruptionForRoute(disruptions, route.id)
+        return (
+          <RouteCard
+            key={route.id}
+            route={route}
+            onEdit={onEdit}
+            onDelete={onDelete}
+            onClick={onClick}
+            isDeleting={deletingId === route.id}
+            disruption={disruption}
+            disruptionsLoading={disruptionsLoading}
+          />
+        )
+      })}
     </div>
   )
 }

--- a/frontend/src/components/routes/ScheduleGrid/ScheduleGrid.test.tsx
+++ b/frontend/src/components/routes/ScheduleGrid/ScheduleGrid.test.tsx
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ScheduleGrid } from './ScheduleGrid'
+
+describe('ScheduleGrid', () => {
+  describe('rendering', () => {
+    it('should render day headers', () => {
+      const onChange = vi.fn()
+      render(<ScheduleGrid onChange={onChange} />)
+
+      expect(screen.getByText('Mon')).toBeInTheDocument()
+      expect(screen.getByText('Tue')).toBeInTheDocument()
+      expect(screen.getByText('Wed')).toBeInTheDocument()
+      expect(screen.getByText('Thu')).toBeInTheDocument()
+      expect(screen.getByText('Fri')).toBeInTheDocument()
+      expect(screen.getByText('Sat')).toBeInTheDocument()
+      expect(screen.getByText('Sun')).toBeInTheDocument()
+    })
+
+    it('should render time labels for hours', () => {
+      const onChange = vi.fn()
+      render(<ScheduleGrid onChange={onChange} />)
+
+      // Should show hour markers (just hour numbers, not minutes)
+      expect(screen.getByText('00')).toBeInTheDocument()
+      expect(screen.getByText('01')).toBeInTheDocument()
+      expect(screen.getByText('12')).toBeInTheDocument()
+      expect(screen.getByText('23')).toBeInTheDocument()
+    })
+
+    it('should render grid cells', () => {
+      const onChange = vi.fn()
+      render(<ScheduleGrid onChange={onChange} />)
+
+      // Should have cells for each day-slot combination
+      // 7 days × 96 slots = 672 cells
+      const cells = screen.getAllByRole('button')
+      expect(cells.length).toBe(672)
+    })
+
+    it('should show selected cells', () => {
+      const onChange = vi.fn()
+      const initialSelection = new Set(['MON:0', 'TUE:5'])
+
+      render(<ScheduleGrid initialSelection={initialSelection} onChange={onChange} />)
+
+      const monCell = screen.getByLabelText('Mon 00:00:00')
+      expect(monCell).toHaveAttribute('aria-pressed', 'true')
+      expect(monCell).toHaveClass('bg-primary')
+    })
+
+    it('should show unselected cells', () => {
+      const onChange = vi.fn()
+      render(<ScheduleGrid onChange={onChange} />)
+
+      const monCell = screen.getByLabelText('Mon 00:00:00')
+      expect(monCell).toHaveAttribute('aria-pressed', 'false')
+      expect(monCell).toHaveClass('bg-background')
+    })
+  })
+
+  describe('interaction', () => {
+    it('should toggle cell on click', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      render(<ScheduleGrid onChange={onChange} />)
+
+      const monCell = screen.getByLabelText('Mon 00:00:00')
+
+      await user.click(monCell)
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      const selection = onChange.mock.calls[0][0]
+      expect(selection.has('MON:0')).toBe(true)
+    })
+
+    it('should deselect cell on second click', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+      const initialSelection = new Set(['MON:0'])
+
+      render(<ScheduleGrid initialSelection={initialSelection} onChange={onChange} />)
+
+      const monCell = screen.getByLabelText('Mon 00:00:00')
+
+      await user.click(monCell)
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      const selection = onChange.mock.calls[0][0]
+      expect(selection.has('MON:0')).toBe(false)
+    })
+
+    it('should not respond to clicks when disabled', async () => {
+      const user = userEvent.setup()
+      const onChange = vi.fn()
+
+      render(<ScheduleGrid onChange={onChange} disabled={true} />)
+
+      const monCell = screen.getByLabelText('Mon 00:00:00')
+
+      await user.click(monCell)
+
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it('should disable all cells when disabled prop is true', () => {
+      const onChange = vi.fn()
+      render(<ScheduleGrid onChange={onChange} disabled={true} />)
+
+      const cells = screen.getAllByRole('button')
+      cells.forEach((cell) => {
+        expect(cell).toBeDisabled()
+      })
+    })
+  })
+
+  describe('accessibility', () => {
+    it('should have aria-labels for cells', () => {
+      const onChange = vi.fn()
+      render(<ScheduleGrid onChange={onChange} />)
+
+      const monCell = screen.getByLabelText('Mon 00:00:00')
+      expect(monCell).toBeInTheDocument()
+
+      const tueCell = screen.getByLabelText('Tue 09:00:00')
+      expect(tueCell).toBeInTheDocument()
+    })
+
+    it('should have aria-pressed for selected state', () => {
+      const onChange = vi.fn()
+      const initialSelection = new Set(['MON:0'])
+
+      render(<ScheduleGrid initialSelection={initialSelection} onChange={onChange} />)
+
+      const monCell = screen.getByLabelText('Mon 00:00:00')
+      expect(monCell).toHaveAttribute('aria-pressed', 'true')
+
+      const tueCell = screen.getByLabelText('Tue 00:00:00')
+      expect(tueCell).toHaveAttribute('aria-pressed', 'false')
+    })
+
+    it('should have button role for cells', () => {
+      const onChange = vi.fn()
+      render(<ScheduleGrid onChange={onChange} />)
+
+      const cells = screen.getAllByRole('button')
+      expect(cells.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('className prop', () => {
+    it('should apply custom className to container', () => {
+      const onChange = vi.fn()
+      const { container } = render(<ScheduleGrid onChange={onChange} className="custom-class" />)
+
+      const card = container.querySelector('.custom-class')
+      expect(card).toBeInTheDocument()
+    })
+  })
+
+  describe('initialSelection updates', () => {
+    it('should update selection when initialSelection prop changes', () => {
+      const onChange = vi.fn()
+      const { rerender } = render(
+        <ScheduleGrid initialSelection={new Set(['MON:0'])} onChange={onChange} />
+      )
+
+      let monCell = screen.getByLabelText('Mon 00:00:00')
+      expect(monCell).toHaveAttribute('aria-pressed', 'true')
+
+      rerender(<ScheduleGrid initialSelection={new Set(['TUE:5'])} onChange={onChange} />)
+
+      monCell = screen.getByLabelText('Mon 00:00:00')
+      const tueCell = screen.getByLabelText('Tue 01:15:00')
+
+      expect(monCell).toHaveAttribute('aria-pressed', 'false')
+      expect(tueCell).toHaveAttribute('aria-pressed', 'true')
+    })
+  })
+})

--- a/frontend/src/components/routes/ScheduleGrid/ScheduleGrid.tsx
+++ b/frontend/src/components/routes/ScheduleGrid/ScheduleGrid.tsx
@@ -1,0 +1,254 @@
+/**
+ * ScheduleGrid Component
+ *
+ * A grid-based UI for selecting time slots across days of the week.
+ * - Columns: Days of the week (Mon-Sun)
+ * - Rows: 15-minute time intervals (00:00-23:45)
+ * - Interaction: Click to toggle cells, drag to select ranges
+ *
+ * @see Issue #356: Simplify alerting time
+ */
+
+import { type GridSelection, type DayCode, type CellId, DAYS, DAY_LABELS } from './types'
+import { slotToTime } from './transforms'
+import { useScheduleGridState } from './hooks/useScheduleGridState'
+import { isSelected } from './selection'
+import { Card } from '../../ui/card'
+
+// Stable empty selection to avoid creating new Set instances on each render
+const EMPTY_SELECTION: GridSelection = new Set()
+
+export interface ScheduleGridProps {
+  /** Initial selection (e.g., loaded from existing schedules) */
+  initialSelection?: GridSelection
+
+  /** Callback when selection changes */
+  onChange: (selection: GridSelection) => void
+
+  /** Whether grid is disabled */
+  disabled?: boolean
+
+  /** CSS class name for container */
+  className?: string
+}
+
+/**
+ * Main schedule grid component
+ *
+ * Renders a 7×96 grid where users can select time slots by clicking or dragging.
+ *
+ * @example
+ * <ScheduleGrid
+ *   initialSelection={schedulesToGrid(route.schedules)}
+ *   onChange={(selection) => {
+ *     const schedules = gridToSchedules(selection)
+ *     // Save schedules...
+ *   }}
+ *   disabled={!isEditing}
+ * />
+ */
+export function ScheduleGrid({
+  initialSelection = EMPTY_SELECTION,
+  onChange,
+  disabled = false,
+  className = '',
+}: ScheduleGridProps) {
+  const {
+    previewSelection,
+    isDragging,
+    handleCellClick,
+    handleDragStart,
+    handleDragMove,
+    handleDragEnd,
+  } = useScheduleGridState({
+    initialSelection,
+    onChange,
+    disabled,
+  })
+
+  return (
+    <Card className={`p-4 ${className}`}>
+      <div className="overflow-x-auto">
+        <div className="inline-block min-w-full">
+          {/* Grid container - transposed: days as rows, time as columns */}
+          <div
+            className="relative"
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '60px repeat(96, 15px)', // 96 × 15px = 1440px for time slots
+              gridTemplateRows: 'auto repeat(7, 24px)', // Header + 7 days
+              gap: '0',
+            }}
+            onMouseLeave={() => {
+              if (isDragging) {
+                handleDragEnd()
+              }
+            }}
+          >
+            {/* Top-left corner cell */}
+            <div className="sticky top-0 left-0 z-20 bg-background border-b border-r border-border p-2 text-xs font-medium text-center">
+              Day
+            </div>
+
+            {/* Time headers (24 hour columns, each spanning 4 slots) */}
+            {Array.from({ length: 24 }, (_, hour) => {
+              const hourStr = hour.toString().padStart(2, '0')
+              return (
+                <div
+                  key={hour}
+                  className="sticky top-0 z-10 bg-background border-b border-l border-border text-xs text-center font-medium"
+                  style={{
+                    gridColumn: `span 4`, // Span 4 columns (4 × 15px = 60px)
+                    height: '24px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    fontSize: '11px',
+                  }}
+                >
+                  {hourStr}
+                </div>
+              )
+            })}
+
+            {/* Day rows */}
+            {DAYS.map((day) => (
+              <DayRow
+                key={day}
+                day={day}
+                previewSelection={previewSelection}
+                disabled={disabled}
+                isDragging={isDragging}
+                onCellClick={handleCellClick}
+                onCellMouseDown={handleDragStart}
+                onCellMouseEnter={handleDragMove}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+interface DayRowProps {
+  day: DayCode
+  previewSelection: GridSelection
+  disabled: boolean
+  isDragging: boolean
+  onCellClick: (cell: CellId) => void
+  onCellMouseDown: (cell: CellId) => void
+  onCellMouseEnter: (cell: CellId) => void
+}
+
+/**
+ * A single row of the grid (one day across all time slots)
+ */
+function DayRow({
+  day,
+  previewSelection,
+  disabled,
+  isDragging,
+  onCellClick,
+  onCellMouseDown,
+  onCellMouseEnter,
+}: DayRowProps) {
+  return (
+    <>
+      {/* Day label */}
+      <div
+        className="sticky left-0 z-10 bg-background border-r border-t border-border p-1 text-xs font-medium text-center"
+        style={{ height: '24px' }}
+      >
+        {DAY_LABELS[day]}
+      </div>
+
+      {/* Cells for each time slot */}
+      {Array.from({ length: 96 }, (_, slot) => {
+        const isHourMark = slot % 4 === 0
+        return (
+          <GridCell
+            key={`${day}:${slot}`}
+            day={day}
+            slot={slot}
+            isSelected={isSelected(previewSelection, { day, slot })}
+            isHourMark={isHourMark}
+            disabled={disabled}
+            isDragging={isDragging}
+            onClick={onCellClick}
+            onMouseDown={onCellMouseDown}
+            onMouseEnter={onCellMouseEnter}
+          />
+        )
+      })}
+    </>
+  )
+}
+
+interface GridCellProps {
+  day: DayCode
+  slot: number
+  isSelected: boolean
+  isHourMark: boolean
+  disabled: boolean
+  isDragging: boolean
+  onClick: (cell: CellId) => void
+  onMouseDown: (cell: CellId) => void
+  onMouseEnter: (cell: CellId) => void
+}
+
+/**
+ * A single grid cell
+ */
+function GridCell({
+  day,
+  slot,
+  isSelected,
+  isHourMark,
+  disabled,
+  isDragging,
+  onClick,
+  onMouseDown,
+  onMouseEnter,
+}: GridCellProps) {
+  const cell: CellId = { day, slot }
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault()
+    if (!isDragging) {
+      onClick(cell)
+    }
+  }
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    e.preventDefault()
+    onMouseDown(cell)
+  }
+
+  const handleMouseEnter = () => {
+    if (isDragging) {
+      onMouseEnter(cell)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className={`
+        border-border
+        ${isHourMark ? 'border-l' : 'border-l-0'}
+        border-t border-r-0 border-b
+        transition-colors
+        ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'}
+        ${isSelected ? 'bg-primary hover:bg-primary/90' : 'bg-background hover:bg-accent'}
+      `}
+      style={{ width: '15px', height: '24px' }}
+      onClick={handleClick}
+      onMouseDown={handleMouseDown}
+      onMouseEnter={handleMouseEnter}
+      disabled={disabled}
+      aria-label={`${DAY_LABELS[day]} ${slotToTime(slot)}`}
+      aria-pressed={isSelected}
+    />
+  )
+}

--- a/frontend/src/components/routes/ScheduleGrid/hooks/useScheduleGridState.test.ts
+++ b/frontend/src/components/routes/ScheduleGrid/hooks/useScheduleGridState.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useScheduleGridState } from './useScheduleGridState'
+
+describe('useScheduleGridState', () => {
+  describe('initial state', () => {
+    it('should initialize with empty selection by default', () => {
+      const { result } = renderHook(() => useScheduleGridState())
+
+      expect(result.current.selection.size).toBe(0)
+      expect(result.current.isDragging).toBe(false)
+      expect(result.current.dragStart).toBe(null)
+      expect(result.current.dragEnd).toBe(null)
+    })
+
+    it('should initialize with provided selection', () => {
+      const initialSelection = new Set(['MON:0', 'TUE:5'])
+      const { result } = renderHook(() => useScheduleGridState({ initialSelection }))
+
+      expect(result.current.selection).toEqual(initialSelection)
+    })
+
+    it('should update selection when initialSelection prop changes', () => {
+      const { result, rerender } = renderHook(
+        ({ initialSelection }) => useScheduleGridState({ initialSelection }),
+        {
+          initialProps: { initialSelection: new Set(['MON:0']) },
+        }
+      )
+
+      expect(result.current.selection.size).toBe(1)
+
+      rerender({ initialSelection: new Set(['TUE:5', 'WED:10']) })
+
+      expect(result.current.selection.size).toBe(2)
+      expect(result.current.selection.has('TUE:5')).toBe(true)
+      expect(result.current.selection.has('WED:10')).toBe(true)
+    })
+  })
+
+  describe('handleCellClick', () => {
+    it('should toggle cell on click', () => {
+      const { result } = renderHook(() => useScheduleGridState())
+
+      act(() => {
+        result.current.handleCellClick({ day: 'MON', slot: 0 })
+      })
+
+      expect(result.current.selection.has('MON:0')).toBe(true)
+
+      act(() => {
+        result.current.handleCellClick({ day: 'MON', slot: 0 })
+      })
+
+      expect(result.current.selection.has('MON:0')).toBe(false)
+    })
+
+    it('should call onChange callback', () => {
+      const onChange = vi.fn()
+      const { result } = renderHook(() => useScheduleGridState({ onChange }))
+
+      act(() => {
+        result.current.handleCellClick({ day: 'MON', slot: 0 })
+      })
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      const calledWith = onChange.mock.calls[0][0]
+      expect(calledWith.has('MON:0')).toBe(true)
+    })
+
+    it('should not change selection when disabled', () => {
+      const { result } = renderHook(() => useScheduleGridState({ disabled: true }))
+
+      act(() => {
+        result.current.handleCellClick({ day: 'MON', slot: 0 })
+      })
+
+      expect(result.current.selection.size).toBe(0)
+    })
+  })
+
+  describe('drag selection', () => {
+    it('should start drag on handleDragStart', () => {
+      const { result } = renderHook(() => useScheduleGridState())
+
+      act(() => {
+        result.current.handleDragStart({ day: 'MON', slot: 0 })
+      })
+
+      expect(result.current.isDragging).toBe(true)
+      expect(result.current.dragStart).toEqual({ day: 'MON', slot: 0 })
+      expect(result.current.dragEnd).toEqual({ day: 'MON', slot: 0 })
+    })
+
+    it('should update dragEnd on handleDragMove', () => {
+      const { result } = renderHook(() => useScheduleGridState())
+
+      act(() => {
+        result.current.handleDragStart({ day: 'MON', slot: 0 })
+      })
+
+      act(() => {
+        result.current.handleDragMove({ day: 'MON', slot: 5 })
+      })
+
+      expect(result.current.dragEnd).toEqual({ day: 'MON', slot: 5 })
+      expect(result.current.isDragging).toBe(true)
+    })
+
+    it('should not update dragEnd if not dragging', () => {
+      const { result } = renderHook(() => useScheduleGridState())
+
+      act(() => {
+        result.current.handleDragMove({ day: 'MON', slot: 5 })
+      })
+
+      expect(result.current.dragEnd).toBe(null)
+    })
+
+    it('should commit selection and reset drag state on handleDragEnd', () => {
+      const { result } = renderHook(() => useScheduleGridState())
+
+      act(() => {
+        result.current.handleDragStart({ day: 'MON', slot: 0 })
+      })
+
+      act(() => {
+        result.current.handleDragMove({ day: 'MON', slot: 2 })
+      })
+
+      act(() => {
+        result.current.handleDragEnd()
+      })
+
+      expect(result.current.isDragging).toBe(false)
+      expect(result.current.dragStart).toBe(null)
+      expect(result.current.dragEnd).toBe(null)
+      expect(result.current.selection.has('MON:0')).toBe(true)
+      expect(result.current.selection.has('MON:1')).toBe(true)
+      expect(result.current.selection.has('MON:2')).toBe(true)
+    })
+
+    it('should show preview selection during drag', () => {
+      const { result } = renderHook(() => useScheduleGridState())
+
+      act(() => {
+        result.current.handleDragStart({ day: 'MON', slot: 0 })
+      })
+
+      act(() => {
+        result.current.handleDragMove({ day: 'MON', slot: 2 })
+      })
+
+      // Preview should include drag range
+      expect(result.current.previewSelection.has('MON:0')).toBe(true)
+      expect(result.current.previewSelection.has('MON:1')).toBe(true)
+      expect(result.current.previewSelection.has('MON:2')).toBe(true)
+
+      // Actual selection not changed yet
+      expect(result.current.selection.size).toBe(0)
+    })
+
+    it('should add to existing selection when dragging', () => {
+      const initialSelection = new Set(['TUE:10'])
+      const { result } = renderHook(() => useScheduleGridState({ initialSelection }))
+
+      act(() => {
+        result.current.handleDragStart({ day: 'MON', slot: 0 })
+      })
+
+      act(() => {
+        result.current.handleDragMove({ day: 'MON', slot: 1 })
+      })
+
+      act(() => {
+        result.current.handleDragEnd()
+      })
+
+      // Should have both original and new selection
+      expect(result.current.selection.has('TUE:10')).toBe(true)
+      expect(result.current.selection.has('MON:0')).toBe(true)
+      expect(result.current.selection.has('MON:1')).toBe(true)
+    })
+
+    it('should not start drag when disabled', () => {
+      const { result } = renderHook(() => useScheduleGridState({ disabled: true }))
+
+      act(() => {
+        result.current.handleDragStart({ day: 'MON', slot: 0 })
+      })
+
+      expect(result.current.isDragging).toBe(false)
+    })
+
+    it('should not update drag when disabled mid-drag', () => {
+      const { result, rerender } = renderHook(
+        ({ disabled }) => useScheduleGridState({ disabled }),
+        { initialProps: { disabled: false } }
+      )
+
+      act(() => {
+        result.current.handleDragStart({ day: 'MON', slot: 0 })
+      })
+
+      rerender({ disabled: true })
+
+      act(() => {
+        result.current.handleDragMove({ day: 'MON', slot: 5 })
+      })
+
+      expect(result.current.dragEnd).toEqual({ day: 'MON', slot: 0 })
+    })
+
+    it('should call onChange on drag end', () => {
+      const onChange = vi.fn()
+      const { result } = renderHook(() => useScheduleGridState({ onChange }))
+
+      act(() => {
+        result.current.handleDragStart({ day: 'MON', slot: 0 })
+      })
+
+      act(() => {
+        result.current.handleDragMove({ day: 'MON', slot: 2 })
+      })
+
+      act(() => {
+        result.current.handleDragEnd()
+      })
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      const calledWith = onChange.mock.calls[0][0]
+      expect(calledWith.has('MON:0')).toBe(true)
+      expect(calledWith.has('MON:1')).toBe(true)
+      expect(calledWith.has('MON:2')).toBe(true)
+    })
+  })
+
+  describe('setSelection', () => {
+    it('should update selection programmatically', () => {
+      const { result } = renderHook(() => useScheduleGridState())
+
+      const newSelection = new Set(['MON:0', 'TUE:5'])
+      act(() => {
+        result.current.setSelection(newSelection)
+      })
+
+      expect(result.current.selection).toEqual(newSelection)
+    })
+
+    it('should call onChange when set programmatically', () => {
+      const onChange = vi.fn()
+      const { result } = renderHook(() => useScheduleGridState({ onChange }))
+
+      const newSelection = new Set(['MON:0'])
+      act(() => {
+        result.current.setSelection(newSelection)
+      })
+
+      expect(onChange).toHaveBeenCalledWith(newSelection)
+    })
+  })
+
+  describe('previewSelection', () => {
+    it('should equal selection when not dragging', () => {
+      const initialSelection = new Set(['MON:0'])
+      const { result } = renderHook(() => useScheduleGridState({ initialSelection }))
+
+      expect(result.current.previewSelection).toEqual(result.current.selection)
+    })
+
+    it('should include drag range when dragging', () => {
+      const { result } = renderHook(() => useScheduleGridState())
+
+      act(() => {
+        result.current.handleDragStart({ day: 'MON', slot: 0 })
+      })
+
+      act(() => {
+        result.current.handleDragMove({ day: 'TUE', slot: 2 })
+      })
+
+      // Preview should include entire rectangular range
+      expect(result.current.previewSelection.size).toBeGreaterThan(0)
+      expect(result.current.previewSelection.has('MON:0')).toBe(true)
+      expect(result.current.previewSelection.has('TUE:2')).toBe(true)
+    })
+
+    it('should return to normal selection after drag ends', () => {
+      const { result } = renderHook(() => useScheduleGridState())
+
+      act(() => {
+        result.current.handleDragStart({ day: 'MON', slot: 0 })
+      })
+
+      act(() => {
+        result.current.handleDragMove({ day: 'MON', slot: 2 })
+      })
+
+      const previewDuringDrag = result.current.previewSelection
+
+      act(() => {
+        result.current.handleDragEnd()
+      })
+
+      // After drag, preview should equal committed selection
+      expect(result.current.previewSelection).toEqual(result.current.selection)
+      expect(result.current.previewSelection.size).toBe(previewDuringDrag.size)
+    })
+  })
+})

--- a/frontend/src/components/routes/ScheduleGrid/hooks/useScheduleGridState.ts
+++ b/frontend/src/components/routes/ScheduleGrid/hooks/useScheduleGridState.ts
@@ -1,0 +1,229 @@
+/**
+ * Custom hook for managing schedule grid state
+ *
+ * This hook integrates the pure functions for grid selection and drag handling.
+ * It manages:
+ * - Selection state
+ * - Drag selection state (start cell, current cell, is dragging)
+ * - Event handlers for click and drag interactions
+ *
+ * @see ADR 11: Frontend State Management Pattern
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react'
+import { type GridSelection, type CellId } from '../types'
+import { toggleCell, selectRange, isSelected } from '../selection'
+
+export interface UseScheduleGridStateOptions {
+  /** Initial selection (e.g., loaded from API) */
+  initialSelection?: GridSelection
+  /** Callback when selection changes */
+  onChange?: (selection: GridSelection) => void
+  /** Whether grid is disabled */
+  disabled?: boolean
+}
+
+export interface UseScheduleGridStateReturn {
+  /** Current selection */
+  selection: GridSelection
+
+  /** Whether user is currently dragging to select */
+  isDragging: boolean
+
+  /** Drag start cell (null when not dragging) */
+  dragStart: CellId | null
+
+  /** Current drag end cell (null when not dragging) */
+  dragEnd: CellId | null
+
+  /** Preview selection during drag (includes original selection + drag range) */
+  previewSelection: GridSelection
+
+  /** Handle cell click (toggle single cell) */
+  handleCellClick: (cell: CellId) => void
+
+  /** Handle drag start (mouse down on cell) */
+  handleDragStart: (cell: CellId) => void
+
+  /** Handle drag move (mouse move over cell while dragging) */
+  handleDragMove: (cell: CellId) => void
+
+  /** Handle drag end (mouse up) */
+  handleDragEnd: () => void
+
+  /** Programmatically set selection */
+  setSelection: (selection: GridSelection) => void
+}
+
+/**
+ * Hook for managing schedule grid state and drag selection
+ *
+ * @param options Configuration options
+ * @returns State and handlers for grid interaction
+ *
+ * @example
+ * const {
+ *   selection,
+ *   isDragging,
+ *   previewSelection,
+ *   handleCellClick,
+ *   handleDragStart,
+ *   handleDragMove,
+ *   handleDragEnd
+ * } = useScheduleGridState({
+ *   initialSelection: schedulesToGrid(schedules),
+ *   onChange: (sel) => console.log('Selection changed', sel)
+ * })
+ */
+export function useScheduleGridState(
+  options: UseScheduleGridStateOptions = {}
+): UseScheduleGridStateReturn {
+  const { initialSelection = new Set(), onChange, disabled = false } = options
+
+  // Selection state
+  const [selection, setSelectionInternal] = useState<GridSelection>(initialSelection)
+
+  // Drag state
+  const [isDragging, setIsDragging] = useState(false)
+  const [dragStart, setDragStart] = useState<CellId | null>(null)
+  const [dragEnd, setDragEnd] = useState<CellId | null>(null)
+  const [dragMode, setDragMode] = useState<'add' | 'remove'>('add')
+
+  // Notify parent of selection changes
+  const setSelection = useCallback(
+    (newSelection: GridSelection) => {
+      setSelectionInternal(newSelection)
+      onChange?.(newSelection)
+    },
+    [onChange]
+  )
+
+  // Track previous initialSelection to detect changes by content, not reference
+  const prevInitialSelection = useRef(initialSelection)
+
+  // Update selection when initialSelection changes (compare Set contents, not reference)
+  useEffect(() => {
+    const prev = prevInitialSelection.current
+
+    // Check if contents have changed
+    let hasChanged = false
+    if (prev.size !== initialSelection.size) {
+      hasChanged = true
+    } else {
+      // Check if all items are the same
+      for (const item of initialSelection) {
+        if (!prev.has(item)) {
+          hasChanged = true
+          break
+        }
+      }
+    }
+
+    if (hasChanged) {
+      setSelectionInternal(initialSelection)
+      prevInitialSelection.current = initialSelection
+    }
+  }, [initialSelection])
+
+  // Calculate preview selection during drag
+  const previewSelection =
+    isDragging && dragStart && dragEnd
+      ? selectRange(selection, dragStart, dragEnd, dragMode)
+      : selection
+
+  // Handle single cell click (toggle)
+  const handleCellClick = useCallback(
+    (cell: CellId) => {
+      if (disabled) return
+
+      const newSelection = toggleCell(selection, cell)
+      setSelection(newSelection)
+    },
+    [selection, setSelection, disabled]
+  )
+
+  // Handle drag start
+  const handleDragStart = useCallback(
+    (cell: CellId) => {
+      if (disabled) return
+
+      // Determine drag mode: if starting cell is selected, we're removing; otherwise adding
+      const mode = isSelected(selection, cell) ? 'remove' : 'add'
+
+      setIsDragging(true)
+      setDragStart(cell)
+      setDragEnd(cell)
+      setDragMode(mode)
+    },
+    [disabled, selection]
+  )
+
+  // Handle drag move
+  const handleDragMove = useCallback(
+    (cell: CellId) => {
+      if (!isDragging || disabled) return
+
+      setDragEnd(cell)
+    },
+    [isDragging, disabled]
+  )
+
+  // Handle drag end
+  const handleDragEnd = useCallback(() => {
+    if (!isDragging || disabled) return
+
+    // Only commit if it's a real drag (more than one cell)
+    // Single-cell "drags" are handled by handleCellClick
+    if (dragStart && dragEnd) {
+      const isSingleCell = dragStart.day === dragEnd.day && dragStart.slot === dragEnd.slot
+
+      if (!isSingleCell) {
+        // Commit the drag selection using the determined mode
+        const newSelection = selectRange(selection, dragStart, dragEnd, dragMode)
+        setSelection(newSelection)
+      }
+    }
+
+    // Reset drag state
+    setIsDragging(false)
+    setDragStart(null)
+    setDragEnd(null)
+    setDragMode('add')
+  }, [isDragging, dragStart, dragEnd, dragMode, selection, setSelection, disabled])
+
+  // Store handleDragEnd in a ref to avoid dependency cascade in useEffect
+  const handleDragEndRef = useRef(handleDragEnd)
+  useEffect(() => {
+    handleDragEndRef.current = handleDragEnd
+  }, [handleDragEnd])
+
+  // Handle mouse up globally to end drag even if cursor leaves grid
+  useEffect(() => {
+    if (!isDragging) return
+
+    const handleGlobalMouseUp = () => {
+      handleDragEndRef.current()
+    }
+
+    window.addEventListener('mouseup', handleGlobalMouseUp)
+    window.addEventListener('touchend', handleGlobalMouseUp)
+
+    return () => {
+      window.removeEventListener('mouseup', handleGlobalMouseUp)
+      window.removeEventListener('touchend', handleGlobalMouseUp)
+    }
+  }, [isDragging])
+
+  return {
+    selection,
+    isDragging,
+    dragStart,
+    dragEnd,
+    previewSelection,
+    handleCellClick,
+    handleDragStart,
+    handleDragMove,
+    handleDragEnd,
+    setSelection,
+  }
+}

--- a/frontend/src/components/routes/ScheduleGrid/index.ts
+++ b/frontend/src/components/routes/ScheduleGrid/index.ts
@@ -1,0 +1,52 @@
+/**
+ * ScheduleGrid component barrel export
+ *
+ * Provides clean imports for the schedule grid component and related utilities.
+ */
+
+export { ScheduleGrid } from './ScheduleGrid'
+export type { ScheduleGridProps } from './ScheduleGrid'
+
+export { useScheduleGridState } from './hooks/useScheduleGridState'
+export type {
+  UseScheduleGridStateOptions,
+  UseScheduleGridStateReturn,
+} from './hooks/useScheduleGridState'
+
+export {
+  type DayCode,
+  type TimeSlotIndex,
+  type CellId,
+  type GridSelection,
+  type TimeBlock,
+  type ValidationResult,
+  DAYS,
+  DAY_LABELS,
+  SLOTS_PER_DAY,
+  MINUTES_PER_SLOT,
+  cellKey,
+  parseKey,
+} from './types'
+
+export {
+  slotToTime,
+  timeToSlot,
+  selectionToBlocks,
+  gridToSchedules,
+  schedulesToGrid,
+} from './transforms'
+
+export {
+  toggleCell,
+  isSelected,
+  selectRange,
+  clearSelection,
+  selectDay,
+  deselectDay,
+  selectTimeSlot,
+  deselectTimeSlot,
+  isDaySelected,
+  isTimeSlotSelected,
+} from './selection'
+
+export { validateNotEmpty, validateMaxSchedules, validateAll } from './validation'

--- a/frontend/src/components/routes/ScheduleGrid/selection.test.ts
+++ b/frontend/src/components/routes/ScheduleGrid/selection.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect } from 'vitest'
+import {
+  toggleCell,
+  isSelected,
+  selectRange,
+  clearSelection,
+  selectDay,
+  deselectDay,
+  selectTimeSlot,
+  deselectTimeSlot,
+  isDaySelected,
+  isTimeSlotSelected,
+} from './selection'
+
+describe('ScheduleGrid selection', () => {
+  describe('toggleCell', () => {
+    it('should add cell if not in selection', () => {
+      const selection = new Set<string>()
+      const result = toggleCell(selection, { day: 'MON', slot: 0 })
+      expect(result.has('MON:0')).toBe(true)
+    })
+
+    it('should remove cell if in selection', () => {
+      const selection = new Set(['MON:0'])
+      const result = toggleCell(selection, { day: 'MON', slot: 0 })
+      expect(result.has('MON:0')).toBe(false)
+      expect(result.size).toBe(0)
+    })
+
+    it('should return new Set (immutable)', () => {
+      const selection = new Set<string>()
+      const result = toggleCell(selection, { day: 'MON', slot: 0 })
+      expect(result).not.toBe(selection)
+      expect(selection.size).toBe(0) // Original unchanged
+    })
+
+    it('should not affect other cells', () => {
+      const selection = new Set(['TUE:5'])
+      const result = toggleCell(selection, { day: 'MON', slot: 0 })
+      expect(result.has('TUE:5')).toBe(true)
+      expect(result.has('MON:0')).toBe(true)
+      expect(result.size).toBe(2)
+    })
+  })
+
+  describe('isSelected', () => {
+    it('should return true for selected cell', () => {
+      const selection = new Set(['MON:0', 'TUE:5'])
+      expect(isSelected(selection, { day: 'MON', slot: 0 })).toBe(true)
+      expect(isSelected(selection, { day: 'TUE', slot: 5 })).toBe(true)
+    })
+
+    it('should return false for unselected cell', () => {
+      const selection = new Set(['MON:0'])
+      expect(isSelected(selection, { day: 'TUE', slot: 0 })).toBe(false)
+      expect(isSelected(selection, { day: 'MON', slot: 1 })).toBe(false)
+    })
+
+    it('should return false for empty selection', () => {
+      const selection = new Set<string>()
+      expect(isSelected(selection, { day: 'MON', slot: 0 })).toBe(false)
+    })
+  })
+
+  describe('selectRange', () => {
+    it('should select rectangular range (add mode)', () => {
+      const selection = new Set<string>()
+      const result = selectRange(selection, { day: 'MON', slot: 0 }, { day: 'TUE', slot: 2 }, 'add')
+
+      // Should have MON:0, MON:1, MON:2, TUE:0, TUE:1, TUE:2
+      expect(result.size).toBe(6)
+      expect(result.has('MON:0')).toBe(true)
+      expect(result.has('MON:1')).toBe(true)
+      expect(result.has('MON:2')).toBe(true)
+      expect(result.has('TUE:0')).toBe(true)
+      expect(result.has('TUE:1')).toBe(true)
+      expect(result.has('TUE:2')).toBe(true)
+    })
+
+    it('should handle reverse order (end before start)', () => {
+      const selection = new Set<string>()
+      const result = selectRange(selection, { day: 'TUE', slot: 2 }, { day: 'MON', slot: 0 }, 'add')
+
+      // Should still select the rectangle
+      expect(result.size).toBe(6)
+      expect(result.has('MON:0')).toBe(true)
+      expect(result.has('TUE:2')).toBe(true)
+    })
+
+    it('should select single cell when start equals end', () => {
+      const selection = new Set<string>()
+      const result = selectRange(selection, { day: 'MON', slot: 5 }, { day: 'MON', slot: 5 }, 'add')
+
+      expect(result.size).toBe(1)
+      expect(result.has('MON:5')).toBe(true)
+    })
+
+    it('should remove cells in remove mode', () => {
+      const selection = new Set(['MON:0', 'MON:1', 'TUE:0', 'TUE:1'])
+      const result = selectRange(
+        selection,
+        { day: 'MON', slot: 0 },
+        { day: 'MON', slot: 1 },
+        'remove'
+      )
+
+      expect(result.size).toBe(2)
+      expect(result.has('MON:0')).toBe(false)
+      expect(result.has('MON:1')).toBe(false)
+      expect(result.has('TUE:0')).toBe(true)
+      expect(result.has('TUE:1')).toBe(true)
+    })
+
+    it('should toggle cells in toggle mode', () => {
+      const selection = new Set(['MON:0', 'MON:1'])
+      const result = selectRange(
+        selection,
+        { day: 'MON', slot: 1 },
+        { day: 'MON', slot: 2 },
+        'toggle'
+      )
+
+      // MON:1 was selected, so it's removed
+      // MON:2 was not selected, so it's added
+      // MON:0 remains selected (not in range)
+      expect(result.size).toBe(2)
+      expect(result.has('MON:0')).toBe(true)
+      expect(result.has('MON:1')).toBe(false)
+      expect(result.has('MON:2')).toBe(true)
+    })
+
+    it('should handle multi-day range', () => {
+      const selection = new Set<string>()
+      const result = selectRange(
+        selection,
+        { day: 'THU', slot: 48 },
+        { day: 'SUN', slot: 50 },
+        'add'
+      )
+
+      // Should select THU, FRI, SAT, SUN for slots 48, 49, 50
+      expect(result.size).toBe(4 * 3) // 4 days × 3 slots
+      expect(result.has('THU:48')).toBe(true)
+      expect(result.has('FRI:49')).toBe(true)
+      expect(result.has('SAT:50')).toBe(true)
+      expect(result.has('SUN:48')).toBe(true)
+    })
+
+    it('should default to add mode', () => {
+      const selection = new Set<string>()
+      const result = selectRange(selection, { day: 'MON', slot: 0 }, { day: 'MON', slot: 1 })
+
+      expect(result.size).toBe(2)
+      expect(result.has('MON:0')).toBe(true)
+      expect(result.has('MON:1')).toBe(true)
+    })
+  })
+
+  describe('clearSelection', () => {
+    it('should return empty set', () => {
+      const result = clearSelection()
+      expect(result.size).toBe(0)
+      expect(result).toEqual(new Set())
+    })
+  })
+
+  describe('selectDay', () => {
+    it('should select all slots for a day', () => {
+      const selection = new Set<string>()
+      const result = selectDay(selection, 'MON')
+
+      expect(result.size).toBe(96)
+      expect(result.has('MON:0')).toBe(true)
+      expect(result.has('MON:47')).toBe(true)
+      expect(result.has('MON:95')).toBe(true)
+    })
+
+    it('should add to existing selection', () => {
+      const selection = new Set(['TUE:0'])
+      const result = selectDay(selection, 'MON')
+
+      expect(result.size).toBe(97) // 96 + 1
+      expect(result.has('TUE:0')).toBe(true)
+    })
+
+    it('should be idempotent', () => {
+      const selection = new Set<string>()
+      const result1 = selectDay(selection, 'MON')
+      const result2 = selectDay(result1, 'MON')
+
+      expect(result2.size).toBe(96)
+      expect(result2).toEqual(result1)
+    })
+  })
+
+  describe('deselectDay', () => {
+    it('should remove all slots for a day', () => {
+      const selection = new Set(['MON:0', 'MON:1', 'TUE:0'])
+      const result = deselectDay(selection, 'MON')
+
+      expect(result.size).toBe(1)
+      expect(result.has('MON:0')).toBe(false)
+      expect(result.has('MON:1')).toBe(false)
+      expect(result.has('TUE:0')).toBe(true)
+    })
+
+    it('should work on empty selection', () => {
+      const selection = new Set<string>()
+      const result = deselectDay(selection, 'MON')
+
+      expect(result.size).toBe(0)
+    })
+
+    it('should be idempotent', () => {
+      const selection = selectDay(new Set(), 'MON')
+      const result1 = deselectDay(selection, 'MON')
+      const result2 = deselectDay(result1, 'MON')
+
+      expect(result2.size).toBe(0)
+      expect(result2).toEqual(result1)
+    })
+  })
+
+  describe('selectTimeSlot', () => {
+    it('should select slot across all days', () => {
+      const selection = new Set<string>()
+      const result = selectTimeSlot(selection, 48) // 12:00
+
+      expect(result.size).toBe(7)
+      expect(result.has('MON:48')).toBe(true)
+      expect(result.has('TUE:48')).toBe(true)
+      expect(result.has('WED:48')).toBe(true)
+      expect(result.has('THU:48')).toBe(true)
+      expect(result.has('FRI:48')).toBe(true)
+      expect(result.has('SAT:48')).toBe(true)
+      expect(result.has('SUN:48')).toBe(true)
+    })
+
+    it('should add to existing selection', () => {
+      const selection = new Set(['MON:0'])
+      const result = selectTimeSlot(selection, 48)
+
+      expect(result.size).toBe(8) // 1 + 7
+    })
+
+    it('should be idempotent', () => {
+      const selection = new Set<string>()
+      const result1 = selectTimeSlot(selection, 48)
+      const result2 = selectTimeSlot(result1, 48)
+
+      expect(result2.size).toBe(7)
+      expect(result2).toEqual(result1)
+    })
+  })
+
+  describe('deselectTimeSlot', () => {
+    it('should remove slot from all days', () => {
+      const selection = new Set(['MON:48', 'TUE:48', 'MON:0'])
+      const result = deselectTimeSlot(selection, 48)
+
+      expect(result.size).toBe(1)
+      expect(result.has('MON:48')).toBe(false)
+      expect(result.has('TUE:48')).toBe(false)
+      expect(result.has('MON:0')).toBe(true)
+    })
+
+    it('should work on empty selection', () => {
+      const selection = new Set<string>()
+      const result = deselectTimeSlot(selection, 48)
+
+      expect(result.size).toBe(0)
+    })
+  })
+
+  describe('isDaySelected', () => {
+    it('should return true when all slots for day are selected', () => {
+      const selection = selectDay(new Set(), 'MON')
+      expect(isDaySelected(selection, 'MON')).toBe(true)
+    })
+
+    it('should return false when any slot is missing', () => {
+      const selection = selectDay(new Set(), 'MON')
+      selection.delete('MON:0')
+      expect(isDaySelected(selection, 'MON')).toBe(false)
+    })
+
+    it('should return false for empty selection', () => {
+      const selection = new Set<string>()
+      expect(isDaySelected(selection, 'MON')).toBe(false)
+    })
+  })
+
+  describe('isTimeSlotSelected', () => {
+    it('should return true when slot selected for all days', () => {
+      const selection = selectTimeSlot(new Set(), 48)
+      expect(isTimeSlotSelected(selection, 48)).toBe(true)
+    })
+
+    it('should return false when any day is missing the slot', () => {
+      const selection = selectTimeSlot(new Set(), 48)
+      selection.delete('MON:48')
+      expect(isTimeSlotSelected(selection, 48)).toBe(false)
+    })
+
+    it('should return false for empty selection', () => {
+      const selection = new Set<string>()
+      expect(isTimeSlotSelected(selection, 48)).toBe(false)
+    })
+  })
+
+  describe('immutability', () => {
+    it('all functions should return new Set instances', () => {
+      const original = new Set(['MON:0'])
+
+      const toggled = toggleCell(original, { day: 'TUE', slot: 0 })
+      expect(toggled).not.toBe(original)
+
+      const ranged = selectRange(original, { day: 'MON', slot: 1 }, { day: 'MON', slot: 2 })
+      expect(ranged).not.toBe(original)
+
+      const daySelected = selectDay(original, 'TUE')
+      expect(daySelected).not.toBe(original)
+
+      const dayDeselected = deselectDay(original, 'MON')
+      expect(dayDeselected).not.toBe(original)
+
+      const slotSelected = selectTimeSlot(original, 10)
+      expect(slotSelected).not.toBe(original)
+
+      const slotDeselected = deselectTimeSlot(original, 0)
+      expect(slotDeselected).not.toBe(original)
+    })
+  })
+})

--- a/frontend/src/components/routes/ScheduleGrid/selection.ts
+++ b/frontend/src/components/routes/ScheduleGrid/selection.ts
@@ -1,0 +1,277 @@
+/**
+ * Pure functions for manipulating grid selection state
+ *
+ * These functions handle all selection operations:
+ * - Toggle single cells
+ * - Select rectangular ranges (for drag selection)
+ * - Bulk operations (select all, clear all)
+ *
+ * All functions return new Set instances (immutable updates).
+ *
+ * @see ADR 11: Frontend State Management Pattern
+ */
+
+import {
+  type GridSelection,
+  type CellId,
+  type DayCode,
+  type TimeSlotIndex,
+  DAYS,
+  cellKey,
+} from './types'
+
+/**
+ * Toggle a single cell's selection state
+ *
+ * If the cell is currently selected, it will be deselected.
+ * If the cell is not selected, it will be selected.
+ *
+ * @param selection Current grid selection
+ * @param cell Cell to toggle
+ * @returns New grid selection with cell toggled
+ *
+ * @example
+ * const selection = new Set(['MON:0'])
+ * toggleCell(selection, { day: 'MON', slot: 0 })
+ * // => Set([]) (cell was removed)
+ *
+ * toggleCell(selection, { day: 'TUE', slot: 5 })
+ * // => Set(['MON:0', 'TUE:5']) (cell was added)
+ */
+export function toggleCell(selection: GridSelection, cell: CellId): GridSelection {
+  const newSelection = new Set(selection)
+  const key = cellKey(cell.day, cell.slot)
+
+  if (newSelection.has(key)) {
+    newSelection.delete(key)
+  } else {
+    newSelection.add(key)
+  }
+
+  return newSelection
+}
+
+/**
+ * Check if a cell is currently selected
+ *
+ * @param selection Current grid selection
+ * @param cell Cell to check
+ * @returns True if cell is selected, false otherwise
+ *
+ * @example
+ * const selection = new Set(['MON:0', 'TUE:5'])
+ * isSelected(selection, { day: 'MON', slot: 0 }) // => true
+ * isSelected(selection, { day: 'WED', slot: 10 }) // => false
+ */
+export function isSelected(selection: GridSelection, cell: CellId): boolean {
+  return selection.has(cellKey(cell.day, cell.slot))
+}
+
+/**
+ * Select mode for range selection
+ *
+ * - 'add': Add all cells in range to selection
+ * - 'remove': Remove all cells in range from selection
+ * - 'toggle': Toggle each cell in range individually
+ */
+export type SelectMode = 'add' | 'remove' | 'toggle'
+
+/**
+ * Select a rectangular range of cells
+ *
+ * Used for drag selection. Selects all cells in the rectangular region
+ * defined by start and end cells.
+ *
+ * @param selection Current grid selection
+ * @param start Start cell (one corner of rectangle)
+ * @param end End cell (opposite corner of rectangle)
+ * @param mode Selection mode ('add', 'remove', or 'toggle')
+ * @returns New grid selection with range applied
+ *
+ * @example
+ * const selection = new Set()
+ * const start = { day: 'MON', slot: 0 }
+ * const end = { day: 'TUE', slot: 2 }
+ * selectRange(selection, start, end, 'add')
+ * // => Set(['MON:0', 'MON:1', 'MON:2', 'TUE:0', 'TUE:1', 'TUE:2'])
+ */
+export function selectRange(
+  selection: GridSelection,
+  start: CellId,
+  end: CellId,
+  mode: SelectMode = 'add'
+): GridSelection {
+  const newSelection = new Set(selection)
+
+  // Determine day range
+  const startDayIndex = DAYS.indexOf(start.day)
+  const endDayIndex = DAYS.indexOf(end.day)
+  const minDayIndex = Math.min(startDayIndex, endDayIndex)
+  const maxDayIndex = Math.max(startDayIndex, endDayIndex)
+
+  // Determine slot range
+  const minSlot = Math.min(start.slot, end.slot)
+  const maxSlot = Math.max(start.slot, end.slot)
+
+  // Apply operation to all cells in range
+  for (let dayIndex = minDayIndex; dayIndex <= maxDayIndex; dayIndex++) {
+    const day = DAYS[dayIndex]
+    for (let slot = minSlot; slot <= maxSlot; slot++) {
+      const key = cellKey(day, slot)
+
+      if (mode === 'add') {
+        newSelection.add(key)
+      } else if (mode === 'remove') {
+        newSelection.delete(key)
+      } else if (mode === 'toggle') {
+        if (newSelection.has(key)) {
+          newSelection.delete(key)
+        } else {
+          newSelection.add(key)
+        }
+      }
+    }
+  }
+
+  return newSelection
+}
+
+/**
+ * Clear all selections
+ *
+ * @returns Empty grid selection
+ *
+ * @example
+ * clearSelection() // => Set([])
+ */
+export function clearSelection(): GridSelection {
+  return new Set()
+}
+
+/**
+ * Select all cells for a specific day
+ *
+ * @param selection Current grid selection
+ * @param day Day to select
+ * @returns New grid selection with all cells for day selected
+ *
+ * @example
+ * const selection = new Set()
+ * selectDay(selection, 'MON')
+ * // => Set(['MON:0', 'MON:1', ..., 'MON:95'])
+ */
+export function selectDay(selection: GridSelection, day: DayCode): GridSelection {
+  const newSelection = new Set(selection)
+
+  for (let slot = 0; slot < 96; slot++) {
+    newSelection.add(cellKey(day, slot))
+  }
+
+  return newSelection
+}
+
+/**
+ * Deselect all cells for a specific day
+ *
+ * @param selection Current grid selection
+ * @param day Day to deselect
+ * @returns New grid selection with all cells for day removed
+ *
+ * @example
+ * const selection = new Set(['MON:0', 'MON:1', 'TUE:5'])
+ * deselectDay(selection, 'MON')
+ * // => Set(['TUE:5'])
+ */
+export function deselectDay(selection: GridSelection, day: DayCode): GridSelection {
+  const newSelection = new Set(selection)
+
+  for (let slot = 0; slot < 96; slot++) {
+    newSelection.delete(cellKey(day, slot))
+  }
+
+  return newSelection
+}
+
+/**
+ * Select a specific time slot across all days
+ *
+ * @param selection Current grid selection
+ * @param slot Time slot to select
+ * @returns New grid selection with slot selected for all days
+ *
+ * @example
+ * const selection = new Set()
+ * selectTimeSlot(selection, 48) // 12:00
+ * // => Set(['MON:48', 'TUE:48', 'WED:48', 'THU:48', 'FRI:48', 'SAT:48', 'SUN:48'])
+ */
+export function selectTimeSlot(selection: GridSelection, slot: TimeSlotIndex): GridSelection {
+  const newSelection = new Set(selection)
+
+  for (const day of DAYS) {
+    newSelection.add(cellKey(day, slot))
+  }
+
+  return newSelection
+}
+
+/**
+ * Deselect a specific time slot across all days
+ *
+ * @param selection Current grid selection
+ * @param slot Time slot to deselect
+ * @returns New grid selection with slot removed from all days
+ *
+ * @example
+ * const selection = new Set(['MON:48', 'TUE:48', 'TUE:49'])
+ * deselectTimeSlot(selection, 48)
+ * // => Set(['TUE:49'])
+ */
+export function deselectTimeSlot(selection: GridSelection, slot: TimeSlotIndex): GridSelection {
+  const newSelection = new Set(selection)
+
+  for (const day of DAYS) {
+    newSelection.delete(cellKey(day, slot))
+  }
+
+  return newSelection
+}
+
+/**
+ * Check if an entire day is selected
+ *
+ * @param selection Current grid selection
+ * @param day Day to check
+ * @returns True if all slots for the day are selected
+ *
+ * @example
+ * const selection = new Set(['MON:0', 'MON:1', ..., 'MON:95'])
+ * isDaySelected(selection, 'MON') // => true
+ */
+export function isDaySelected(selection: GridSelection, day: DayCode): boolean {
+  for (let slot = 0; slot < 96; slot++) {
+    if (!selection.has(cellKey(day, slot))) {
+      return false
+    }
+  }
+  return true
+}
+
+/**
+ * Check if a time slot is selected across all days
+ *
+ * @param selection Current grid selection
+ * @param slot Time slot to check
+ * @returns True if slot is selected for all days
+ *
+ * @example
+ * const selection = new Set(['MON:48', 'TUE:48', ..., 'SUN:48'])
+ * isTimeSlotSelected(selection, 48) // => true
+ */
+export function isTimeSlotSelected(selection: GridSelection, slot: TimeSlotIndex): boolean {
+  for (const day of DAYS) {
+    if (!selection.has(cellKey(day, slot))) {
+      return false
+    }
+  }
+  return true
+}

--- a/frontend/src/components/routes/ScheduleGrid/transforms.test.ts
+++ b/frontend/src/components/routes/ScheduleGrid/transforms.test.ts
@@ -1,0 +1,347 @@
+import { describe, it, expect } from 'vitest'
+import {
+  slotToTime,
+  timeToSlot,
+  selectionToBlocks,
+  gridToSchedules,
+  schedulesToGrid,
+} from './transforms'
+import type { ScheduleResponse } from './types'
+
+describe('ScheduleGrid transforms', () => {
+  describe('slotToTime', () => {
+    it('should convert slot 0 to 00:00:00', () => {
+      expect(slotToTime(0)).toBe('00:00:00')
+    })
+
+    it('should convert slot 1 to 00:15:00', () => {
+      expect(slotToTime(1)).toBe('00:15:00')
+    })
+
+    it('should convert slot 4 to 01:00:00', () => {
+      expect(slotToTime(4)).toBe('01:00:00')
+    })
+
+    it('should convert slot 48 to 12:00:00', () => {
+      expect(slotToTime(48)).toBe('12:00:00')
+    })
+
+    it('should convert slot 95 to 23:45:00', () => {
+      expect(slotToTime(95)).toBe('23:45:00')
+    })
+
+    it('should pad single digit hours and minutes', () => {
+      expect(slotToTime(2)).toBe('00:30:00') // 00:30
+      expect(slotToTime(5)).toBe('01:15:00') // 01:15
+      expect(slotToTime(36)).toBe('09:00:00') // 09:00
+    })
+  })
+
+  describe('timeToSlot', () => {
+    it('should convert 00:00:00 to slot 0', () => {
+      expect(timeToSlot('00:00:00')).toBe(0)
+    })
+
+    it('should convert 00:15:00 to slot 1', () => {
+      expect(timeToSlot('00:15:00')).toBe(1)
+    })
+
+    it('should convert 01:00:00 to slot 4', () => {
+      expect(timeToSlot('01:00:00')).toBe(4)
+    })
+
+    it('should convert 12:00:00 to slot 48', () => {
+      expect(timeToSlot('12:00:00')).toBe(48)
+    })
+
+    it('should convert 23:45:00 to slot 95', () => {
+      expect(timeToSlot('23:45:00')).toBe(95)
+    })
+
+    it('should round down non-15-minute times', () => {
+      expect(timeToSlot('09:22:00')).toBe(37) // Rounds down to 09:15 (slot 37)
+      expect(timeToSlot('14:59:00')).toBe(59) // Rounds down to 14:45 (slot 59)
+      expect(timeToSlot('10:07:00')).toBe(40) // Rounds down to 10:00 (slot 40)
+    })
+
+    it('should be inverse of slotToTime for valid 15-minute intervals', () => {
+      for (let slot = 0; slot < 96; slot++) {
+        const time = slotToTime(slot)
+        expect(timeToSlot(time)).toBe(slot)
+      }
+    })
+  })
+
+  describe('selectionToBlocks', () => {
+    it('should return empty array for empty selection', () => {
+      const selection = new Set<string>()
+      expect(selectionToBlocks(selection)).toEqual([])
+    })
+
+    it('should create single block for contiguous selection', () => {
+      const selection = new Set(['MON:0', 'MON:1', 'MON:2'])
+      const blocks = selectionToBlocks(selection)
+      expect(blocks).toEqual([{ day: 'MON', startSlot: 0, endSlot: 3 }])
+    })
+
+    it('should create multiple blocks for non-contiguous selection on same day', () => {
+      const selection = new Set(['MON:0', 'MON:1', 'MON:5', 'MON:6'])
+      const blocks = selectionToBlocks(selection)
+      expect(blocks).toEqual([
+        { day: 'MON', startSlot: 0, endSlot: 2 },
+        { day: 'MON', startSlot: 5, endSlot: 7 },
+      ])
+    })
+
+    it('should create separate blocks for different days', () => {
+      const selection = new Set(['MON:0', 'TUE:10', 'WED:20'])
+      const blocks = selectionToBlocks(selection)
+      expect(blocks).toEqual([
+        { day: 'MON', startSlot: 0, endSlot: 1 },
+        { day: 'TUE', startSlot: 10, endSlot: 11 },
+        { day: 'WED', startSlot: 20, endSlot: 21 },
+      ])
+    })
+
+    it('should handle complex selection patterns', () => {
+      const selection = new Set([
+        'MON:0',
+        'MON:1',
+        'MON:2', // Mon 00:00-00:45
+        'MON:10',
+        'MON:11', // Mon 02:30-03:00
+        'TUE:48',
+        'TUE:49',
+        'TUE:50', // Tue 12:00-12:45
+      ])
+      const blocks = selectionToBlocks(selection)
+      expect(blocks).toEqual([
+        { day: 'MON', startSlot: 0, endSlot: 3 },
+        { day: 'MON', startSlot: 10, endSlot: 12 },
+        { day: 'TUE', startSlot: 48, endSlot: 51 },
+      ])
+    })
+
+    it('should handle single slot selection', () => {
+      const selection = new Set(['FRI:48'])
+      const blocks = selectionToBlocks(selection)
+      expect(blocks).toEqual([{ day: 'FRI', startSlot: 48, endSlot: 49 }])
+    })
+  })
+
+  describe('gridToSchedules', () => {
+    it('should return empty array for empty selection', () => {
+      const selection = new Set<string>()
+      expect(gridToSchedules(selection)).toEqual([])
+    })
+
+    it('should convert single contiguous block to schedule', () => {
+      const selection = new Set(['MON:0', 'MON:1', 'MON:2', 'MON:3'])
+      const schedules = gridToSchedules(selection)
+      expect(schedules).toEqual([
+        {
+          days_of_week: ['MON'],
+          start_time: '00:00:00',
+          end_time: '01:00:00',
+        },
+      ])
+    })
+
+    it('should create separate schedules for non-contiguous blocks', () => {
+      const selection = new Set(['MON:0', 'MON:1', 'MON:10', 'MON:11'])
+      const schedules = gridToSchedules(selection)
+      expect(schedules).toEqual([
+        {
+          days_of_week: ['MON'],
+          start_time: '00:00:00',
+          end_time: '00:30:00',
+        },
+        {
+          days_of_week: ['MON'],
+          start_time: '02:30:00',
+          end_time: '03:00:00',
+        },
+      ])
+    })
+
+    it('should create separate schedules for different days', () => {
+      const selection = new Set(['MON:36', 'TUE:36']) // 09:00
+      const schedules = gridToSchedules(selection)
+      expect(schedules).toEqual([
+        {
+          days_of_week: ['MON'],
+          start_time: '09:00:00',
+          end_time: '09:15:00',
+        },
+        {
+          days_of_week: ['TUE'],
+          start_time: '09:00:00',
+          end_time: '09:15:00',
+        },
+      ])
+    })
+
+    it('should handle typical weekday morning commute', () => {
+      // Mon-Fri 07:00-09:00 (slots 28-35)
+      const selection = new Set([
+        'MON:28',
+        'MON:29',
+        'MON:30',
+        'MON:31',
+        'MON:32',
+        'MON:33',
+        'MON:34',
+        'MON:35',
+      ])
+      const schedules = gridToSchedules(selection)
+      expect(schedules).toEqual([
+        {
+          days_of_week: ['MON'],
+          start_time: '07:00:00',
+          end_time: '09:00:00',
+        },
+      ])
+    })
+  })
+
+  describe('schedulesToGrid', () => {
+    it('should return empty set for empty schedules', () => {
+      const schedules: ScheduleResponse[] = []
+      const selection = schedulesToGrid(schedules)
+      expect(selection.size).toBe(0)
+    })
+
+    it('should convert single schedule to grid selection', () => {
+      const schedules: ScheduleResponse[] = [
+        {
+          id: '1',
+          days_of_week: ['MON'],
+          start_time: '00:00:00',
+          end_time: '01:00:00',
+        },
+      ]
+      const selection = schedulesToGrid(schedules)
+      expect(selection).toEqual(new Set(['MON:0', 'MON:1', 'MON:2', 'MON:3']))
+    })
+
+    it('should expand schedule with multiple days', () => {
+      const schedules: ScheduleResponse[] = [
+        {
+          id: '1',
+          days_of_week: ['MON', 'TUE'],
+          start_time: '09:00:00',
+          end_time: '09:30:00',
+        },
+      ]
+      const selection = schedulesToGrid(schedules)
+      expect(selection).toEqual(new Set(['MON:36', 'MON:37', 'TUE:36', 'TUE:37']))
+    })
+
+    it('should handle multiple schedules', () => {
+      const schedules: ScheduleResponse[] = [
+        {
+          id: '1',
+          days_of_week: ['MON'],
+          start_time: '09:00:00',
+          end_time: '09:15:00',
+        },
+        {
+          id: '2',
+          days_of_week: ['TUE'],
+          start_time: '14:00:00',
+          end_time: '14:15:00',
+        },
+      ]
+      const selection = schedulesToGrid(schedules)
+      expect(selection).toEqual(new Set(['MON:36', 'TUE:56']))
+    })
+
+    it('should handle overlapping schedules (union)', () => {
+      const schedules: ScheduleResponse[] = [
+        {
+          id: '1',
+          days_of_week: ['MON'],
+          start_time: '09:00:00',
+          end_time: '10:00:00',
+        },
+        {
+          id: '2',
+          days_of_week: ['MON'],
+          start_time: '09:30:00',
+          end_time: '10:30:00',
+        },
+      ]
+      const selection = schedulesToGrid(schedules)
+      // Should include 09:00-10:30 (slots 36-41, exclusive of end)
+      // Schedule 1: slots 36-39 (09:00-10:00)
+      // Schedule 2: slots 38-41 (09:30-10:30)
+      // Union: slots 36-41 (6 slots total)
+      expect(selection.has('MON:36')).toBe(true)
+      expect(selection.has('MON:37')).toBe(true)
+      expect(selection.has('MON:38')).toBe(true)
+      expect(selection.has('MON:39')).toBe(true)
+      expect(selection.has('MON:40')).toBe(true)
+      expect(selection.has('MON:41')).toBe(true)
+      expect(selection.has('MON:42')).toBe(false) // Exclusive of end time
+      expect(selection.size).toBe(6)
+    })
+  })
+
+  describe('round-trip conversion', () => {
+    it('should round-trip from grid to schedules to grid', () => {
+      const original = new Set(['MON:0', 'MON:1', 'TUE:48', 'TUE:49'])
+      const schedules = gridToSchedules(original)
+      const restored = schedulesToGrid(schedules)
+      expect(restored).toEqual(original)
+    })
+
+    it('should round-trip from schedules to grid to schedules', () => {
+      const original: ScheduleResponse[] = [
+        {
+          id: '1',
+          days_of_week: ['MON'],
+          start_time: '09:00:00',
+          end_time: '17:00:00',
+        },
+      ]
+      const grid = schedulesToGrid(original)
+      const schedules = gridToSchedules(grid)
+
+      // Should produce equivalent schedule (might split by day)
+      expect(schedules).toHaveLength(1)
+      expect(schedules[0]).toEqual({
+        days_of_week: ['MON'],
+        start_time: '09:00:00',
+        end_time: '17:00:00',
+      })
+    })
+
+    it('should handle complex round-trip', () => {
+      const original = new Set([
+        // Mon morning
+        'MON:36',
+        'MON:37',
+        'MON:38',
+        'MON:39', // 09:00-10:00
+        // Mon afternoon
+        'MON:56',
+        'MON:57',
+        'MON:58',
+        'MON:59', // 14:00-15:00
+        // Tue all day
+        'TUE:0',
+        'TUE:1',
+        'TUE:2',
+        'TUE:3',
+        'TUE:4',
+        'TUE:5',
+        'TUE:6',
+        'TUE:7', // 00:00-02:00
+      ])
+
+      const schedules = gridToSchedules(original)
+      const restored = schedulesToGrid(schedules)
+      expect(restored).toEqual(original)
+    })
+  })
+})

--- a/frontend/src/components/routes/ScheduleGrid/transforms.ts
+++ b/frontend/src/components/routes/ScheduleGrid/transforms.ts
@@ -1,0 +1,223 @@
+/**
+ * Pure functions for transforming between grid selection and API schedule format
+ *
+ * These functions handle the bidirectional conversion:
+ * - Grid selection (Set of cell keys) → API schedules
+ * - API schedules → Grid selection
+ *
+ * All functions are pure (no side effects, no external state) and fully testable.
+ *
+ * @see ADR 11: Frontend State Management Pattern
+ */
+
+import {
+  type GridSelection,
+  type TimeBlock,
+  type CreateScheduleRequest,
+  type ScheduleResponse,
+  type DayCode,
+  type TimeSlotIndex,
+  DAYS,
+  MINUTES_PER_SLOT,
+  cellKey,
+  parseKey,
+} from './types'
+
+/**
+ * Convert time slot index to HH:MM:SS time string
+ *
+ * @param slot Time slot index (0-95)
+ * @returns Time string in HH:MM:SS format
+ *
+ * @example
+ * slotToTime(0) // => '00:00:00'
+ * slotToTime(1) // => '00:15:00'
+ * slotToTime(48) // => '12:00:00'
+ * slotToTime(95) // => '23:45:00'
+ */
+export function slotToTime(slot: TimeSlotIndex): string {
+  const totalMinutes = slot * MINUTES_PER_SLOT
+  const hours = Math.floor(totalMinutes / 60)
+  const minutes = totalMinutes % 60
+
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}:00`
+}
+
+/**
+ * Convert HH:MM:SS time string to slot index
+ *
+ * Rounds down to the nearest 15-minute slot.
+ *
+ * @param time Time string in HH:MM:SS or HH:MM format
+ * @returns Time slot index (0-95)
+ *
+ * @example
+ * timeToSlot('00:00:00') // => 0
+ * timeToSlot('00:15:00') // => 1
+ * timeToSlot('12:00:00') // => 48
+ * timeToSlot('23:45:00') // => 95
+ * timeToSlot('09:22:00') // => 37 (rounds down to 09:15)
+ */
+export function timeToSlot(time: string): TimeSlotIndex {
+  const [hoursStr, minutesStr] = time.split(':')
+  const hours = parseInt(hoursStr, 10)
+  const minutes = parseInt(minutesStr, 10)
+
+  const totalMinutes = hours * 60 + minutes
+  return Math.floor(totalMinutes / MINUTES_PER_SLOT)
+}
+
+/**
+ * Get all selected slots for a specific day, sorted
+ *
+ * @param selection Grid selection
+ * @param day Day to filter by
+ * @returns Sorted array of slot indices for that day
+ */
+function getSlotsForDay(selection: GridSelection, day: DayCode): TimeSlotIndex[] {
+  const slots: TimeSlotIndex[] = []
+
+  for (const key of selection) {
+    const cell = parseKey(key)
+    if (cell.day === day) {
+      slots.push(cell.slot)
+    }
+  }
+
+  return slots.sort((a, b) => a - b)
+}
+
+/**
+ * Group contiguous selected slots into time blocks
+ *
+ * Takes a sorted array of slot indices and groups them into continuous ranges.
+ *
+ * @param day Day of the week
+ * @param slots Sorted array of slot indices
+ * @returns Array of TimeBlock objects
+ *
+ * @example
+ * groupIntoBlocks('MON', [0, 1, 2, 5, 6])
+ * // => [
+ * //   { day: 'MON', startSlot: 0, endSlot: 3 },
+ * //   { day: 'MON', startSlot: 5, endSlot: 7 }
+ * // ]
+ */
+function groupIntoBlocks(day: DayCode, slots: TimeSlotIndex[]): TimeBlock[] {
+  if (slots.length === 0) {
+    return []
+  }
+
+  const blocks: TimeBlock[] = []
+  let startSlot = slots[0]
+  let endSlot = slots[0] + 1
+
+  for (let i = 1; i < slots.length; i++) {
+    if (slots[i] === endSlot) {
+      // Contiguous slot - extend current block
+      endSlot = slots[i] + 1
+    } else {
+      // Gap found - finalize current block and start new one
+      blocks.push({ day, startSlot, endSlot })
+      startSlot = slots[i]
+      endSlot = slots[i] + 1
+    }
+  }
+
+  // Add final block
+  blocks.push({ day, startSlot, endSlot })
+
+  return blocks
+}
+
+/**
+ * Convert grid selection to contiguous time blocks per day
+ *
+ * @param selection Grid selection
+ * @returns Array of TimeBlock objects
+ *
+ * @example
+ * const selection = new Set(['MON:0', 'MON:1', 'MON:5', 'TUE:48'])
+ * selectionToBlocks(selection)
+ * // => [
+ * //   { day: 'MON', startSlot: 0, endSlot: 2 },
+ * //   { day: 'MON', startSlot: 5, endSlot: 6 },
+ * //   { day: 'TUE', startSlot: 48, endSlot: 49 }
+ * // ]
+ */
+export function selectionToBlocks(selection: GridSelection): TimeBlock[] {
+  const blocks: TimeBlock[] = []
+
+  for (const day of DAYS) {
+    const slots = getSlotsForDay(selection, day)
+    if (slots.length > 0) {
+      blocks.push(...groupIntoBlocks(day, slots))
+    }
+  }
+
+  return blocks
+}
+
+/**
+ * Convert grid selection to API schedule format
+ *
+ * Converts the grid selection into an array of schedule requests by:
+ * 1. Grouping contiguous cells into time blocks per day
+ * 2. Converting each block to a schedule with single-day array and time range
+ *
+ * @param selection Grid selection
+ * @returns Array of CreateScheduleRequest objects
+ *
+ * @example
+ * const selection = new Set(['MON:0', 'MON:1', 'TUE:48'])
+ * gridToSchedules(selection)
+ * // => [
+ * //   { days_of_week: ['MON'], start_time: '00:00:00', end_time: '00:30:00' },
+ * //   { days_of_week: ['TUE'], start_time: '12:00:00', end_time: '12:15:00' }
+ * // ]
+ */
+export function gridToSchedules(selection: GridSelection): CreateScheduleRequest[] {
+  const blocks = selectionToBlocks(selection)
+
+  return blocks.map((block) => ({
+    days_of_week: [block.day],
+    start_time: slotToTime(block.startSlot),
+    end_time: slotToTime(block.endSlot),
+  }))
+}
+
+/**
+ * Convert API schedules to grid selection
+ *
+ * Expands each schedule into individual cell selections:
+ * - For each day in the schedule's days_of_week
+ * - For each 15-minute slot between start_time and end_time
+ * - Add the cell to the selection
+ *
+ * @param schedules Array of schedule responses from API
+ * @returns Grid selection
+ *
+ * @example
+ * const schedules = [
+ *   { id: '1', days_of_week: ['MON', 'TUE'], start_time: '09:00:00', end_time: '10:00:00' }
+ * ]
+ * schedulesToGrid(schedules)
+ * // => Set(['MON:36', 'MON:37', 'MON:38', 'MON:39',
+ * //          'TUE:36', 'TUE:37', 'TUE:38', 'TUE:39'])
+ */
+export function schedulesToGrid(schedules: ScheduleResponse[]): GridSelection {
+  const selection = new Set<string>()
+
+  for (const schedule of schedules) {
+    const startSlot = timeToSlot(schedule.start_time)
+    const endSlot = timeToSlot(schedule.end_time)
+
+    for (const day of schedule.days_of_week) {
+      for (let slot = startSlot; slot < endSlot; slot++) {
+        selection.add(cellKey(day as DayCode, slot))
+      }
+    }
+  }
+
+  return selection
+}

--- a/frontend/src/components/routes/ScheduleGrid/types.test.ts
+++ b/frontend/src/components/routes/ScheduleGrid/types.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest'
+import { cellKey, parseKey, DAYS, SLOTS_PER_DAY, MINUTES_PER_SLOT, DAY_LABELS } from './types'
+
+describe('ScheduleGrid types', () => {
+  describe('constants', () => {
+    it('DAYS should contain all 7 days in order', () => {
+      expect(DAYS).toEqual(['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'])
+    })
+
+    it('DAY_LABELS should have labels for all days', () => {
+      expect(DAY_LABELS).toEqual({
+        MON: 'Mon',
+        TUE: 'Tue',
+        WED: 'Wed',
+        THU: 'Thu',
+        FRI: 'Fri',
+        SAT: 'Sat',
+        SUN: 'Sun',
+      })
+    })
+
+    it('SLOTS_PER_DAY should be 96 (24 hours * 4 slots/hour)', () => {
+      expect(SLOTS_PER_DAY).toBe(96)
+    })
+
+    it('MINUTES_PER_SLOT should be 15', () => {
+      expect(MINUTES_PER_SLOT).toBe(15)
+    })
+  })
+
+  describe('cellKey', () => {
+    it('should create key from day and slot', () => {
+      expect(cellKey('MON', 0)).toBe('MON:0')
+      expect(cellKey('FRI', 48)).toBe('FRI:48')
+      expect(cellKey('SUN', 95)).toBe('SUN:95')
+    })
+
+    it('should handle all days', () => {
+      for (const day of DAYS) {
+        expect(cellKey(day, 0)).toBe(`${day}:0`)
+      }
+    })
+
+    it('should handle all slot indices', () => {
+      expect(cellKey('MON', 0)).toBe('MON:0')
+      expect(cellKey('MON', 95)).toBe('MON:95')
+    })
+  })
+
+  describe('parseKey', () => {
+    it('should parse valid keys', () => {
+      expect(parseKey('MON:0')).toEqual({ day: 'MON', slot: 0 })
+      expect(parseKey('FRI:48')).toEqual({ day: 'FRI', slot: 48 })
+      expect(parseKey('SUN:95')).toEqual({ day: 'SUN', slot: 95 })
+    })
+
+    it('should round-trip with cellKey', () => {
+      const original = { day: 'TUE' as const, slot: 42 }
+      const key = cellKey(original.day, original.slot)
+      const parsed = parseKey(key)
+      expect(parsed).toEqual(original)
+    })
+
+    it('should throw error for invalid day code', () => {
+      expect(() => parseKey('MONDAY:0')).toThrow('Invalid day code')
+      expect(() => parseKey('XXX:5')).toThrow('Invalid day code')
+    })
+
+    it('should throw error for invalid slot index', () => {
+      expect(() => parseKey('MON:abc')).toThrow('Invalid slot index')
+      expect(() => parseKey('MON:-1')).toThrow('Invalid slot index')
+      expect(() => parseKey('MON:96')).toThrow('Invalid slot index')
+      expect(() => parseKey('MON:100')).toThrow('Invalid slot index')
+    })
+
+    it('should throw error for malformed keys', () => {
+      expect(() => parseKey('MON')).toThrow()
+      expect(() => parseKey('0:MON')).toThrow('Invalid day code')
+      expect(() => parseKey('')).toThrow('Invalid day code')
+    })
+  })
+})

--- a/frontend/src/components/routes/ScheduleGrid/types.ts
+++ b/frontend/src/components/routes/ScheduleGrid/types.ts
@@ -1,0 +1,160 @@
+/**
+ * Type definitions for ScheduleGrid state management
+ *
+ * This module provides shared types for the ScheduleGrid component's state,
+ * grid selection representation, and related data structures. These types support
+ * the extraction of validation and business logic into pure, testable functions.
+ *
+ * @see ADR 11: Frontend State Management Pattern
+ */
+
+import type { ScheduleResponse, CreateScheduleRequest } from '@/types'
+
+/**
+ * Days of the week as used by the API
+ *
+ * These match the backend day codes in UserRouteSchedule model
+ */
+export const DAYS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'] as const
+export type DayCode = (typeof DAYS)[number]
+
+/**
+ * Display labels for days of the week (short form)
+ */
+export const DAY_LABELS: Record<DayCode, string> = {
+  MON: 'Mon',
+  TUE: 'Tue',
+  WED: 'Wed',
+  THU: 'Thu',
+  FRI: 'Fri',
+  SAT: 'Sat',
+  SUN: 'Sun',
+}
+
+/**
+ * Time slot index representing 15-minute intervals
+ *
+ * - 0 = 00:00
+ * - 1 = 00:15
+ * - 2 = 00:30
+ * - 3 = 00:45
+ * - 4 = 01:00
+ * - ...
+ * - 95 = 23:45
+ *
+ * Total of 96 slots per day (24 hours × 4 slots/hour)
+ */
+export type TimeSlotIndex = number // 0-95
+
+/**
+ * Number of 15-minute time slots in a day
+ */
+export const SLOTS_PER_DAY = 96
+
+/**
+ * Number of minutes per time slot
+ */
+export const MINUTES_PER_SLOT = 15
+
+/**
+ * Identifier for a single cell in the grid
+ */
+export interface CellId {
+  /** Day of the week */
+  day: DayCode
+  /** Time slot index (0-95) */
+  slot: TimeSlotIndex
+}
+
+/**
+ * Grid selection state
+ *
+ * Stores selected cells as a Set of string keys for O(1) lookups.
+ * Each key is formatted as "DAY:SLOT" (e.g., "MON:0", "TUE:48")
+ *
+ * Using a Set rather than a 2D array provides:
+ * - Efficient membership testing
+ * - Immutable update patterns
+ * - Sparse storage (only selected cells consume memory)
+ */
+export type GridSelection = Set<string>
+
+/**
+ * Create a cell key from day and slot
+ *
+ * @param day Day of the week
+ * @param slot Time slot index (0-95)
+ * @returns String key "DAY:SLOT"
+ *
+ * @example
+ * cellKey('MON', 0) // => 'MON:0'
+ * cellKey('FRI', 48) // => 'FRI:48'
+ */
+export function cellKey(day: DayCode, slot: TimeSlotIndex): string {
+  return `${day}:${slot}`
+}
+
+/**
+ * Parse a cell key back into day and slot
+ *
+ * @param key Cell key string "DAY:SLOT"
+ * @returns CellId object with day and slot
+ * @throws Error if key format is invalid
+ *
+ * @example
+ * parseKey('MON:0') // => { day: 'MON', slot: 0 }
+ * parseKey('FRI:48') // => { day: 'FRI', slot: 48 }
+ */
+export function parseKey(key: string): CellId {
+  const [day, slotStr] = key.split(':')
+  const slot = parseInt(slotStr, 10)
+
+  if (!DAYS.includes(day as DayCode)) {
+    throw new Error(`Invalid day code in key: ${day}`)
+  }
+
+  if (isNaN(slot) || slot < 0 || slot >= SLOTS_PER_DAY) {
+    throw new Error(`Invalid slot index in key: ${slotStr}`)
+  }
+
+  return { day: day as DayCode, slot }
+}
+
+/**
+ * Validation result (discriminated union)
+ *
+ * This pattern makes it easy to check validation results and handle
+ * errors consistently throughout the component.
+ *
+ * @example
+ * ```typescript
+ * const result = validateNotEmpty(selection)
+ * if (!result.valid) {
+ *   setError(result.error)
+ *   return
+ * }
+ * // Continue with valid selection...
+ * ```
+ */
+export type ValidationResult = { valid: true } | { valid: false; error: string }
+
+/**
+ * Contiguous time block for a single day
+ *
+ * Represents a continuous range of selected time slots on one day.
+ * Used as an intermediate representation when converting grid selection
+ * to API schedule format.
+ */
+export interface TimeBlock {
+  /** Day of the week */
+  day: DayCode
+  /** Start slot index (inclusive) */
+  startSlot: TimeSlotIndex
+  /** End slot index (exclusive) */
+  endSlot: TimeSlotIndex
+}
+
+/**
+ * Re-export schedule types from API for convenience
+ */
+export type { ScheduleResponse, CreateScheduleRequest }

--- a/frontend/src/components/routes/ScheduleGrid/validation.test.ts
+++ b/frontend/src/components/routes/ScheduleGrid/validation.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest'
+import { validateNotEmpty, validateMaxSchedules, validateAll } from './validation'
+
+describe('ScheduleGrid validation', () => {
+  describe('validateNotEmpty', () => {
+    it('should pass for non-empty selection', () => {
+      const selection = new Set(['MON:0'])
+      const result = validateNotEmpty(selection)
+      expect(result.valid).toBe(true)
+    })
+
+    it('should fail for empty selection', () => {
+      const selection = new Set<string>()
+      const result = validateNotEmpty(selection)
+      expect(result).toEqual({
+        valid: false,
+        error: 'Please select at least one time slot',
+      })
+    })
+
+    it('should pass for multiple selected cells', () => {
+      const selection = new Set(['MON:0', 'TUE:5', 'WED:10'])
+      const result = validateNotEmpty(selection)
+      expect(result.valid).toBe(true)
+    })
+  })
+
+  describe('validateMaxSchedules', () => {
+    it('should pass for selection within limit', () => {
+      const selection = new Set(['MON:0', 'MON:1', 'TUE:5'])
+      const result = validateMaxSchedules(selection, 10)
+      expect(result.valid).toBe(true)
+    })
+
+    it('should pass for contiguous selection (single block per day)', () => {
+      // MON: 0-10 (1 block), TUE: 0-10 (1 block) = 2 blocks total
+      const selection = new Set<string>()
+      for (let i = 0; i <= 10; i++) {
+        selection.add(`MON:${i}`)
+        selection.add(`TUE:${i}`)
+      }
+      const result = validateMaxSchedules(selection, 10)
+      expect(result.valid).toBe(true)
+    })
+
+    it('should fail when too many blocks', () => {
+      // Create 11 separate blocks (each day with gap)
+      const selection = new Set<string>()
+      for (let i = 0; i < 11; i++) {
+        selection.add(`MON:${i * 2}`) // 0, 2, 4, 6... (creates gaps)
+      }
+      const result = validateMaxSchedules(selection, 10)
+      expect(result.valid).toBe(false)
+      expect(result.error).toContain('Too many time blocks')
+      expect(result.error).toContain('11')
+      expect(result.error).toContain('10')
+    })
+
+    it('should use default max of 100', () => {
+      const selection = new Set(['MON:0'])
+      const result = validateMaxSchedules(selection)
+      expect(result.valid).toBe(true)
+    })
+
+    it('should handle complex pattern with multiple blocks per day', () => {
+      // Create multiple non-contiguous blocks
+      const selection = new Set([
+        'MON:0',
+        'MON:1', // Block 1
+        'MON:5',
+        'MON:6', // Block 2
+        'TUE:10',
+        'TUE:11', // Block 3
+        'WED:20',
+        'WED:21', // Block 4
+      ])
+      const result = validateMaxSchedules(selection, 5)
+      expect(result.valid).toBe(true)
+
+      const resultFail = validateMaxSchedules(selection, 3)
+      expect(resultFail.valid).toBe(false)
+    })
+
+    it('should count blocks correctly with single-slot gaps', () => {
+      // MON:0, gap, MON:2, gap, MON:4 = 3 blocks
+      const selection = new Set(['MON:0', 'MON:2', 'MON:4'])
+      const result = validateMaxSchedules(selection, 2)
+      expect(result.valid).toBe(false)
+    })
+
+    it('should handle all days with blocks', () => {
+      const selection = new Set<string>()
+      const days = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN']
+      // Add 2 blocks per day = 14 blocks total
+      for (const day of days) {
+        selection.add(`${day}:0`)
+        selection.add(`${day}:1`)
+        selection.add(`${day}:5`)
+        selection.add(`${day}:6`)
+      }
+      const result = validateMaxSchedules(selection, 20)
+      expect(result.valid).toBe(true)
+
+      const resultFail = validateMaxSchedules(selection, 10)
+      expect(resultFail.valid).toBe(false)
+    })
+  })
+
+  describe('validateAll', () => {
+    it('should pass when all validations pass', () => {
+      const selection = new Set(['MON:0', 'MON:1'])
+      const result = validateAll(selection)
+      expect(result.valid).toBe(true)
+    })
+
+    it('should fail on empty selection first', () => {
+      const selection = new Set<string>()
+      const result = validateAll(selection)
+      expect(result.valid).toBe(false)
+      expect(result.error).toContain('at least one time slot')
+    })
+
+    it('should fail on too many blocks if not empty', () => {
+      const selection = new Set<string>()
+      for (let i = 0; i < 11; i++) {
+        selection.add(`MON:${i * 2}`)
+      }
+      const result = validateAll(selection, { maxSchedules: 10 })
+      expect(result.valid).toBe(false)
+      expect(result.error).toContain('Too many time blocks')
+    })
+
+    it('should respect custom maxSchedules option', () => {
+      const selection = new Set(['MON:0', 'MON:1', 'MON:5', 'MON:6', 'MON:10', 'MON:11'])
+      const resultPass = validateAll(selection, { maxSchedules: 5 })
+      expect(resultPass.valid).toBe(true)
+
+      const resultFail = validateAll(selection, { maxSchedules: 2 })
+      expect(resultFail.valid).toBe(false)
+    })
+
+    it('should use default options when not provided', () => {
+      const selection = new Set(['MON:0'])
+      const result = validateAll(selection)
+      expect(result.valid).toBe(true)
+    })
+
+    it('should return first validation error encountered', () => {
+      // Empty selection will fail first check
+      const selection = new Set<string>()
+      const result = validateAll(selection, { maxSchedules: 0 })
+      expect(result.valid).toBe(false)
+      // Should get "empty" error, not "too many blocks"
+      expect(result.error).toContain('at least one time slot')
+    })
+  })
+
+  describe('validation result type', () => {
+    it('should return discriminated union', () => {
+      const validResult = validateNotEmpty(new Set(['MON:0']))
+      if (validResult.valid) {
+        // TypeScript should allow this branch
+        expect(validResult.valid).toBe(true)
+      }
+
+      const invalidResult = validateNotEmpty(new Set())
+      if (!invalidResult.valid) {
+        // TypeScript should allow accessing error here
+        expect(invalidResult.error).toBeDefined()
+      }
+    })
+  })
+})

--- a/frontend/src/components/routes/ScheduleGrid/validation.ts
+++ b/frontend/src/components/routes/ScheduleGrid/validation.ts
@@ -1,0 +1,106 @@
+/**
+ * Pure validation functions for grid selection
+ *
+ * These functions validate grid selection state and return validation results
+ * following the discriminated union pattern.
+ *
+ * @see ADR 11: Frontend State Management Pattern
+ */
+
+import { DAYS, SLOTS_PER_DAY, type GridSelection, type ValidationResult } from './types'
+
+/**
+ * Validate that selection is not empty
+ *
+ * @param selection Grid selection to validate
+ * @returns Validation result
+ *
+ * @example
+ * validateNotEmpty(new Set()) // => { valid: false, error: 'Please select at least one time slot' }
+ * validateNotEmpty(new Set(['MON:0'])) // => { valid: true }
+ */
+export function validateNotEmpty(selection: GridSelection): ValidationResult {
+  if (selection.size === 0) {
+    return { valid: false, error: 'Please select at least one time slot' }
+  }
+  return { valid: true }
+}
+
+/**
+ * Validate that selection doesn't exceed maximum number of schedules
+ *
+ * Since each contiguous block per day becomes a separate schedule,
+ * we need to ensure we don't exceed backend limits.
+ *
+ * Note: This is a soft limit - the backend doesn't enforce a hard limit,
+ * but having too many schedules could impact performance.
+ *
+ * @param selection Grid selection to validate
+ * @param maxSchedules Maximum number of schedules allowed (default: 100)
+ * @returns Validation result
+ *
+ * @example
+ * const selection = new Set(['MON:0', 'MON:5', 'TUE:10']) // 3 separate blocks
+ * validateMaxSchedules(selection, 2) // => { valid: false, error: 'Too many time blocks...' }
+ * validateMaxSchedules(selection, 5) // => { valid: true }
+ */
+export function validateMaxSchedules(
+  selection: GridSelection,
+  maxSchedules: number = 100
+): ValidationResult {
+  // Count number of blocks by counting transitions from selected to not-selected
+  // This is an approximation - actual block count is calculated in transforms.ts
+  // But for validation purposes, this gives us a reasonable upper bound
+
+  let blockCount = 0
+
+  for (const day of DAYS) {
+    let inBlock = false
+    for (let slot = 0; slot < SLOTS_PER_DAY; slot++) {
+      const isSelected = selection.has(`${day}:${slot}`)
+      if (isSelected && !inBlock) {
+        blockCount++
+        inBlock = true
+      } else if (!isSelected && inBlock) {
+        inBlock = false
+      }
+    }
+  }
+
+  if (blockCount > maxSchedules) {
+    return {
+      valid: false,
+      error: `Too many time blocks selected (${blockCount}). Please limit to ${maxSchedules} blocks or fewer.`,
+    }
+  }
+
+  return { valid: true }
+}
+
+/**
+ * Run all validation checks on a selection
+ *
+ * @param selection Grid selection to validate
+ * @param options Validation options
+ * @returns Validation result (first failure encountered, or valid)
+ *
+ * @example
+ * validateAll(new Set()) // => { valid: false, error: 'Please select at least one time slot' }
+ * validateAll(new Set(['MON:0'])) // => { valid: true }
+ */
+export function validateAll(
+  selection: GridSelection,
+  options: { maxSchedules?: number } = {}
+): ValidationResult {
+  const notEmptyResult = validateNotEmpty(selection)
+  if (!notEmptyResult.valid) {
+    return notEmptyResult
+  }
+
+  const maxSchedulesResult = validateMaxSchedules(selection, options.maxSchedules)
+  if (!maxSchedulesResult.valid) {
+    return maxSchedulesResult
+  }
+
+  return { valid: true }
+}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -55,4 +55,6 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 )
 Button.displayName = 'Button'
 
+// Variants exported for composition (shadcn/ui pattern used in pagination.tsx)
+// eslint-disable-next-line react-refresh/only-export-components
 export { Button, buttonVariants }

--- a/frontend/src/contexts/ConfigContext.tsx
+++ b/frontend/src/contexts/ConfigContext.tsx
@@ -45,6 +45,8 @@ export function ConfigProvider({ config, children }: ConfigProviderProps) {
  * }
  * ```
  */
+// Hook exported alongside provider per React context pattern
+// eslint-disable-next-line react-refresh/only-export-components
 export function useConfig(): AppConfig {
   const config = useContext(ConfigContext)
 

--- a/frontend/src/contexts/PollingContext.tsx
+++ b/frontend/src/contexts/PollingContext.tsx
@@ -101,6 +101,8 @@ export function PollingProvider({ children }: { children: ReactNode }) {
   return <PollingContext.Provider value={contextValue}>{children}</PollingContext.Provider>
 }
 
+// Hook exported alongside provider per React context pattern
+// eslint-disable-next-line react-refresh/only-export-components
 export function usePollingCoordinator(): PollingContextType {
   const context = useContext(PollingContext)
   if (context === undefined) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -589,6 +589,28 @@ export async function deleteSchedule(routeId: string, scheduleId: string): Promi
   await fetchAPI<void>(`/routes/${routeId}/schedules/${scheduleId}`, { method: 'DELETE' })
 }
 
+/**
+ * Replace all schedules for a route (atomic upsert)
+ *
+ * @param routeId The route ID
+ * @param schedules Array of schedules to set (empty array deletes all)
+ * @returns The updated list of schedules
+ * @throws {ApiError} 422 if validation fails (quarter-hour boundaries, invalid days, end_time <= start_time)
+ */
+export async function upsertSchedules(
+  routeId: string,
+  schedules: CreateScheduleRequest[]
+): Promise<ScheduleResponse[]> {
+  const response = await fetchAPI<ScheduleResponse[]>(`/routes/${routeId}/schedules`, {
+    method: 'PUT',
+    body: JSON.stringify({ schedules }),
+  })
+  if (!response) {
+    throw new ApiError(204, 'Unexpected 204 response from upsert schedules endpoint')
+  }
+  return response
+}
+
 // ============================================================================
 // Notification Preference API
 // ============================================================================

--- a/frontend/src/lib/disruption-utils.test.ts
+++ b/frontend/src/lib/disruption-utils.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest'
+import { getWorstDisruptionForRoute } from './disruption-utils'
+import type { RouteDisruptionResponse, DisruptionResponse } from '@/types'
+
+// Helper function to create mock disruption data
+const createDisruption = (
+  routeId: string,
+  severity: number,
+  overrides?: Partial<DisruptionResponse>
+): RouteDisruptionResponse => ({
+  route_id: routeId,
+  route_name: 'Test Route',
+  disruption: {
+    line_id: 'victoria',
+    line_name: 'Victoria',
+    mode: 'tube',
+    status_severity: severity,
+    status_severity_description: severity === 10 ? 'Good Service' : 'Minor Delays',
+    reason: 'Test reason',
+    created_at: '2025-01-01T10:00:00Z',
+    affected_routes: null,
+    ...overrides,
+  },
+  affected_segments: [0, 1],
+  affected_stations: ['940GZZLUOXC'],
+})
+
+describe('getWorstDisruptionForRoute', () => {
+  describe('null and empty cases', () => {
+    it('should return null when disruptions is null', () => {
+      const result = getWorstDisruptionForRoute(null, 'route-1')
+      expect(result).toBeNull()
+    })
+
+    it('should return null when disruptions array is empty', () => {
+      const result = getWorstDisruptionForRoute([], 'route-1')
+      expect(result).toBeNull()
+    })
+
+    it('should return null when no disruptions match the route ID', () => {
+      const disruptions = [createDisruption('route-2', 6), createDisruption('route-3', 8)]
+      const result = getWorstDisruptionForRoute(disruptions, 'route-1')
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('single disruption', () => {
+    it('should return the single disruption when only one matches', () => {
+      const disruptions = [createDisruption('route-1', 6), createDisruption('route-2', 8)]
+      const result = getWorstDisruptionForRoute(disruptions, 'route-1')
+
+      expect(result).not.toBeNull()
+      expect(result?.route_id).toBe('route-1')
+      expect(result?.disruption.status_severity).toBe(6)
+    })
+  })
+
+  describe('multiple disruptions', () => {
+    it('should return the worst (lowest severity) disruption when multiple match', () => {
+      const disruptions = [
+        createDisruption('route-1', 10), // Good Service
+        createDisruption('route-1', 6), // Minor Delays
+        createDisruption('route-1', 20), // Severe Delays
+        createDisruption('route-2', 5), // Different route
+      ]
+      const result = getWorstDisruptionForRoute(disruptions, 'route-1')
+
+      expect(result).not.toBeNull()
+      expect(result?.disruption.status_severity).toBe(6)
+    })
+
+    it('should return the most severe disruption (severity 1) over others', () => {
+      const disruptions = [
+        createDisruption('route-1', 8),
+        createDisruption('route-1', 1), // Most severe (closure/suspension)
+        createDisruption('route-1', 6),
+      ]
+      const result = getWorstDisruptionForRoute(disruptions, 'route-1')
+
+      expect(result).not.toBeNull()
+      expect(result?.disruption.status_severity).toBe(1)
+    })
+
+    it('should handle multiple routes with overlapping severity codes', () => {
+      const disruptions = [
+        createDisruption('route-1', 10),
+        createDisruption('route-2', 5),
+        createDisruption('route-1', 7),
+        createDisruption('route-3', 3),
+      ]
+
+      const result1 = getWorstDisruptionForRoute(disruptions, 'route-1')
+      expect(result1?.disruption.status_severity).toBe(7)
+
+      const result2 = getWorstDisruptionForRoute(disruptions, 'route-2')
+      expect(result2?.disruption.status_severity).toBe(5)
+
+      const result3 = getWorstDisruptionForRoute(disruptions, 'route-3')
+      expect(result3?.disruption.status_severity).toBe(3)
+    })
+  })
+
+  describe('edge cases', () => {
+    it('should handle severity 10 (Good Service) correctly', () => {
+      const disruptions = [createDisruption('route-1', 10)]
+      const result = getWorstDisruptionForRoute(disruptions, 'route-1')
+
+      expect(result).not.toBeNull()
+      expect(result?.disruption.status_severity).toBe(10)
+    })
+
+    it('should prefer severity 5 over severity 10', () => {
+      const disruptions = [createDisruption('route-1', 10), createDisruption('route-1', 5)]
+      const result = getWorstDisruptionForRoute(disruptions, 'route-1')
+
+      expect(result?.disruption.status_severity).toBe(5)
+    })
+
+    it('should handle all disruptions being for the same route', () => {
+      const disruptions = [
+        createDisruption('route-1', 6),
+        createDisruption('route-1', 8),
+        createDisruption('route-1', 7),
+      ]
+      const result = getWorstDisruptionForRoute(disruptions, 'route-1')
+
+      expect(result?.disruption.status_severity).toBe(6)
+    })
+
+    it('should return the first disruption when all have the same severity', () => {
+      const disruptions = [
+        createDisruption('route-1', 6),
+        createDisruption('route-1', 6),
+        createDisruption('route-1', 6),
+      ]
+      const result = getWorstDisruptionForRoute(disruptions, 'route-1')
+
+      expect(result).not.toBeNull()
+      expect(result?.disruption.status_severity).toBe(6)
+      // Should be the first one since they're all equal
+      expect(result).toBe(disruptions[0])
+    })
+  })
+
+  describe('data structure validation', () => {
+    it('should preserve all fields of the returned disruption', () => {
+      const disruptions = [
+        createDisruption('route-1', 6, {
+          line_id: 'piccadilly',
+          line_name: 'Piccadilly',
+          reason: 'Signal failure at Kings Cross',
+          status_severity_description: 'Minor Delays',
+        }),
+      ]
+      const result = getWorstDisruptionForRoute(disruptions, 'route-1')
+
+      expect(result).not.toBeNull()
+      expect(result?.route_id).toBe('route-1')
+      expect(result?.route_name).toBe('Test Route')
+      expect(result?.disruption.line_id).toBe('piccadilly')
+      expect(result?.disruption.line_name).toBe('Piccadilly')
+      expect(result?.disruption.reason).toBe('Signal failure at Kings Cross')
+      expect(result?.affected_segments).toEqual([0, 1])
+      expect(result?.affected_stations).toEqual(['940GZZLUOXC'])
+    })
+  })
+})

--- a/frontend/src/lib/disruption-utils.ts
+++ b/frontend/src/lib/disruption-utils.ts
@@ -1,0 +1,40 @@
+import type { RouteDisruptionResponse } from '@/types'
+
+/**
+ * Get the worst (most severe) disruption for a specific route
+ *
+ * TfL severity codes: Lower numbers = more severe
+ * - 1-4: Severe disruptions (closures, suspensions)
+ * - 5-9: Minor/moderate delays
+ * - 10: Good Service
+ * - 10-20: Good Service / No disruptions
+ *
+ * @param disruptions - Array of route disruptions (can be null)
+ * @param routeId - The route ID to filter by
+ * @returns The most severe disruption for the route, or null if none exist
+ *
+ * @example
+ * const worst = getWorstDisruptionForRoute(disruptions, 'route-123')
+ * if (worst) {
+ *   console.log(`Route has ${worst.disruption.status_severity_description}`)
+ * }
+ */
+export function getWorstDisruptionForRoute(
+  disruptions: RouteDisruptionResponse[] | null | undefined,
+  routeId: string
+): RouteDisruptionResponse | null {
+  if (!disruptions || disruptions.length === 0) {
+    return null
+  }
+
+  const routeDisruptions = disruptions.filter((d) => d.route_id === routeId)
+
+  if (routeDisruptions.length === 0) {
+    return null
+  }
+
+  // Return the disruption with the lowest severity number (most severe)
+  return routeDisruptions.reduce((worst, current) =>
+    current.disruption.status_severity < worst.disruption.status_severity ? current : worst
+  )
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,6 +10,8 @@ import { useConfig } from './contexts/ConfigContext'
  * AppWithAuth - Wraps app in Auth0Provider using runtime config
  * Must be inside ConfigLoader to access config via useConfig hook
  */
+// Entry point file - no exports needed
+// eslint-disable-next-line react-refresh/only-export-components
 function AppWithAuth() {
   const config = useConfig()
 

--- a/frontend/src/pages/CreateRoute.tsx
+++ b/frontend/src/pages/CreateRoute.tsx
@@ -25,7 +25,7 @@ import {
   ApiError,
   createRoute,
   upsertSegments,
-  createSchedule,
+  upsertSchedules,
   createNotificationPreference,
   validateRoute as apiValidateRoute,
   getRoutes,
@@ -138,7 +138,7 @@ export function CreateRoute() {
       // 2. Add segments
       await upsertSegments(route.id, segments)
 
-      // 3. Add schedules (convert grid selection to schedules)
+      // 3. Add schedules (atomically - Issue #359)
       // Validate that at least one time slot is selected
       const validationResult = validateNotEmpty(scheduleSelection)
       if (!validationResult.valid) {
@@ -148,9 +148,7 @@ export function CreateRoute() {
       }
 
       const schedules = gridToSchedules(scheduleSelection)
-      for (const schedule of schedules) {
-        await createSchedule(route.id, schedule)
-      }
+      await upsertSchedules(route.id, schedules)
 
       // 4. Add notification preferences
       for (const notification of notifications) {

--- a/frontend/src/pages/CreateRoute.tsx
+++ b/frontend/src/pages/CreateRoute.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { useNavigate, Link } from 'react-router-dom'
-import { ChevronRight, Plus, Trash2 } from 'lucide-react'
+import { ChevronRight, Trash2 } from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
@@ -8,14 +8,16 @@ import { Textarea } from '../components/ui/textarea'
 import { Alert, AlertDescription } from '../components/ui/alert'
 import { Card } from '../components/ui/card'
 import { SegmentBuilder } from '../components/routes/SegmentBuilder/SegmentBuilder'
-import { ScheduleForm } from '../components/routes/ScheduleForm'
-import { ScheduleCard } from '../components/routes/ScheduleCard'
+import {
+  ScheduleGrid,
+  gridToSchedules,
+  validateNotEmpty,
+  type GridSelection,
+} from '../components/routes/ScheduleGrid'
 import { useTflData } from '../hooks/useTflData'
 import { useContacts } from '../hooks/useContacts'
 import type {
   SegmentRequest,
-  CreateScheduleRequest,
-  ScheduleResponse,
   CreateNotificationPreferenceRequest,
   NotificationMethod,
 } from '@/types'
@@ -28,10 +30,6 @@ import {
   validateRoute as apiValidateRoute,
   getRoutes,
 } from '../lib/api'
-
-interface LocalSchedule extends Omit<ScheduleResponse, 'id'> {
-  id: string // Temporary local ID
-}
 
 interface LocalNotificationPreference {
   id: string // Temporary local ID
@@ -52,9 +50,8 @@ export function CreateRoute() {
   // Journey (segments) state
   const [segments, setSegments] = useState<SegmentRequest[]>([])
 
-  // Alert configuration state
-  const [schedules, setSchedules] = useState<LocalSchedule[]>([])
-  const [showAddSchedule, setShowAddSchedule] = useState(false)
+  // Alert configuration state (using grid selection for schedules)
+  const [scheduleSelection, setScheduleSelection] = useState<GridSelection>(new Set())
   const [notifications, setNotifications] = useState<LocalNotificationPreference[]>([])
   const [selectedContactId, setSelectedContactId] = useState<string>('')
   const [selectedMethod, setSelectedMethod] = useState<NotificationMethod>('email')
@@ -70,21 +67,6 @@ export function CreateRoute() {
 
   const handleSaveSegments = async (newSegments: SegmentRequest[]) => {
     setSegments(newSegments)
-  }
-
-  const handleAddSchedule = async (data: CreateScheduleRequest) => {
-    const newSchedule: LocalSchedule = {
-      id: `temp-${Date.now()}`,
-      days_of_week: data.days_of_week,
-      start_time: data.start_time,
-      end_time: data.end_time,
-    }
-    setSchedules([...schedules, newSchedule])
-    setShowAddSchedule(false)
-  }
-
-  const handleDeleteSchedule = (scheduleId: string) => {
-    setSchedules(schedules.filter((s) => s.id !== scheduleId))
   }
 
   const handleAddNotification = () => {
@@ -156,13 +138,18 @@ export function CreateRoute() {
       // 2. Add segments
       await upsertSegments(route.id, segments)
 
-      // 3. Add schedules
+      // 3. Add schedules (convert grid selection to schedules)
+      // Validate that at least one time slot is selected
+      const validationResult = validateNotEmpty(scheduleSelection)
+      if (!validationResult.valid) {
+        setError(validationResult.error!)
+        setIsCreating(false)
+        return
+      }
+
+      const schedules = gridToSchedules(scheduleSelection)
       for (const schedule of schedules) {
-        await createSchedule(route.id, {
-          days_of_week: schedule.days_of_week,
-          start_time: schedule.start_time,
-          end_time: schedule.end_time,
-        })
+        await createSchedule(route.id, schedule)
       }
 
       // 4. Add notification preferences
@@ -301,45 +288,11 @@ export function CreateRoute() {
           {/* Active Times Subsection */}
           <div className="mb-6">
             <h3 className="mb-3 text-lg font-medium">Active Times</h3>
-            <Card className="p-6">
-              {!showAddSchedule && (
-                <Button onClick={() => setShowAddSchedule(true)} className="mb-4">
-                  <Plus className="mr-2 h-4 w-4" />
-                  Add Active Time
-                </Button>
-              )}
-
-              {showAddSchedule && (
-                <div className="mb-4">
-                  <ScheduleForm
-                    onSave={handleAddSchedule}
-                    onCancel={() => setShowAddSchedule(false)}
-                  />
-                </div>
-              )}
-
-              {schedules.length === 0 ? (
-                <Alert>
-                  <AlertDescription>
-                    No active times configured. Add times when you want to receive alerts for this
-                    route.
-                  </AlertDescription>
-                </Alert>
-              ) : (
-                <div className="space-y-2">
-                  {schedules.map((schedule) => (
-                    <ScheduleCard
-                      key={schedule.id}
-                      daysOfWeek={schedule.days_of_week}
-                      startTime={schedule.start_time.substring(0, 5)}
-                      endTime={schedule.end_time.substring(0, 5)}
-                      onEdit={() => {}}
-                      onDelete={() => handleDeleteSchedule(schedule.id)}
-                    />
-                  ))}
-                </div>
-              )}
-            </Card>
+            <ScheduleGrid
+              initialSelection={scheduleSelection}
+              onChange={setScheduleSelection}
+              disabled={false}
+            />
           </div>
 
           {/* Send Alerts To Subsection */}

--- a/frontend/src/pages/RouteDetails.tsx
+++ b/frontend/src/pages/RouteDetails.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useParams, useNavigate, Link } from 'react-router-dom'
-import { ChevronRight, Edit, Trash2, Plus, X } from 'lucide-react'
+import { ChevronRight, Edit, Trash2, X } from 'lucide-react'
 import { Button } from '../components/ui/button'
 import { Input } from '../components/ui/input'
 import { Label } from '../components/ui/label'
@@ -9,8 +9,13 @@ import { Alert, AlertDescription } from '../components/ui/alert'
 import { Card } from '../components/ui/card'
 import { SegmentBuilder } from '../components/routes/SegmentBuilder/SegmentBuilder'
 import { SegmentDisplay } from '../components/routes/SegmentDisplay'
-import { ScheduleForm } from '../components/routes/ScheduleForm'
-import { ScheduleCard } from '../components/routes/ScheduleCard'
+import {
+  ScheduleGrid,
+  schedulesToGrid,
+  gridToSchedules,
+  validateNotEmpty,
+  type GridSelection,
+} from '../components/routes/ScheduleGrid'
 import { NotificationDisplay } from '../components/routes/NotificationDisplay'
 import { useTflData } from '../hooks/useTflData'
 import { useContacts } from '../hooks/useContacts'
@@ -19,8 +24,6 @@ import type {
   RouteResponse,
   SegmentRequest,
   ScheduleResponse,
-  CreateScheduleRequest,
-  UpdateScheduleRequest,
   NotificationPreferenceResponse,
   CreateNotificationPreferenceRequest,
   NotificationMethod,
@@ -32,7 +35,6 @@ import {
   deleteRoute,
   upsertSegments,
   createSchedule,
-  updateSchedule,
   deleteSchedule,
   getNotificationPreferences,
   createNotificationPreference,
@@ -65,11 +67,8 @@ export function RouteDetails() {
   // Segments editing
   const [editSegments, setEditSegments] = useState<SegmentRequest[]>([])
 
-  // Schedules editing
-  const [editSchedules, setEditSchedules] = useState<ScheduleResponse[]>([])
-  const [showAddSchedule, setShowAddSchedule] = useState(false)
-  const [editingScheduleId, setEditingScheduleId] = useState<string | null>(null)
-  const [deletingScheduleId, setDeletingScheduleId] = useState<string | null>(null)
+  // Schedules editing (using grid selection)
+  const [editScheduleSelection, setEditScheduleSelection] = useState<GridSelection>(new Set())
 
   // Notifications editing
   const [editNotifications, setEditNotifications] = useState<NotificationPreferenceResponse[]>([])
@@ -107,15 +106,13 @@ export function RouteDetails() {
     setEditName(route.name)
     setEditDescription(route.description || '')
     setEditSegments(route.segments.map(segmentResponseToRequest))
-    setEditSchedules([...route.schedules])
+    setEditScheduleSelection(schedulesToGrid(route.schedules))
     setEditNotifications([...notifications])
     setIsEditing(true)
   }
 
   const handleCancelEditing = () => {
     setIsEditing(false)
-    setShowAddSchedule(false)
-    setEditingScheduleId(null)
     setSelectedContactId('')
   }
 
@@ -132,9 +129,26 @@ export function RouteDetails() {
       // 2. Update segments
       const updatedSegments = await upsertSegments(id, editSegments)
 
-      // 3. Sync schedules (delete removed, add new ones)
-      // Note: For simplicity, we'll just keep the schedule management as-is
-      // since schedules are managed separately with add/edit/delete buttons
+      // 3. Sync schedules (delete all old, create new ones from grid)
+      // Validate that at least one time slot is selected
+      const validationResult = validateNotEmpty(editScheduleSelection)
+      if (!validationResult.valid) {
+        setError(new ApiError(400, validationResult.error!))
+        return
+      }
+
+      // Delete all existing schedules
+      for (const schedule of route.schedules) {
+        await deleteSchedule(id, schedule.id)
+      }
+
+      // Create new schedules from grid selection
+      const newSchedules = gridToSchedules(editScheduleSelection)
+      const createdSchedules: ScheduleResponse[] = []
+      for (const scheduleData of newSchedules) {
+        const created = await createSchedule(id, scheduleData)
+        createdSchedules.push(created)
+      }
 
       // 4. Sync notifications (delete removed, add new ones)
       // Delete notifications that were removed
@@ -168,12 +182,10 @@ export function RouteDetails() {
       setRoute({
         ...updatedRoute,
         segments: updatedSegments,
-        schedules: editSchedules,
+        schedules: createdSchedules,
       })
 
       setIsEditing(false)
-      setShowAddSchedule(false)
-      setEditingScheduleId(null)
     } catch (err) {
       console.error('Failed to save changes:', err)
       setError(err as ApiError)
@@ -199,37 +211,6 @@ export function RouteDetails() {
 
   const handleSaveSegments = async (newSegments: SegmentRequest[]) => {
     setEditSegments(newSegments)
-  }
-
-  const handleCreateSchedule = async (data: CreateScheduleRequest) => {
-    if (!route) return
-
-    const newSchedule = await createSchedule(route.id, data)
-    setEditSchedules([...editSchedules, newSchedule])
-    setShowAddSchedule(false)
-  }
-
-  const handleUpdateSchedule = async (scheduleId: string, data: UpdateScheduleRequest) => {
-    if (!route) return
-
-    const updatedSchedule = await updateSchedule(route.id, scheduleId, data)
-    setEditSchedules(editSchedules.map((s) => (s.id === scheduleId ? updatedSchedule : s)))
-    setEditingScheduleId(null)
-  }
-
-  const handleDeleteSchedule = async (scheduleId: string) => {
-    if (!route) return
-    if (!confirm('Are you sure you want to delete this schedule?')) return
-
-    try {
-      setDeletingScheduleId(scheduleId)
-      await deleteSchedule(route.id, scheduleId)
-      setEditSchedules(editSchedules.filter((s) => s.id !== scheduleId))
-    } catch (err) {
-      console.error('Failed to delete schedule:', err)
-    } finally {
-      setDeletingScheduleId(null)
-    }
   }
 
   const handleAddNotification = () => {
@@ -304,8 +285,6 @@ export function RouteDetails() {
       </div>
     )
   }
-
-  const editingSchedule = editSchedules.find((s) => s.id === editingScheduleId)
 
   // Get verified contacts for notification method selector
   const verifiedEmails = contacts?.emails?.filter((e) => e.verified) || []
@@ -414,59 +393,30 @@ export function RouteDetails() {
           {/* Active Times Subsection */}
           <div className="mb-6">
             <h3 className="mb-3 text-lg font-medium">Active Times</h3>
-            <Card className="p-6">
-              {isEditing && !showAddSchedule && !editingScheduleId && (
-                <Button onClick={() => setShowAddSchedule(true)} className="mb-4">
-                  <Plus className="mr-2 h-4 w-4" />
-                  Add Active Time
-                </Button>
-              )}
-
-              {showAddSchedule && (
-                <div className="mb-4">
-                  <ScheduleForm
-                    onSave={handleCreateSchedule}
-                    onCancel={() => setShowAddSchedule(false)}
+            {isEditing ? (
+              <ScheduleGrid
+                initialSelection={editScheduleSelection}
+                onChange={setEditScheduleSelection}
+                disabled={false}
+              />
+            ) : (
+              <>
+                {route.schedules.length === 0 ? (
+                  <Alert>
+                    <AlertDescription>
+                      No active times configured. Edit this route to set when you want to receive
+                      alerts.
+                    </AlertDescription>
+                  </Alert>
+                ) : (
+                  <ScheduleGrid
+                    initialSelection={schedulesToGrid(route.schedules)}
+                    onChange={() => {}}
+                    disabled={true}
                   />
-                </div>
-              )}
-
-              {editingScheduleId && editingSchedule && (
-                <div className="mb-4">
-                  <ScheduleForm
-                    initialDays={editingSchedule.days_of_week}
-                    initialStartTime={editingSchedule.start_time.substring(0, 5)}
-                    initialEndTime={editingSchedule.end_time.substring(0, 5)}
-                    onSave={(data) => handleUpdateSchedule(editingScheduleId, data)}
-                    onCancel={() => setEditingScheduleId(null)}
-                    isEditing={true}
-                  />
-                </div>
-              )}
-
-              {(isEditing ? editSchedules : route.schedules).length === 0 ? (
-                <Alert>
-                  <AlertDescription>
-                    No active times configured.{' '}
-                    {isEditing && 'Add times when you want to receive alerts for this route.'}
-                  </AlertDescription>
-                </Alert>
-              ) : (
-                <div className="space-y-2">
-                  {(isEditing ? editSchedules : route.schedules).map((schedule) => (
-                    <ScheduleCard
-                      key={schedule.id}
-                      daysOfWeek={schedule.days_of_week}
-                      startTime={schedule.start_time.substring(0, 5)}
-                      endTime={schedule.end_time.substring(0, 5)}
-                      onEdit={isEditing ? () => setEditingScheduleId(schedule.id) : () => {}}
-                      onDelete={isEditing ? () => handleDeleteSchedule(schedule.id) : () => {}}
-                      isDeleting={deletingScheduleId === schedule.id}
-                    />
-                  ))}
-                </div>
-              )}
-            </Card>
+                )}
+              </>
+            )}
           </div>
 
           {/* Send Alerts To Subsection */}

--- a/frontend/src/pages/Routes.tsx
+++ b/frontend/src/pages/Routes.tsx
@@ -15,6 +15,7 @@ import {
 } from '../components/ui/dialog'
 import { RouteList } from '../components/routes/RouteList'
 import { useRoutes } from '../hooks/useRoutes'
+import { useUserRouteDisruptions } from '../hooks/useUserRouteDisruptions'
 
 /**
  * Routes page for managing commute routes
@@ -28,6 +29,7 @@ import { useRoutes } from '../hooks/useRoutes'
 export function Routes() {
   const navigate = useNavigate()
   const { routes, loading, error, deleteRoute } = useRoutes()
+  const { disruptions, loading: disruptionsLoading } = useUserRouteDisruptions()
 
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const [deletingRoute, setDeletingRoute] = useState<{ id: string; name: string } | null>(null)
@@ -138,6 +140,8 @@ export function Routes() {
             onDelete={handleDeleteClick}
             loading={loading}
             deletingId={deletingId}
+            disruptions={disruptions}
+            disruptionsLoading={disruptionsLoading}
           />
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
This release includes major enhancements to user route management with a new grid-based schedule UI, improved notification system with service restoration alerts and simplified email formatting, plus comprehensive test coverage improvements.

## Features
- **Grid-based schedule UI** (#358) - Intuitive click-and-drag interface for selecting alert times across 7 days × 24 hours with 15-minute intervals
- **Atomic schedule updates** (#360) - PUT endpoint for route schedules with quarter-hour validation and transactional safety
- **Route-specific disruptions on /routes page** (#355) - Real-time disruption indicators on route cards with severity-based visual badges
- **Cleared disruption notifications** (#372) - Users receive notifications when previously-alerted disruptions clear, showing both restored and still-disrupted lines
- **Simplified notification emails** (#376) - Concise subject lines with key info (e.g., "⚠️ To Work: Victoria, Northern disrupted"), removed verbose content for better scannability
- **PR review bodies in fetch script** (#363) - Enhanced `gh_pr_comments_fetch.sh` to include top-level PR review summaries

## Fixes
- **Test isolation for fetch_lines** (#375) - Added `db_session.expire_all()` to prevent intermittent test failures from stale SQLAlchemy identity map
- **Release PR creator guidelines** (#353) - Updated to ensure `origin/release` (not local branch) is used for PR comparisons

## Refactors
- **Test coverage improvements** (#374) - Backend coverage increased from 95.69% to 95.92% through fixture cleanup, test consolidation (DRY), and new metadata endpoint tests

---

### Notable Changes:
- **Breaking change in gh_pr_comments_fetch.sh:** `--type reviews` renamed to `--type threads`, default changed from `reviews` to `all`
- **New database column:** `is_cleared_state` on `alert_disabled_severities` table with migration
- **Enhanced accessibility:** All new disruption UI components include proper ARIA labels and keyboard navigation

### Test Coverage:
- Backend: 95.92% (up from 95.69%)
- Frontend: 833 tests passing
- All pre-commit hooks passing